### PR TITLE
Update flatlogcodes.cpp

### DIFF
--- a/flatlogs/src/flatlogcodes.cpp
+++ b/flatlogs/src/flatlogcodes.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <set>
 #include <cstring>
+#include <algorithm>
 
 #include <sys/stat.h>
 

--- a/flatlogs/src/flatlogcodes.cpp
+++ b/flatlogs/src/flatlogcodes.cpp
@@ -90,6 +90,15 @@ int readCodeFile( std::map<eventCodeT, typeSchemaPair> & codeMap, ///< [out] The
          return -1;
       }
 
+      // Trim leading whitespace:
+      line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](unsigned char ch) {
+         return !std::isspace(ch);
+      }));
+
+      // Trim trailing whitespace:
+      line.erase(std::find_if(line.rbegin(), line.rend(), [](unsigned char ch) {
+         return !std::isspace(ch);
+      }).base(), line.end());
       
       size_t com = line.find('#', 0);
 


### PR DESCRIPTION
In doing a full MagAOX install in a new VM I think I came across a very particular error. The line 
`if(line.size() == 0) continue;`
is not parsing empty logCodes.dat files as empty because they each contain a CR character, so `flatlogcodes` fails with the check
```
      if(logCodeStr.size() == 0)
      {
         std::cerr << fileName << " line " << lineNo << ": no log code found. (" << __FILE__ << " " << __LINE__ << ")\n";
         return -1;
      }
```
at the first blank line (line 4).

This PR trims leading and trailing whitespaces from logCodes.dat line before parsing it.