### PR TITLE
Resurrector 20250428 resuctrl xsup permissions

### DIFF
--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1451,6 +1451,12 @@ void MagAOXApp<_useINDI>::loadBasicConfig() // virtual
     bool ig{ false };
     config( ig, "ignore_git" );
 
+    {
+    //--------- Check for, and ignore, mkfifo-hexbeat --------//
+    bool mh{ false };
+    config( mh, "mkfifo-hexbeat" );
+    }
+
     config( m_indiserver_ctrl_fifo, "indiserver_ctrl_fifo" );
 
     if( !ig && m_gitAlert )

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -2115,6 +2115,8 @@ template <bool _useINDI>
 int MagAOXApp<_useINDI>::mkStatusDir()
 {
     std::string statusDir = sysPath;
+    statusDir += "/";
+    statusDir += m_configName;
 
     // Get the maximum privileges available
     elevatedPrivileges elPriv( this );
@@ -2132,6 +2134,7 @@ int MagAOXApp<_useINDI>::mkStatusDir()
             return -1;
         }
     }
+    ::perror((std::string("mkdir of ")+statusDir).c_str());
     return 0;
 }
 

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1326,7 +1326,7 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
         std::cerr
         << "Status directory either already existed or was created successfully"
         << std::endl;
-        break;
+        exit( 0 );
     }
 
     if( m_configName == "" )

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -398,6 +398,18 @@ class MagAOXApp : public application
 
     pid_t m_pid{ 0 }; ///< This process's PID
 
+    /// Attempt to create status directory for PID file
+
+    /** call mkdir("/opt/MagAOX/sys/<m_configName>/") with appropriate permissions and ownership
+     *
+     * Called by lockPID() below; also called when --mkfifo-hexbeat is command-line argument
+     *
+     * \returns 0 on success.
+     * \returns -1 on any error
+     */
+
+    int mkStatusDir();
+
     /// Attempt to lock the PID by writing it to a file. Fails if a process is already running with the same config
     /// name.
     /** First checks the PID file for an existing PID.  If found, interrogates /proc to determine if that process is
@@ -2093,10 +2105,8 @@ int MagAOXApp<_useINDI>::setEuidReal()
 }
 
 template <bool _useINDI>
-int MagAOXApp<_useINDI>::lockPID()
+int MagAOXApp<_useINDI>::mkStatusDir()
 {
-    m_pid = getpid();
-
     std::string statusDir = sysPath;
 
     // Get the maximum privileges available
@@ -2115,7 +2125,20 @@ int MagAOXApp<_useINDI>::lockPID()
             return -1;
         }
     }
+    return 0;
+}
 
+template <bool _useINDI>
+int MagAOXApp<_useINDI>::lockPID()
+{
+    if (mkStatusDir()) { return -1; }
+
+    m_pid = getpid();
+
+    // Get the maximum privileges available
+    elevatedPrivileges elPriv( this );
+
+    std::string statusDir = sysPath;
     statusDir += "/";
     statusDir += m_configName;
 

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -2134,7 +2134,6 @@ int MagAOXApp<_useINDI>::mkStatusDir()
             return -1;
         }
     }
-    ::perror((std::string("Successful existing/mkdir ")+statusDir).c_str());
     return 0;
 }
 
@@ -3091,7 +3090,6 @@ int MagAOXApp<_useINDI>::createResurrecteeFIFO()
             return -1;
         }
     }
-    ::perror((std::string("Successful existing or mkfifo ") + m_resurrecteeFifoName).c_str());
 
     umask( prev );
     // euidReal();

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1319,7 +1319,13 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
         << ".hb], status directory, and exiting ..."
         << std::endl;
         if ( createResurrecteeFIFO() ) { exit( -1 ); };
+        std::cerr
+        << "Hexbeat FIFO either already existed or was created successfully"
+        << std::endl;
         if( mkStatusDir() ) { exit( -1 ); };
+        std::cerr
+        << "Status directory either already existed or was created successfully"
+        << std::endl;
         break;
     }
 

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1303,6 +1303,24 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
     config.parseCommandLine( argc, argv, "name" );
     config( m_configName, "name" );
 
+    // Special case check for --mkfifo-hexbeat
+    config.add("mkfifo-hexbeat", "", "mkfifo-hexbeat", argType::None
+              , "", "", false, "bool"
+              , "Create Hexbeat FIFO via mkfifo(2) and exit"
+              );
+
+    for (auto pparg = argv+1; pparg < (argv+argc); ++pparg)
+    {
+        if(::strcmp(*pparg, "--mkfifo-hexbeat")) { continue; }
+        std::cerr
+        << "Creating Hexbeat FIFO ["
+       << m_configName
+       << ".hb] and exiting ..."
+        << std::endl;
+        if( m_configName.empty() ) { exit( -1 ); }
+        exit( createResurrecteeFIFO() );
+    }
+
     if( m_configName == "" )
     {
         m_configName = mx::ioutils::pathStem( invokedName );
@@ -3039,6 +3057,9 @@ int MagAOXApp<_useINDI>::createResurrecteeFIFO()
     driverFIFOPath += MAGAOX_driverFIFORelPath;
 
     m_resurrecteeFifoName = driverFIFOPath + "/" + configName() + ".hb";
+
+    // Get max permissions
+    elevatedPrivileges elPriv( this );
 
     mode_t prev = umask( 0 );
 

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -2134,7 +2134,7 @@ int MagAOXApp<_useINDI>::mkStatusDir()
             return -1;
         }
     }
-    ::perror((std::string("mkdir of ")+statusDir).c_str());
+    ::perror((std::string("Successful existing/mkdir ")+statusDir).c_str());
     return 0;
 }
 
@@ -3091,6 +3091,7 @@ int MagAOXApp<_useINDI>::createResurrecteeFIFO()
             return -1;
         }
     }
+    ::perror((std::string("Succesfful existing or mkfifo ") + m_resurrecteeFifoName).c_str());
 
     umask( prev );
     // euidReal();

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1314,8 +1314,8 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
         if(::strcmp(*pparg, "--mkfifo-hexbeat")) { continue; }
         std::cerr
         << "Creating Hexbeat FIFO ["
-       << m_configName
-       << ".hb] and exiting ..."
+        << m_configName
+        << ".hb] and exiting ..."
         << std::endl;
         if( m_configName.empty() ) { exit( -1 ); }
         exit( createResurrecteeFIFO() );

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -601,11 +601,6 @@ class MagAOXApp : public application
     /// Full path name of the INDI driver output FIFO.
     std::string m_driverOutName;
 
-    /// Full path name of the INDI driver control FIFO.
-    /** This is currently only used to signal restarts.
-     */
-    std::string m_driverCtrlName;
-
     /// Full path name of the resurrector/resurrectee FIFO.
     std::string m_resurrecteeFifoName;
 
@@ -1149,12 +1144,6 @@ class MagAOXApp : public application
      * \returns the current value of m_driverOutName
      */
     std::string driverOutName();
-
-    /// Get the INDI control FIFO file name
-    /**
-     * \returns the current value of m_driverCtrlName
-     */
-    std::string driverCtrlName();
 
     /// Get the resurrectee FIFO file name
     /**
@@ -2939,7 +2928,6 @@ int MagAOXApp<_useINDI>::createINDIFIFOS()
 
     m_driverInName = driverFIFOPath + "/" + configName() + ".in";
     m_driverOutName = driverFIFOPath + "/" + configName() + ".out";
-    m_driverCtrlName = driverFIFOPath + "/" + configName() + ".ctrl";
 
     // Get max permissions
     elevatedPrivileges elPriv( this );
@@ -2961,19 +2949,6 @@ int MagAOXApp<_useINDI>::createINDIFIFOS()
 
     errno = 0;
     if( mkfifo( m_driverOutName.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP ) != 0 )
-    {
-        if( errno != EEXIST )
-        {
-            umask( prev );
-            // euidReal();
-            log<software_critical>( { __FILE__, __LINE__, errno, 0, "mkfifo failed" } );
-            log<text_log>( "Failed to create ouput FIFO.", logPrio::LOG_CRITICAL );
-            return -1;
-        }
-    }
-
-    errno = 0;
-    if( mkfifo( m_driverCtrlName.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP ) != 0 )
     {
         if( errno != EEXIST )
         {
@@ -3710,12 +3685,6 @@ template <bool _useINDI>
 std::string MagAOXApp<_useINDI>::driverOutName()
 {
     return m_driverOutName;
-}
-
-template <bool _useINDI>
-std::string MagAOXApp<_useINDI>::driverCtrlName()
-{
-    return m_driverCtrlName;
 }
 
 extern template class MagAOXApp<true>;

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -3091,7 +3091,7 @@ int MagAOXApp<_useINDI>::createResurrecteeFIFO()
             return -1;
         }
     }
-    ::perror((std::string("Succesfful existing or mkfifo ") + m_resurrecteeFifoName).c_str());
+    ::perror((std::string("Successful existing or mkfifo ") + m_resurrecteeFifoName).c_str());
 
     umask( prev );
     // euidReal();

--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1316,10 +1316,11 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
         std::cerr
         << "Creating Hexbeat FIFO ["
         << m_configName
-        << ".hb] and exiting ..."
+        << ".hb], status directory, and exiting ..."
         << std::endl;
-        if( m_configName.empty() ) { exit( -1 ); }
-        exit( createResurrecteeFIFO() );
+        if ( createResurrecteeFIFO() ) { exit( -1 ); };
+        if( mkStatusDir() ) { exit( -1 ); };
+        break;
     }
 
     if( m_configName == "" )
@@ -3054,6 +3055,8 @@ int MagAOXApp<_useINDI>::startINDI()
 template <bool _useINDI>
 int MagAOXApp<_useINDI>::createResurrecteeFIFO()
 {
+    ///Need non-empty drivername
+    if ( m_configName.empty() ) { return -1; }
 
     ///\todo make driver FIFO path full configurable.
     std::string driverFIFOPath = MAGAOX_path;

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -91,11 +91,22 @@ function verb_start {
   || resu_failure "Writable process list file not found; exiting ..." \
   || return 1
 
+  ### sed in-place editing tries to create a temporary file in the same
+  ### directory as the target file, but xsup user is not allowed to
+  ### write to MagAOX configuration directory (/opt/MagAOX/config/),
+  ### so create a temporary file, write proclist file contents to
+  ### that file, sed that file in-place, and write edited contents back
+  ### to configuration proclist file
+  proclist_bn="$(basename "$proclist_txt")"
+  proclist_tmp="$(mktemp -t "$proclist_bn.XXXXXXXXXX")"
+  cat "$proclist_txt" > "$proclist_tmp"
   for procname in ${procnames//${delim}/ } ; do
     ### Remove any leading whitespace+# for proclist file procname entry
     ### also any prefixes:  "-" or "py:" or "nhb:"
-    sed -E -i -e "/^$ws0#$wsh0(-|[^: 	]*:)?${procname}$ws1$notws1$ws0\$/s/^$wsh1//" "$proclist_txt"
+    sed -E -i -e "/^$ws0#$wsh0(-|[^: 	]*:)?${procname}$ws1$notws1$ws0\$/s/^$wsh1//" "$proclist_tmp"
   done
+  cat "$proclist_tmp" > "$proclist_txt"
+  rm -f "$proclist_tmp"
 
   ripid=$(resurrector_indi_pid) \
   || resu_failure "resurrector_indi is not running; exiting ..." \
@@ -125,10 +136,16 @@ function verb_stop {
   || resu_failure "Writable process list file not found; exiting ..." \
   || return 1
 
+  ### See comments in function verb_start{} regarding in-place editing
+  proclist_bn="$(basename "$proclist_txt")"
+  proclist_tmp="$(mktemp -t "$proclist_bn.XXXXXXXXXX")"
+  cat "$proclist_txt" > "$proclist_tmp"
   for procname in ${procnames//${delim}/ } ; do
     ### Replace leading whitespace with # in proclist file procname line
-    sed -E -i -e "/^$ws0(-|[^:# 	]*:)?${procname}$ws1$notws1$ws0\$/s/^$ws0/#/" "$proclist_txt"
+    sed -E -i -e "/^$ws0(-|[^:# 	]*:)?${procname}$ws1$notws1$ws0\$/s/^$ws0/#/" "$proclist_tmp"
   done
+  cat "$proclist_tmp" > "$proclist_txt"
+  rm -f "$proclist_tmp"
 
   ripid=$(resurrector_indi_pid) \
   || resu_failure "resurrector_indi is not running; exiting ..." \

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -239,6 +239,7 @@ function verb_reset {
   && return 1
 
   cp -v "$proclist_base" "$proclist_cached"
+  chmod -v o+w "$proclist_cached"
 
 }
 

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -186,6 +186,12 @@ function verb_status {
 }
 
 ########################################################################
+function verb_lstatus {
+  hide lstatus
+  USElsof=yes verb_status
+}
+
+########################################################################
 ### Verb to show, or not, the resurrector_indi file found
 function verb_ripath {
 
@@ -249,7 +255,7 @@ function parse_commands {
     case "$arg" in
 
     ### Verbs
-    startup|shutdown|restart|start|stop|defib|peek|status|ripath|reset)
+    startup|shutdown|restart|start|stop|defib|peek|status|lstatus|ripath|reset)
 
       ### If a second verb is found, add it as procname to procnames var
       [ "$verb" ] \
@@ -543,7 +549,9 @@ function find_device_hexbeat_pipe {
   ri="resurrector_indi"
 
   ### List all processes that have that pipe open; skip resurrector_indi
-  lsof -lnw "$hbpath" \
+  [ "$USElsof" ] && [ "$VERBOSE" ] \
+  && echo "Using [lsof] for [$hbpath]" 1>&2 || true
+  ( [ "$USElsof" ] && lsof -lnw "$hbpath" || true ) \
   | while read cmd pid user fd type dev sizeoff mode path cruft ; do
 
       ### ripid=... => retrieves the PID of the resurrector_indi process
@@ -637,8 +645,10 @@ Usage:
     resuctrl peek --all|PROCNAME [PROCNAME ...]
         - show status and last few log lines (via logdump) for each process
 
-    resuctrl status --all|PROCNAME [PROCNAME ...]
+    resuctrl status|lstatus --all|PROCNAME [PROCNAME ...]
         - show status for each process
+        - status:  skip lsof, and only use [ps x], to check processes
+        - lstatus:  try lsof first, and then [ps x] , to check processes
 
     resuctrl defib --all|PROCNAME[ [PROCNAME ...]]
         - declare to resurrector that PROCNAME processes have expired,
@@ -681,6 +691,7 @@ return 1
 }
 
 ########################################################################
+### Debug output
 function hide {
   ( [ "$VERBOSE" ] && cat || cat > /dev/null ) << EoFhide
 In verb_{$1}:

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -344,6 +344,7 @@ function parse_commands {
   || return 1
 
   [ ! "$All" ] || procnames="$(find_all_procnames)" || return 1
+  [ ! "$All" ] && [ ! "$procnames" ] && [ "$verb" == "status" ] && procnames="$(find_all_procnames)"
 
   true
 } ### function parse_commands
@@ -492,9 +493,9 @@ function find_resurrector_indi_path {
            "/usr/local/bin/" \
   ; do
      ### If directory ends in "/" then don't recurse below that dir
-     [ "$P%/" == "$P" ] && unset maxdepthopt || maxdepthopt="-maxdepth 1"
+     [ "${P%/}" == "$P" ] && unset maxdepthopt || maxdepthopt="-maxdepth 1"
 
-     find "$P" $depthopt -name resurrector_indi 2>/dev/null \
+     find "$P" $maxdepthopt -name resurrector_indi 2>/dev/null \
      | head -1 | grep . && return 0 || continue
 
   done

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -223,7 +223,7 @@ function verb_ripath {
 }
 
 ########################################################################
-### Verb to reset (or create) the cached proclist
+### Verb to reset (or create) the cached proclist, writable by any user
 function verb_reset {
 
   hide reset
@@ -239,7 +239,30 @@ function verb_reset {
   && return 1
 
   cp -v "$proclist_base" "$proclist_cached"
-  chmod -v o+w "$proclist_cached"
+  [ "$USER" == "xsup" ] && return 0
+  chmod -c o+w "$proclist_cached"
+
+  SH="sudo -H -n"
+  ug="root:xsup"
+  dM=--mode=775
+  fM=--mode=660
+  for procname in $(find_all_procnames | tr "$delim" " ") ; do
+
+    ### Create directory for process files:  pid; outputs
+    pDir="/opt/MagAOX/sys/$procname"
+    [ -d "$pDir" ] \
+    || ( $SH mkdir -v $dM "$pDir" && $SH chown -c $ug "$pDir" ) \
+    || echo "Failed to create process directory $pDir" \
+    || true
+
+    ### Create named FIFO for sending process Hexbeats to resurrector
+    fHb="/opt/MagAOX/drivers/fifos/$procname.hb"
+    [ -p "$fHb" ] \
+    || ( $SH mkfifo $fM "$fHb" && $SH chown -v $ug "$fHb" ) \
+    || echo "Failed to create Hexbeat FIFO $fHb" \
+    || true
+
+  done
 
 }
 

--- a/scripts/resuctrl
+++ b/scripts/resuctrl
@@ -566,6 +566,22 @@ function find_device_hexbeat_pipe {
          ) \
       && break
 
+    done | \grep . && return 0  ### Returns failure if nothing was found
+
+    ### lsof failed; try ps x
+    ### PID TTY STAT  TIME COMMAND
+    ### 5431 ?   Sl    3:29 /opt/MagAOX/bin/xindiserver -n isworkstation
+    ### 5435 ?   Sl    2:19 /opt/MagAOX/bin/timeSeriesSimulator -n tSS
+    ps x | grep " -n " \
+    | while read pid tty stat time arg0 hyphenn devname balance ; do
+      [ "x$balance" == "x" ] \
+      && [ "$hyphenn" == "-n" ] \
+      && [ "$devname" ] \
+      && [ "$devname" == "$1" ] \
+      && ( [ "$2" == "pid" ] && echo "$pid probably" \
+        || ( [ ! "$2" ] && echo "$path" ) \
+         ) \
+      && break
     done | \grep .              ### Returns failure if nothing was found
 }
 

--- a/setup/provision.sh
+++ b/setup/provision.sh
@@ -264,6 +264,12 @@ else
             cd $destdir
             # ensure upstream is set somewhere that isn't on the fs to avoid possibly pushing
             # things and not having them go where we expect
+            ### - IFF $DIR not under $HOME/githubalt/MagAOX & branch dev
+            (
+            [[ "$DIR" == "${DIR##$HOME/githubalt/MagAOX}" ]] \
+            && git rev-parse --abbrev-ref --symbolic-full-name HEAD \
+               | grep -q '^dev$' \
+            || exit 0
             stat /opt/MagAOX/source/MagAOX/.git
             git remote remove origin
             git remote add origin https://github.com/magao-x/MagAOX.git
@@ -271,6 +277,7 @@ else
             git branch -u origin/dev dev
             log_success "In the future, you can re-run this script from /opt/MagAOX/source/MagAOX/setup"
             log_info "(In fact, maybe delete $(dirname $DIR)?)"
+            )
         else
             cd /opt/MagAOX/source/MagAOX
             git fetch

--- a/setup/steps/install_openblas.sh
+++ b/setup/steps/install_openblas.sh
@@ -15,6 +15,6 @@ if [[ ! -d ./OpenBLAS-${VERSION} ]]; then
 fi
 cd ./OpenBLAS-${VERSION}
 make clean
-make USE_OPENMP=1
+make USE_OPENMP=1 $OPENBLAS_MAKE_DEFINES
 sudo make install PREFIX=/usr/local
 log_info "Finished OpenBLAS source install"

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -69,6 +69,7 @@ ___
 ### Create and provision multipass VM named magaox01, plus second cloned VM named magaox02
 
 * N.B. Roles will change to magaox01 and magaox02 after provisioning
+* N.B. The VM hostnames specified below (**-v=magaox01** and **-2=magaox02**) are mandatory when using the config branch specified below (**resurrector-indi-compression**)
 ```
 ./magaox_multipass_setup.sh \
   -v=magaox01 -2=magaox02 \

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -46,12 +46,15 @@ git clone \
 cd
 cd githubalt/MagAOX/setup
 MAGAOX_ROLE=workstation ./pre_provision.sh
+source /etc/profile.d/magaox_role.sh
+bash ./provision.sh"
 ```
 
-### Change role to **magaox01**
+### Change system role to **magaox01**
 * As sudo-capable user:
 ```
 echo MAGAOX_ROLE=magaox01 | sudo tee /etc/profile.d/magaox_role.sh
+source /etc/profile.d/magaox_role.sh
 ```
 ## End of manual installation
 ___

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -54,6 +54,7 @@ MAGAOX_ROLE=workstation ./pre_provision.sh
 echo MAGAOX_ROLE=magaox01 | sudo tee /etc/profile.d/magaox_role.sh
 ```
 
+## End of manual installation
 ___
 ___
 ## Single-command Example of creating new Multipass VMs, followed by installation and provisioning of MagAOX on same:

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -4,7 +4,10 @@
 
 * N.B. Roles will change to magaox01 and magaox02 after provisioning
 ```
-./magaox_multipass_setup.sh -v=magaox01 -2=magaox02 -M=drbitboy/MagAOX,MagAOX,resurrector-20250423 -r=drbitboy/magao-x-config,config,resurrector-indi-compression
+./magaox_multipass_setup.sh \
+  -v=magaox01 -2=magaox02 \
+  -M=drbitboy/MagAOX,MagAOX,resurrector-20250428-resuctrl-xsup-permissions \
+  -r=drbitboy/magao-x-config,config,resurrector-indi-compression
 ```
 
 ## As user ubuntu on both magaox01 and magaox02:

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -47,7 +47,12 @@ cd
 cd githubalt/MagAOX/setup
 MAGAOX_ROLE=workstation ./pre_provision.sh
 source /etc/profile.d/magaox_role.sh
-bash ./provision.sh"
+bash -l ./provision.sh"
+```
+
+### Alternative to compile OpenBLAS for TARGET=HASWELL:
+```
+OPENBLAS_MAKE_DEFINES=TARGET=HASWELL bash -l ./provision.sh"
 ```
 
 ### Change system role to **magaox01**

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -1,6 +1,64 @@
-## As some user on multipass host OS:
+## Example of a manual installation on an existing system:
 
-### Create, provision multipass VM named magaox01, plus second cloned VM named magaox02
+### Role and sources
+
+* MagAOX role:
+  * **magaox01**
+  * Initial role for provisioning:   **workstation**
+* MagAOX source:
+  * Repository => **https://github.com/drbitboy/MagAOX.git**
+  * Branch => **resurrector-20250428-resuctrl-xsup-permissions**
+* MagAOX configuration source:
+  * Repository => **https://github.com/drbitboy/magao-x-config.git**
+  * Branch => **resurrector-indi-compression**
+
+### Initial setup
+
+* As sudo-capable user:
+```
+sudo apt update
+sudo apt upgrade -y
+sudo reboot
+```
+
+### Get sources
+* As sudo-capable user:
+```
+cd
+mkdir githubalt
+
+git clone \
+  --depth=1 \
+  -b resurrector-20250428-resuctrl-xsup-pemissions \
+  https://github.com/drbitboy/MagAOX.git \
+  githubalt/MagAOX
+
+git clone \
+  --depth=1 \
+  -b resurrector-indi-compression \
+  https://github.com/drbitboy/magao-x-config.git \
+  githubalt/config
+```
+
+### Provision MagAOX system
+* As sudo-capable user:
+```
+cd
+cd githubalt/MagAOX/setup
+MAGAOX_ROLE=workstation ./pre_provision.sh
+```
+
+### Change role to **magaox01**
+* As sudo-capable user:
+```
+echo MAGAOX_ROLE=magaox01 | sudo tee /etc/profile.d/magaox_role.sh
+```
+
+___
+___
+## Single-command Example of creating new Multipass VMs, followed by installation and provisioning of MagAOX on same:
+
+### Create and provision multipass VM named magaox01, plus second cloned VM named magaox02
 
 * N.B. Roles will change to magaox01 and magaox02 after provisioning
 ```

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -1,4 +1,4 @@
-## Example of a manual installation on an existing system:
+## Example of a manual MagAOX installation on an existing system:
 
 ### Role and sources
 
@@ -53,11 +53,10 @@ MAGAOX_ROLE=workstation ./pre_provision.sh
 ```
 echo MAGAOX_ROLE=magaox01 | sudo tee /etc/profile.d/magaox_role.sh
 ```
-
 ## End of manual installation
 ___
 ___
-## Single-command Example of creating new Multipass VMs, followed by installation and provisioning of MagAOX on same:
+## Single-command example of automated creation new Multipass VMs, plus installation and provisioning of MagAOX on same:
 
 ### Create and provision multipass VM named magaox01, plus second cloned VM named magaox02
 
@@ -68,21 +67,23 @@ ___
   -M=drbitboy/MagAOX,MagAOX,resurrector-20250428-resuctrl-xsup-permissions \
   -r=drbitboy/magao-x-config,config,resurrector-indi-compression
 ```
+## End of automated installation
+___
+___
+## Running MagAOX system, assuming either installation procedure above is complete
 
-## As user ubuntu on both magaox01 and magaox02:
+### Cache process list file for use by non-privileged user **xsup**; create Hexbeater FIFOs and INDI driver/server system directories (/opt/MagAOX/sys/.../); su to non-privileged user **xsup** to run MagAOX system
 
-### Cache config file that user xsup can use; switch to user xsup
-
+* As sudo-capable user on both/either magaox01 and magaox02:
 ```
 resuctrl reset   ### Creation, provisioning are complete after this step
 sudo su - xsup
 ```
 
-## As user xsup:
-
 ### Start INDI server and all INDI drivers under resurrector control
 ### Update maths_1 and maths_2 INDI drivers, view results
 
+* As user xsup:
 ```
 resuctrl startup
 resuctrl status --all

--- a/setup/workstation_build/README.md
+++ b/setup/workstation_build/README.md
@@ -59,7 +59,7 @@ source /etc/profile.d/magaox_role.sh
 ## End of manual installation
 ___
 ___
-## Single-command example of automated creation new Multipass VMs, plus installation and provisioning of MagAOX on same:
+## Single-command example of automated creation of two new Multipass VMs, plus installation and provisioning of MagAOX on same:
 
 ### Create and provision multipass VM named magaox01, plus second cloned VM named magaox02
 

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -1,15 +1,17 @@
 ## As some user on multipass host OS:
 
-```./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-merge-dev-20250328-02plus-improve-resurrector -r=drbitboy/magao-x-config,config,resurrector-indi-compression
+```
+./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-merge-dev-20250328-02plus-improve-resurrector -r=drbitboy/magao-x-config,config,resurrector-indi-compression
 ```
 
 ## As user ubuntu:
 
 ### Cache config file that user xsup can use; switch to user xsup
 
-```resuctrl reset
-
-sudo su - xsup```
+```
+resuctrl reset
+sudo su - xsup
+```
 
 ## As user xsup:
 

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -15,19 +15,27 @@ sudo su - xsup```
 
 ### Start INDI server and all INDI drivers under resurrector control
 
-```resuctrl startup
-resuctrl status --all```
+```
+resuctrl startup
+resuctrl status --all
+```
 
 ### Stop an INDI driver
 
-```resuctrl stop maths_1
-resuctrl status --all```
+```
+resuctrl stop maths_1
+resuctrl status --all
+```
 
 ### Start an INDI driver
 
-```resuctrl start maths_x
-resuctrl status --all```
+```
+resuctrl start maths_x
+resuctrl status --all
+```
 
 ### Stop everything
 
-```resuctrl stop --all```
+```
+resuctrl stop --all
+```

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -16,7 +16,7 @@ sudo su - xsup```
 ### Start INDI server and all INDI drivers under resurrector control
 
 ```resuctrl startup
-resuctrl status --all``
+resuctrl status --all```
 
 ### Stop an INDI driver
 

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -1,10 +1,19 @@
 ## As some user on multipass host OS:
 
+### Create and provision multipass VM named magaox01
+* N.B. Role will change to magaox01 after provisioning
 ```
-./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-merge-dev-20250328-02plus-improve-resurrector -r=drbitboy/magao-x-config,config,resurrector-indi-compression
+./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-20250423 -r=drbitboy/magao-x-config,config,resurrector-indi-compression
 ```
 
-## As user ubuntu:
+### Clone multipass VM magaox01 to multipass VM named magaox02,
+* then update role to magaox02
+```
+multipass clone -n magaox02 magaox01
+multipass exec magaox02 -- /opt/MagAOX/config/change_role_to_hostname.sh
+```
+
+## As user ubuntu on both magaox01 and magaox02:
 
 ### Cache config file that user xsup can use; switch to user xsup
 

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -1,0 +1,33 @@
+## As some user on multipass host OS:
+
+```./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-merge-dev-20250328-02plus-improve-resurrector -r=drbitboy/magao-x-config,config,resurrector-indi-compression
+```
+
+## As user ubuntu:
+
+### Cache config file that user xsup can use; switch to user xsup
+
+```resuctrl reset
+
+sudo su - xsup```
+
+## As user xsup:
+
+### Start INDI server and all INDI drivers under resurrector control
+
+```resuctrl startup
+resuctrl status --all``
+
+### Stop an INDI driver
+
+```resuctrl stop maths_1
+resuctrl status --all```
+
+### Start an INDI driver
+
+```resuctrl start maths_x
+resuctrl status --all```
+
+### Stop everything
+
+```resuctrl stop --all```

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -1,16 +1,10 @@
 ## As some user on multipass host OS:
 
-### Create and provision multipass VM named magaox01
-* N.B. Role will change to magaox01 after provisioning
-```
-./magaox_multipass_setup.sh -v=magaox01 -M=drbitboy/MagAOX,MagAOX,resurrector-20250423 -r=drbitboy/magao-x-config,config,resurrector-indi-compression
-```
+### Create, provision multipass VM named magaox01, plus second cloned VM named magaox02
 
-### Clone multipass VM magaox01 to multipass VM named magaox02,
-* then update role to magaox02
+* N.B. Roles will change to magaox01 and magaox02 after provisioning
 ```
-multipass clone -n magaox02 magaox01
-multipass exec magaox02 -- /opt/MagAOX/config/change_role_to_hostname.sh
+./magaox_multipass_setup.sh -v=magaox01 -2=magaox02 -M=drbitboy/MagAOX,MagAOX,resurrector-20250423 -r=drbitboy/magao-x-config,config,resurrector-indi-compression
 ```
 
 ## As user ubuntu on both magaox01 and magaox02:

--- a/setup/workstation_build/full_setup_magaox.md
+++ b/setup/workstation_build/full_setup_magaox.md
@@ -12,31 +12,37 @@
 ### Cache config file that user xsup can use; switch to user xsup
 
 ```
-resuctrl reset
+resuctrl reset   ### Creation, provisioning are complete after this step
 sudo su - xsup
 ```
 
 ## As user xsup:
 
 ### Start INDI server and all INDI drivers under resurrector control
+### Update maths_1 and maths_2 INDI drivers, view results
 
 ```
 resuctrl startup
 resuctrl status --all
+
+setINDI maths_1.val.value=1.1   ### on magaox01
+setINDI maths_2.val.value=1.2   ### on magaox02
+
+getINDI -t 1
 ```
 
 ### Stop an INDI driver
 
 ```
-resuctrl stop maths_1
-resuctrl status --all
+resuctrl stop maths_1           ### on magaox01
+resuctrl status                 ### --all is implied
 ```
 
 ### Start an INDI driver
 
 ```
-resuctrl start maths_x
-resuctrl status --all
+resuctrl start maths_1          ### on magaox01
+resuctrl status                 ### --all is implied
 ```
 
 ### Stop everything

--- a/setup/workstation_build/magaox_multipass_setup.sh
+++ b/setup/workstation_build/magaox_multipass_setup.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+#################################################################################
+# perform an unattended multipass VM setup and provisioning for MagAO-X
+#
+# note that you need ~/.ssh/id_ed25519.pub
+#
+# todo: provide CLI options to change disk/cpus/memory
+function default_options() {
+  one="$1"
+  cat << __EoF | ( [ "$one" ] && cat || ( sed 's/ *#.*//'| tr \\n ' ' ) )
+### Command-line options, with defaults:
+-i=24.04                ### VM instance
+-c=4                    ### VM CPUs
+-d=20GiB                ### VM disk space
+-m=8.0GiB               ### VM memory
+-v=magao-x-vm           ### Multipass VM name
+-M=magao-x/MagAOX,,dev  ### MagAOX: GithubUser/GithubName,TargetDir,Branch
+-r=                     ### Additional repos
+-k=${HOME}/.ssh/id_ed25519.pub      ### SSH public key
+__EoF
+}
+for arg in $(default_options) $* ; do
+  [ "$arg" ] || continue
+  case "$arg" in
+  -i=*) _arg_i=${arg#-i=} ;;
+  -c=*) _arg_c=${arg#-c=} ;;
+  -d=*) _arg_d=${arg#-d=} ;;
+  -m=*) _arg_m=${arg#-m=} ;;
+  -v=*) _arg_v=${arg#-v=} ;;
+  -M=*,*,*) _arg_M=${arg#-M=} ;;
+  -r=*,*,*) _arg_r="${_arg_r} ${arg#-r=}" ;;
+  -r=) true ;;
+  -k=*) _arg_k=${arg#-k=} ;;
+  *) echo "Bad argument [$arg]; exiting" && false || default_options help && false || exit 1 ;;
+  esac
+done
+#
+################################################################################
+
+#VM name
+vmname=${_arg_v}
+
+#Source Github repo for MagAOX
+MagAOX_userATrepo=${_arg_M%%,*}
+_M=${_arg_M#$MagAOX_userATrepo,}
+MagAOX_subdir=${_M%%,*}
+[ "$MagAOX_subdir" ] || MagAOX_subdir=MagAOX
+MagAOX_branch=${_M##*,}
+[ "$MagAOX_branch" ] && MagAOX_branch="-b $MagAOX_branch"
+
+set | grep -E '_arg_.=|^MagAOX_'
+
+#basic VM creation
+multipass launch -n $vmname -c $_arg_c -d $_arg_d -m $_arg_m $_arg_i
+
+#install our key
+multipass exec $vmname -- bash -c "echo $(cat $_arg_k) >> ~/.ssh/authorized_keys"
+
+#user@IP
+uATip=ubuntu@$(multipass exec $vmname -- hostname -I | awk '{print $1}')
+
+# first ssh needs to force acceptance of the host key
+ssh -o StrictHostKeyChecking=accept-new $uATip "sudo apt update && sudo apt upgrade -y"
+
+#apply the updates
+multipass stop $vmname
+multipass start $vmname
+
+ssh $uATip "mkdir githubalt"
+
+#Clone MagAO-X repo into VM
+ssh $uATip "git clone --depth=1 $MagAOX_branch https://github.com/${MagAOX_userATrepo}.git githubalt/$MagAOX_subdir"
+
+for uATr_d_b in $_arg_r ; do
+  uATr=${uATr_d_b%%,*}
+  _r=${uATr_d_b#${uATr},}
+  subdir=${_r%%,*}
+  branch=${_r##*,}
+  [ "$branch" ] && branch="-b $branch"
+  ssh $uATip "git clone --depth=1 $branch https://github.com/${uATr}.git githubalt/$subdir"
+done
+
+#pre_provision as workstation to setup environment and users & groups
+ssh $uATip "cd githubalt/MagAOX/setup && MAGAOX_ROLE=workstation ./pre_provision.sh"
+
+#this must be a separate login to get groups updated
+ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
+
+changerole=/opt/MagAOX/config/change_role_to_hostname.sh
+ssh $uATip "[ -x '$changerole' ] && ./$changerole || true"

--- a/setup/workstation_build/magaox_multipass_setup.sh
+++ b/setup/workstation_build/magaox_multipass_setup.sh
@@ -88,4 +88,4 @@ ssh $uATip "cd githubalt/MagAOX/setup && MAGAOX_ROLE=workstation ./pre_provision
 ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
 
 changerole=/opt/MagAOX/config/change_role_to_hostname.sh
-ssh $uATip "[ -x '$changerole' ] && .$changerole || true"
+ssh $uATip "[ -x '$changerole' ] && $changerole || true"

--- a/setup/workstation_build/magaox_multipass_setup.sh
+++ b/setup/workstation_build/magaox_multipass_setup.sh
@@ -15,8 +15,9 @@ function default_options() {
 -d=20GiB                ### VM disk space
 -m=8.0GiB               ### VM memory
 -v=magao-x-vm           ### Multipass VM name
--M=magao-x/MagAOX,,dev  ### MagAOX: GithubUser/GithubName,TargetDir,Branch
+-M=magao-x/MagAOX,,dev  ### MagAOX:  GithubUsr/GithubName,TargDir,Branch
 -r=                     ### Additional repos
+-SP=                    ### Skip Provisioning if not empty
 -k=${HOME}/.ssh/id_ed25519.pub      ### SSH public key
 __EoF
 }
@@ -31,6 +32,7 @@ for arg in $(default_options) $* ; do
   -M=*,*,*) _arg_M=${arg#-M=} ;;
   -r=*,*,*) _arg_r="${_arg_r} ${arg#-r=}" ;;
   -r=) true ;;
+  -SP=*) _arg_SP="${arg#-SP=}" ;;
   -k=*) _arg_k=${arg#-k=} ;;
   *) echo "Bad argument [$arg]; exiting" && false || default_options help && false || exit 1 ;;
   esac
@@ -49,16 +51,27 @@ MagAOX_subdir=${_M%%,*}
 MagAOX_branch=${_M##*,}
 [ "$MagAOX_branch" ] && MagAOX_branch="-b $MagAOX_branch"
 
-set | grep -E '_arg_.=|^MagAOX_'
+set | grep -E '_arg_..*=|^MagAOX_'
 
 #basic VM creation
 multipass launch -n $vmname -c $_arg_c -d $_arg_d -m $_arg_m $_arg_i
+
+
+#ensure public key path ends in .pub
+[ "${_arg_k%.pub}" == "${_arg_k}" ] \
+&& _arg_k="$_arg_k.pub" || true
+
+#ensure public key exists
+[ -r "$_arg_k" ] || ssh-keygen -t ed25519 -N "" -f "${_arg_k%.pub}"
 
 #install our key
 multipass exec $vmname -- bash -c "echo $(cat $_arg_k) >> ~/.ssh/authorized_keys"
 
 #user@IP
 uATip=ubuntu@$(multipass exec $vmname -- hostname -I | awk '{print $1}')
+
+#Ensure this IP is not in known hosts file
+ssh-add -f "${HOME}/.ssh/known_hosts" -R "${uATip#ubuntu@}" 2>/dev/null || true
 
 # first ssh needs to force acceptance of the host key
 ssh -o StrictHostKeyChecking=accept-new $uATip "sudo apt update && sudo apt upgrade -y"
@@ -85,7 +98,9 @@ done
 ssh $uATip "cd githubalt/MagAOX/setup && MAGAOX_ROLE=workstation ./pre_provision.sh"
 
 #this must be a separate login to get groups updated
-ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
+[ "$_arg_SP" ] \
+&& ( echo Skipping provisioning ... || true ) \
+|| ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
 
 changerole=/opt/MagAOX/config/change_role_to_hostname.sh
 ssh $uATip "[ -x '$changerole' ] && $changerole || true"

--- a/setup/workstation_build/magaox_multipass_setup.sh
+++ b/setup/workstation_build/magaox_multipass_setup.sh
@@ -88,4 +88,4 @@ ssh $uATip "cd githubalt/MagAOX/setup && MAGAOX_ROLE=workstation ./pre_provision
 ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
 
 changerole=/opt/MagAOX/config/change_role_to_hostname.sh
-ssh $uATip "[ -x '$changerole' ] && ./$changerole || true"
+ssh $uATip "[ -x '$changerole' ] && .$changerole || true"

--- a/setup/workstation_build/magaox_multipass_setup.sh
+++ b/setup/workstation_build/magaox_multipass_setup.sh
@@ -18,6 +18,7 @@ function default_options() {
 -M=magao-x/MagAOX,,dev  ### MagAOX:  GithubUsr/GithubName,TargDir,Branch
 -r=                     ### Additional repos
 -SP=                    ### Skip Provisioning if not empty
+-2=                     ### Duplicate VM, cloned from first (see -v=...)
 -k=${HOME}/.ssh/id_ed25519.pub      ### SSH public key
 __EoF
 }
@@ -33,6 +34,7 @@ for arg in $(default_options) $* ; do
   -r=*,*,*) _arg_r="${_arg_r} ${arg#-r=}" ;;
   -r=) true ;;
   -SP=*) _arg_SP="${arg#-SP=}" ;;
+  -2=*) _arg_2=${arg#-k=} ;;
   -k=*) _arg_k=${arg#-k=} ;;
   *) echo "Bad argument [$arg]; exiting" && false || default_options help && false || exit 1 ;;
   esac
@@ -103,4 +105,22 @@ ssh $uATip "cd githubalt/MagAOX/setup && MAGAOX_ROLE=workstation ./pre_provision
 || ssh $uATip "cd githubalt/MagAOX/setup && bash ./provision.sh"
 
 changerole=/opt/MagAOX/config/change_role_to_hostname.sh
+
+vmname2=$_arg_2
+
+#clone second multipass VM if requested via -2=vmname2
+if [ "$vmname2" ] ; then
+  #stop first VM, clone to second VM, start both VMs
+  multipass stop $vmname
+  multipass clone -n $vmname2 $vmname
+  multipass start $vmname $vmname2
+  #get ubuntu@IP address of second VM
+  uATip2=ubuntu@$(multipass exec $vmname2 -- hostname -I | awk '{print $1}')
+  #clear second VM's IP address from known hosts
+  ssh-add -f "${HOME}/.ssh/known_hosts" -R "${uATip2#ubuntu@}" 2>/dev/null || true
+  #change role of second VM
+  ssh -o StrictHostKeyChecking=accept-new $uATip2 "[ -x '$changerole' ] && $changerole || true"
+fi
+
+#change role of first VM
 ssh $uATip "[ -x '$changerole' ] && $changerole || true"

--- a/utils/resurrector_indi/HexbeatMonitor.hpp
+++ b/utils/resurrector_indi/HexbeatMonitor.hpp
@@ -378,7 +378,7 @@ public: // interfaces
       * or equivalent (e.g. execvp)
       * \arg \c argv0 is the argv[0] of the process
       * \arg \c hexbeater_name is the argv[2] of the process,
-      * following the -n in argv[3]
+      * following the -n in argv[1]
       *
       * $ echo Sanford | od -a -b -tx1 -tx4
       * 0000000   S   a   n   f   o   r   d  nl

--- a/utils/resurrector_indi/HexbeatMonitor.hpp
+++ b/utils/resurrector_indi/HexbeatMonitor.hpp
@@ -135,14 +135,26 @@ static inline std::string time_to_hb(int delay)
 // /////////////////////////////////////////////////////////////////////
 // /////////////////////////////////////////////////////////////////////
 
+template <bool _SIGCHLD_HNDLR = true>
 class HexbeatMonitor
 {
 public: // interfaces
 
+    constexpr static bool m_SIGCHLD_HNDLR{_SIGCHLD_HNDLR};
     /// Constructor
     /** Ensure SIGCHLD signal handler is installed, but only once
       */
-    HexbeatMonitor() { HexbeatMonitor::install_sigchld_handler(); }
+    HexbeatMonitor() {
+        static bool first{true};
+        if (m_SIGCHLD_HNDLR && first)
+        {
+            std::cerr
+            << "Installing default SIGCHLD handler for HexbeatMonitor"
+            << std::endl;
+            HexbeatMonitor<_SIGCHLD_HNDLR>::install_sigchld_handler();
+            first = false;
+        }
+    }
 
     /// Check for opened or active HexbeatMonitor that matches both
     //  a given command and a given HexbeatMonitor name
@@ -187,7 +199,10 @@ public: // interfaces
       *         is known, the FD is used as an index into the vhexbeats
       *         vector argument to locate the target HexbeatMonitor
       *         instance
-      * \returns FD (file descriptor) of file opened
+      * \returns FD (file descriptor; value >= 0) of FIFO file opened
+      * \returns -2 if FIFO not opened and do_mkfifo is false
+      * \returns -1 if FIFO not opened and do_mkfifo is true
+      *
       * \arg \c argv0 is the path to the hexbeater executable
       * \arg \c hbname is the hexbeater name (command-line option -n)
       * \arg \c fd_set_cpy is an [fd_set] object that contains bits of
@@ -196,6 +211,7 @@ public: // interfaces
       * \arg \c vhexbeats is a vector of HexbeatMonitor's
       * \arg ... => varargs are (char*) directory components of the FIFO
       *             path, ending with a NULL
+      * \arg \c do_mkfifo - Whether to try to create FIFO if not opened
       * N.B. there is no corresponding close_fifo; the FIFO FD (md_fd)
       *      will be closed automatically when the m_fd is reset to -1
       *      via routine update_status(...)
@@ -207,12 +223,13 @@ public: // interfaces
                   , std::vector<HexbeatMonitor>& vhexbeats
                   , int init_delay
                   , va_list ap
+                  , bool do_mkfifo = true
                   )
     {
         // Build the FIFO path, open the FIFO, return on failure
-        std::string fifo_name = HexbeatMonitor::build_fifo_path(hbname, ap);
-        int fd = HexbeatMonitor::open_hexbeater_fifo(fifo_name, vhexbeats);
-        if (fd < 0) { return -1; }
+        std::string fifo_name = HexbeatMonitor<_SIGCHLD_HNDLR>::build_fifo_path(hbname, ap);
+        int fd = HexbeatMonitor<_SIGCHLD_HNDLR>::open_hexbeater_fifo(fifo_name, vhexbeats, do_mkfifo);
+        if (fd < 0) { return fd; }
 
         // Initialize the instance to the [opened] operational state
         vhexbeats[fd].init_on_open(argv0, hbname, fd_set_cpy, nfds
@@ -427,7 +444,7 @@ public: // interfaces
             {
                 if (hexbeater_args.size()==0)
                 {
-                    if (HexbeatMonitor::matches(p,"python"))
+                    if (HexbeatMonitor<_SIGCHLD_HNDLR>::matches(p,"python"))
                     {
                         p += strlen(p) + 1;
                         continue;
@@ -441,7 +458,7 @@ public: // interfaces
                 // If argv[1] is not -n, then it's not a hexbeater
                 if (hexbeater_args.size()==2 && hexbeater_args[1]!="-n") { break; }
                 // If argv[0] is some form of "indiserver" then break after 3 arguments
-                if (hexbeater_args.size()==3 && HexbeatMonitor::is_is(argv0)) { break; }
+                if (hexbeater_args.size()==3 && HexbeatMonitor<_SIGCHLD_HNDLR>::is_is(argv0)) { break; }
             }
 
             // Eliminate non-hexbeaters
@@ -476,7 +493,8 @@ public: // interfaces
     }
     // /////////////////////////////////////////////////////////////////
 
-    friend std::ostream& operator<<(std::ostream&, const HexbeatMonitor&);
+    template <bool TPARM>
+    friend std::ostream& operator<<(std::ostream&, const HexbeatMonitor<TPARM>&);
 
 private: // Internal attributes and interfaces
 
@@ -640,19 +658,19 @@ private: // Internal attributes and interfaces
     static void
     install_sigchld_handler()
     {
-        static int singleton{0};
-        if (singleton) { return; }
+        static bool first{true};
+        if (!first) { return; }
 
         struct sigaction sa;
-        sa.sa_handler = &HexbeatMonitor::hbm_sigchld_handler;
+        sa.sa_handler = &HexbeatMonitor<_SIGCHLD_HNDLR>::hbm_sigchld_handler;
         sigemptyset(&sa.sa_mask);
         sa.sa_flags = SA_RESTART | SA_NOCLDSTOP | SA_NOCLDWAIT;
         if (sigaction(SIGCHLD, &sa, 0) == -1)
         {
-            perror("Error in HexbeatMonitor:: SIGCHLD handler install");
+            perror("Error in HexbeatMonitor<_SIGCHLD_HNDLR>:: SIGCHLD handler install");
             exit(1);
         }
-        singleton = 1;
+        first = false;
     }
     // ////////////////////////////////////////////////////////////////
 
@@ -710,8 +728,34 @@ private: // Internal attributes and interfaces
     // ////////////////////////////////////////////////////////////////
     // ////////////////////////////////////////////////////////////////
     static int
+    mkfifo_hexbeater(const std::string& fifo_name)
+    {
+        // Make Hexbeater FIFO
+        mode_t prev_mode;
+        errno = 0;
+        prev_mode = umask(0);
+        int istat{0};
+        istat = mkfifo(fifo_name.c_str(), S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+        prev_mode = umask(prev_mode);
+        return istat;
+    }
+    // ////////////////////////////////////////////////////////////////
+
+    // ////////////////////////////////////////////////////////////////
+    // ////////////////////////////////////////////////////////////////
+    /// Open hexbeater FIFO; optionally create if it does not exist
+    /** \returns Opened file descriptor (value >= 0) on success
+      * \returns -2 if FIFO file does not exist and do_mkfifo is false
+      * \returns -1 if FIFO file does not exist and could not be created
+      *
+      * \arg \c fifo_name - full FIFO filepath
+      * \arg \c vhexbeats - vector of Hexbeaters by FIFO file descr
+      * \arg \c do_mkfifo - Whether to try to create FIFO if not opened
+      */
+    static int
     open_hexbeater_fifo(const std::string& fifo_name
                        , std::vector<HexbeatMonitor>& vhexbeats
+                       , bool do_mkfifo = true
                        )
     {
         // Open FIFO read-write and non-blocking; create FIFO if needed
@@ -721,13 +765,14 @@ private: // Internal attributes and interfaces
 
         if (fd < 0 && errno == ENOENT)
         {
+            // FIFO file does not exist and argument prevents making one
+            if (!do_mkfifo){ return -2; }
+
             // File does not exist:  create FIFO; re-attempt open
-            mode_t prev_mode;
-            errno = 0;
-            prev_mode = umask(0);
-            istat = mkfifo(fifo_name.c_str(), S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
-            prev_mode = umask(prev_mode);
-            if (istat < 0) { return -1; }
+            if (HexbeatMonitor::mkfifo_hexbeater(fifo_name) < 0)
+            {
+              return -1;
+            }
             fd = open(fifo_name.c_str(),O_RDWR|O_NONBLOCK|O_CLOEXEC);
         }
         if (fd < 0) { return -1; }
@@ -751,14 +796,14 @@ private: // Internal attributes and interfaces
     // ////////////////////////////////////////////////////////////////
     // ////////////////////////////////////////////////////////////////
     /// Find this instance's hexbeater PID by argv[0] and hexbeater name
-    /** Use the static HexbeatMonitor::find_hexbeater_pid below
+    /** Use the static HexbeatMonitor<_SIGCHLD_HNDLR>::find_hexbeater_pid below
       * \returns PID of matching process from /proc/ filesystem
       */
     int
     find_hexbeater_pid()
     {
          if (m_fd < 0) { return 0; }
-         return HexbeatMonitor::find_hexbeater_pid(m_argv0, m_hbname);
+         return HexbeatMonitor<_SIGCHLD_HNDLR>::find_hexbeater_pid(m_argv0, m_hbname);
     }
     // ////////////////////////////////////////////////////////////////
 
@@ -877,7 +922,7 @@ private: // Internal attributes and interfaces
 
         // Find locations in buffer of start of heartbeat and/or of '\n'
         std::size_t inl;
-        std::size_t hex9 = HexbeatMonitor::hex9_nlterminated(m_buffer, inl);
+        std::size_t hex9 = HexbeatMonitor<_SIGCHLD_HNDLR>::hex9_nlterminated(m_buffer, inl);
 
         // Valid hexbeat found:  store it; erase data through newline
         if (hex9!=std::string::npos)
@@ -919,7 +964,7 @@ private: // Internal attributes and interfaces
     static bool
     is_is(const std::string& argv0)
     {
-        return HexbeatMonitor::matches(argv0, "indiserver");
+        return HexbeatMonitor<_SIGCHLD_HNDLR>::matches(argv0, "indiserver");
     }
     // ////////////////////////////////////////////////////////////////
 
@@ -974,7 +1019,9 @@ private: // Internal attributes and interfaces
     }
     // ////////////////////////////////////////////////////////////////
 };
-std::ostream& operator<<(std::ostream& os, const HexbeatMonitor& hbm)
+
+template <bool TPARM>
+std::ostream& operator<<(std::ostream& os, const HexbeatMonitor<TPARM>& hbm)
 {
     os
     << "<HexbeatMonitor \""

--- a/utils/resurrector_indi/redirect_prototype.cpp
+++ b/utils/resurrector_indi/redirect_prototype.cpp
@@ -135,7 +135,8 @@ public:
             /// Append next (or first) sub-directory token
             fullpath += (fullpath.empty() ? "" : "/") + *it;
 
-            struct stat stbuf{0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,{0,0},0};
+            struct stat stbuf;
+            memset(&stbuf, 0, sizeof(stbuf));
 
             /// Get directory status; true if stat(...) fails
             if (stat(fullpath.c_str(),&stbuf))

--- a/utils/resurrector_indi/resurrector.hpp
+++ b/utils/resurrector_indi/resurrector.hpp
@@ -5,7 +5,7 @@
 #define MACRO_FD_SETSIZE FD_SETSIZE
 #endif
 
-template <int HBR_FD_SETSIZE = MACRO_FD_SETSIZE>
+template <bool _HBM_SIGCHLD_HNDLR = true, int HBR_FD_SETSIZE = MACRO_FD_SETSIZE>
 class resurrectorT
 {
 private:
@@ -19,7 +19,7 @@ private:
 
     std::set<int> m_fds; ///< FDs of all opened hexbeaters in m_hbmarr
 
-    std::vector<HexbeatMonitor> m_hbmarr{std::vector<HexbeatMonitor>(HBR_FD_SETSIZE)}; ///< vector of hexbeat monitors, active or not
+    std::vector<HexbeatMonitor<_HBM_SIGCHLD_HNDLR>> m_hbmarr{std::vector<HexbeatMonitor<_HBM_SIGCHLD_HNDLR>>(HBR_FD_SETSIZE)}; ///< vector of hexbeat monitors, active or not
 
 public:
     /// Constructor
@@ -29,7 +29,7 @@ public:
     resurrectorT(void (*output_redirect)(std::string)=nullptr) : m_nfds(0), m_fds({})
     {
         FD_ZERO(&m_fdset_cpy);
-        for (std::vector<HexbeatMonitor>::iterator it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
+        for (auto it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
         {
             it->output_redirect_set(output_redirect);
         }
@@ -39,7 +39,7 @@ public:
     void
     pending_close_all_set(const bool tf)
     {
-        for (std::vector<HexbeatMonitor>::iterator it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
+        for (auto it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
         {
             it->pending_close_set(tf);
         }
@@ -49,7 +49,7 @@ public:
     void
     pending_close_all_set_on_match(const bool tf, std::string& argv0, std::string& hbname)
     {
-        for (std::vector<HexbeatMonitor>::iterator it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
+        for (auto it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
         {
             if (it->match(argv0, hbname)) { it->pending_close_set(tf); }
         }
@@ -59,7 +59,7 @@ public:
     void
     pending_close_all_close()
     {
-        for (std::vector<HexbeatMonitor>::iterator it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
+        for (auto it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
         {
             if (it->pending_close_get())
             {
@@ -111,7 +111,7 @@ public:
         }
 
         // Loop on the active FDs, each representing an active hexbeater
-        for (std::vector<HexbeatMonitor>::iterator it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
+        for (auto it = m_hbmarr.begin(); it != m_hbmarr.end(); ++it)
         {
             // Read any hexbeat data from the hexbeater FIFO, compare
             // the local hexbeat (hbnow, above) to the latest received
@@ -176,7 +176,7 @@ public:
 
         // Initialize varargs; open new FIFO; clean up varargs
         va_list ap; va_start(ap, hbname);
-        int newfd = HexbeatMonitor::open_hexbeater(
+        int newfd = HexbeatMonitor<_HBM_SIGCHLD_HNDLR>::open_hexbeater(
                     argv0, hbname, m_fdset_cpy, m_nfds, m_hbmarr
                     , init_delay
                     , ap);

--- a/utils/resurrector_indi/test/gausswait.cpp
+++ b/utils/resurrector_indi/test/gausswait.cpp
@@ -38,6 +38,7 @@
 #include <stdarg.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/prctl.h>
 
 extern "C" {
 #include "strcat_varargs.c"
@@ -64,6 +65,10 @@ static char* myname = (char*) unknown;   // Process name after -n parsed
 static struct timeval static_timeout;    // Keep track of last timeout
 static int broken_pipes = 0;             // Count of successive SIGPIPEs
 static int mypid = -1;                   // PID of this process
+
+static uid_t ruid = -1;
+static uid_t euid = -1;
+static uid_t suid = -1;
 
 /// Signal handler:  exit on any signal caught
 void
@@ -178,6 +183,47 @@ send_hexbeat(int fdfifo, int offset)
 int
 main(int argc, char** argv)
 {
+    // Restore dumpable attribute
+    std::cerr
+    << prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) << "=prctl(PR_GET_DUMPABLE,...) before"
+    << std::endl;
+
+    std::cerr
+    << prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) << "=prctl(PR_SET_DUMPABLE,1{dumpable},...)"
+    << std::endl;
+
+    std::cerr
+    << prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) << "=prctl(PR_GET_DUMPABLE,...) after"
+    << std::endl;
+
+    // Get real (process), effective (possibly root), and saved UIDs
+    int gru = getresuid(&ruid, &euid, &suid);
+    std::cerr
+    << gru << "=getresuid(...); "
+    << ruid << "=ruid; "
+    << euid << "=euid; "
+    << suid << "=suid"
+    << std::endl;
+
+    // Restore UID to real; it may have been effective
+    int seu = seteuid(ruid);
+    std::cerr
+    << seu << "=seteuid(" << ruid << ")"
+    << std::endl;
+
+    // Restore dumpable attribute
+    std::cerr
+    << prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) << "=prctl(PR_GET_DUMPABLE,...) before"
+    << std::endl;
+
+    std::cerr
+    << prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) << "=prctl(PR_SET_DUMPABLE,1{dumpable},...)"
+    << std::endl;
+
+    std::cerr
+    << prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) << "=prctl(PR_GET_DUMPABLE,...) after"
+    << std::endl;
+
     // Parse name, save to static memory
     assert(argc == 3);
     assert(std::string("-n") == std::string(argv[1]));


### PR DESCRIPTION
PR into magao-x resurrector-merge-dev-20250328 branch; eventually it will end up in resurrector, and then in dev (someday?).

Still a few things to clean up, but this replaces https://github.com/magao-x/MagAOX/pull/178, i.e. it has everything that #178 had, plus it uses ```resuctrl reset```* to create /opt/MagAOX/sys/\<drivername\>/ directories and resurrector Hexbeater named FIFOs, and set the permission (root:xsup) for same.

\* by a non-xsup user that has sudo privielege.