### PR TITLE
Update testMagAOX.bash

### DIFF
--- a/tests/testMagAOX.bash
+++ b/tests/testMagAOX.bash
@@ -26,8 +26,10 @@ echo Running MagAO-X Tests
 
 tests=$(cat tests.list)
 
+: > test_stderr.txt
 for test in $tests; do \
-   echo running $test; \
-   $test 2>test_stderr.txt ; \
+   echo running $test | tee -a test_stderr.txt; \
+   $test 2>>test_stderr.txt ; \
+   echo '' >> test_stderr.txt; \
 done
 


### PR DESCRIPTION
The current version of testMagAOX.bash outputs errors to test_stderr.txt, but the output of each test file is overwritten by the next test file.

Updated the bash script to reset the error file at the beginning of each run and then append the errors for each test file.

Also outputting the test name to the error file, to easily identify the source of the respective errors and separating errors from different test files with a blank line.