### PR TITLE
fix basler startup ROI and other cleanup

### DIFF
--- a/apps/baslerCtrl/baslerCtrl.hpp
+++ b/apps/baslerCtrl/baslerCtrl.hpp
@@ -293,9 +293,6 @@ inline baslerCtrl::~baslerCtrl() noexcept
 
 void baslerCtrl::setupConfig()
 {
-    dev::stdCamera<baslerCtrl>::setupConfig( config );
-
-    dev::frameGrabber<baslerCtrl>::setupConfig( config );
 
     config.add( "camera.serialNumber",
                 "",
@@ -306,6 +303,7 @@ void baslerCtrl::setupConfig()
                 false,
                 "int",
                 "The identifying serial number of the camera." );
+
     config.add( "camera.bits",
                 "",
                 "camera.bits",
@@ -316,7 +314,11 @@ void baslerCtrl::setupConfig()
                 "int",
                 "The number of bits used by the camera.  Default is 10." );
 
-    dev::telemeter<baslerCtrl>::setupConfig( config );
+    STDCAMERA_SETUP_CONFIG( config );
+
+    FRAMEGRABBER_SETUP_CONFIG( config );
+
+    TELEMETER_SETUP_CONFIG( config );
 }
 
 int baslerCtrl::loadConfigImpl( mx::app::appConfigurator &_config )
@@ -344,26 +346,13 @@ void baslerCtrl::loadConfig()
 
 int baslerCtrl::appStartup()
 {
-
-    //=================================
-    // Do camera configuration here
-
     PylonInitialize(); // Initializes pylon runtime before using any pylon methods
 
-    if( dev::stdCamera<baslerCtrl>::appStartup() < 0 )
-    {
-        return log<software_critical, -1>( { __FILE__, __LINE__ } );
-    }
+    STDCAMERA_APP_STARTUP;
 
-    if( dev::frameGrabber<baslerCtrl>::appStartup() < 0 )
-    {
-        return log<software_critical, -1>( { __FILE__, __LINE__ } );
-    }
+    FRAMEGRABBER_APP_STARTUP;
 
-    if( dev::telemeter<baslerCtrl>::appStartup() < 0 )
-    {
-        return log<software_error, -1>( { __FILE__, __LINE__ } );
-    }
+    TELEMETER_APP_STARTUP;
 
     m_tempHist.maxEntries( 30 );
 
@@ -374,17 +363,9 @@ int baslerCtrl::appStartup()
 
 int baslerCtrl::appLogic()
 {
-    // and run stdCamera's appLogic
-    if( dev::stdCamera<baslerCtrl>::appLogic() < 0 )
-    {
-        return log<software_error, -1>( { __FILE__, __LINE__ } );
-    }
+    STDCAMERA_APP_LOGIC;
 
-    // and run frameGrabber's appLogic to see if the f.g. thread has exited.
-    if( dev::frameGrabber<baslerCtrl>::appLogic() < 0 )
-    {
-        return log<software_error, -1>( { __FILE__, __LINE__ } );
-    }
+    FRAMEGRABBER_APP_LOGIC;
 
     if( state() == stateCodes::NOTCONNECTED || state() == stateCodes::NODEVICE || state() == stateCodes::ERROR )
     {
@@ -395,7 +376,9 @@ int baslerCtrl::appLogic()
         }
 
         if( state() != stateCodes::CONNECTED )
+        {
             return 0;
+        }
     }
 
     if( state() == stateCodes::CONNECTED )
@@ -413,48 +396,45 @@ int baslerCtrl::appLogic()
 
         // but don't wait for it, just go back around.
         if( !lock.owns_lock() )
+        {
             return 0;
+        }
 
         if( getTemp() < 0 )
         {
             if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
+            {
                 state( stateCodes::ERROR );
+            }
+
             return 0;
         }
 
         if( getExpTime() < 0 )
         {
             if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
+            {
                 state( stateCodes::ERROR );
+            }
+
             return 0;
         }
 
         if( getFPS() < 0 )
         {
             if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
+            {
                 state( stateCodes::ERROR );
+            }
+
             return 0;
         }
 
-        if( stdCamera<baslerCtrl>::updateINDI() < 0 )
-        {
-            log<software_error>( { __FILE__, __LINE__ } );
-            state( stateCodes::ERROR );
-            return 0;
-        }
+        STDCAMERA_UPDATE_INDI;
 
-        if( frameGrabber<baslerCtrl>::updateINDI() < 0 )
-        {
-            log<software_error>( { __FILE__, __LINE__ } );
-            state( stateCodes::ERROR );
-            return 0;
-        }
+        FRAMEGRABBER_UPDATE_INDI;
 
-        if( telemeter<baslerCtrl>::appLogic() < 0 )
-        {
-            log<software_error>( { __FILE__, __LINE__ } );
-            return 0;
-        }
+        TELEMETER_APP_LOGIC;
     }
 
     ///\todo Fall through check?
@@ -464,16 +444,18 @@ int baslerCtrl::appLogic()
 
 int baslerCtrl::appShutdown()
 {
-    dev::stdCamera<baslerCtrl>::appShutdown();
+    STDCAMERA_APP_SHUTDOWN;
 
-    dev::frameGrabber<baslerCtrl>::appShutdown();
+    FRAMEGRABBER_APP_SHUTDOWN;
 
     if( m_camera )
+    {
         m_camera->Close();
+    }
 
     PylonTerminate();
 
-    dev::telemeter<baslerCtrl>::appShutdown();
+    TELEMETER_APP_SHUTDOWN;
 
     return 0;
 }
@@ -684,24 +666,24 @@ int baslerCtrl::connect()
         */
     }
 
-    if(m_full_w != m_camera->SensorWidth.GetValue())
+    if( m_full_w != m_camera->SensorWidth.GetValue() )
     {
-        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI w (camera.full_w) mismatch with camera"});
+        return log<software_critical, -1>( { __FILE__, __LINE__, "full ROI w (camera.full_w) mismatch with camera" } );
     }
 
-    if(m_full_h != m_camera->SensorHeight.GetValue())
+    if( m_full_h != m_camera->SensorHeight.GetValue() )
     {
-        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI h (camera.full_h) mismatch with camera"});
-    }
-    
-    if(m_full_x != 0.5 * ( (float)m_full_w - 1.0 ))
-    {
-        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI x (camera.full_x) mismatch with camera"});
+        return log<software_critical, -1>( { __FILE__, __LINE__, "full ROI h (camera.full_h) mismatch with camera" } );
     }
 
-    if(m_full_y != 0.5 * ( (float)m_full_h - 1.0 ))
+    if( m_full_x != 0.5 * ( (float)m_full_w - 1.0 ) )
     {
-        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI y (camera.full_y) mismatch with camera"});
+        return log<software_critical, -1>( { __FILE__, __LINE__, "full ROI x (camera.full_x) mismatch with camera" } );
+    }
+
+    if( m_full_y != 0.5 * ( (float)m_full_h - 1.0 ) )
+    {
+        return log<software_critical, -1>( { __FILE__, __LINE__, "full ROI y (camera.full_y) mismatch with camera" } );
     }
 
     return 0;
@@ -760,7 +742,7 @@ int baslerCtrl::configureAcquisition()
         // Set ROI.
         int xoff;
         int yoff;
-        if( m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR )
+        if( m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR )
         {
             xoff = ( m_maxWs[bx] - 1 - m_nextROI.x ) - 0.5 * ( (float)m_nextROI.w - 1 );
         }
@@ -770,7 +752,7 @@ int baslerCtrl::configureAcquisition()
             xoff = m_nextROI.x - 0.5 * ( (float)m_nextROI.w - 1 );
         }
 
-        if( m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR )
+        if( m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR )
         {
             yoff = ( m_maxHs[by] - 1 - m_nextROI.y ) - 0.5 * ( (float)m_nextROI.h - 1 );
         }
@@ -821,7 +803,7 @@ int baslerCtrl::configureAcquisition()
         m_currentROI.w = m_camera->Width.GetValue();
         m_currentROI.h = m_camera->Height.GetValue();
 
-        if( m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR )
+        if( m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR )
         {
             m_currentROI.x = m_maxWs[bx] - 1 - ( m_camera->OffsetX.GetValue() + 0.5 * ( (float)m_currentROI.w - 1 ) );
         }
@@ -830,7 +812,7 @@ int baslerCtrl::configureAcquisition()
             m_currentROI.x = m_camera->OffsetX.GetValue() + 0.5 * ( (float)m_currentROI.w - 1 );
         }
 
-        if( m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR )
+        if( m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR )
         {
             m_currentROI.y = m_maxHs[by] - 1 - ( m_camera->OffsetY.GetValue() + 0.5 * ( (float)m_currentROI.h - 1 ) );
         }
@@ -1152,7 +1134,7 @@ int baslerCtrl::checkNextROI()
     //-- round to nearest increment
     //-- recalculate center
     int x;
-    if( m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR )
+    if( m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR )
     {
         x = ( m_maxWs[bx] - 1 - m_nextROI.x ) - 0.5 * ( (float)w - 1 );
     }
@@ -1173,7 +1155,7 @@ int baslerCtrl::checkNextROI()
         x = m_maxWs[bx] - w;
 
     std::cerr << "req x: " << m_nextROI.x;
-    if( m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR )
+    if( m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR )
     {
         m_nextROI.x = m_maxWs[bx] - 1 - ( x + 0.5 * ( (float)w - 1.0 ) );
     }
@@ -1206,7 +1188,7 @@ int baslerCtrl::checkNextROI()
     //-- round to nearest increment
     //-- recalculate center
     int y;
-    if( m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR )
+    if( m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR )
     {
         y = ( m_maxHs[by] - 1 - m_nextROI.y ) - 0.5 * ( (float)h - 1 );
     }
@@ -1227,7 +1209,7 @@ int baslerCtrl::checkNextROI()
         y = m_maxHs[by] - h;
 
     std::cerr << "req y: " << m_nextROI.y;
-    if( m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR )
+    if( m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR )
     {
         m_nextROI.y = m_maxHs[by] - 1 - ( y + 0.5 * ( (float)h - 1 ) );
     }

--- a/apps/baslerCtrl/baslerCtrl.hpp
+++ b/apps/baslerCtrl/baslerCtrl.hpp
@@ -58,6 +58,10 @@ class baslerCtrl : public MagAOXApp<>,
                    public dev::telemeter<baslerCtrl>
 {
 
+    typedef dev::stdCamera<baslerCtrl>    stdCameraT;
+    typedef dev::frameGrabber<baslerCtrl> frameGrabberT;
+    typedef dev::telemeter<baslerCtrl>    telemeterT;
+
     friend class dev::stdCamera<baslerCtrl>;
     friend class dev::frameGrabber<baslerCtrl>;
     friend class dev::telemeter<baslerCtrl>;
@@ -154,6 +158,13 @@ class baslerCtrl : public MagAOXApp<>,
 
     /// Setup the configuration system (called by MagAOXApp::setup())
     virtual void setupConfig();
+
+    /// Implementation of loadConfig logic, separated for testing.
+    /** This is called by loadConfig().
+     */
+    int loadConfigImpl( mx::app::appConfigurator &_config /**< [in] an application configuration
+                                                                    from which to load values*/
+    );
 
     /// load the configuration system results (called by MagAOXApp::setup())
     virtual void loadConfig();
@@ -267,6 +278,11 @@ inline baslerCtrl::baslerCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MO
 {
     m_powerMgtEnabled = false;
 
+    m_full_x = 335.5;
+    m_full_y = 255.5;
+    m_full_w = 672;
+    m_full_h = 512;
+
     return;
 }
 
@@ -275,7 +291,7 @@ inline baslerCtrl::~baslerCtrl() noexcept
     return;
 }
 
-inline void baslerCtrl::setupConfig()
+void baslerCtrl::setupConfig()
 {
     dev::stdCamera<baslerCtrl>::setupConfig( config );
 
@@ -303,19 +319,30 @@ inline void baslerCtrl::setupConfig()
     dev::telemeter<baslerCtrl>::setupConfig( config );
 }
 
-inline void baslerCtrl::loadConfig()
+int baslerCtrl::loadConfigImpl( mx::app::appConfigurator &_config )
 {
-    dev::stdCamera<baslerCtrl>::loadConfig( config );
-
     config( m_serialNumber, "camera.serialNumber" );
     config( m_bits, "camera.bits" );
 
-    dev::frameGrabber<baslerCtrl>::loadConfig( config );
+    STDCAMERA_LOAD_CONFIG( _config );
 
-    dev::telemeter<baslerCtrl>::loadConfig( config );
+    FRAMEGRABBER_LOAD_CONFIG( _config );
+
+    TELEMETER_LOAD_CONFIG( _config );
+
+    return 0;
 }
 
-inline int baslerCtrl::appStartup()
+void baslerCtrl::loadConfig()
+{
+    if( loadConfigImpl( config ) < 0 )
+    {
+        log<software_critical>( { __FILE__, __LINE__, "error loading config" } );
+        m_shutdown = 1;
+    }
+}
+
+int baslerCtrl::appStartup()
 {
 
     //=================================
@@ -345,7 +372,7 @@ inline int baslerCtrl::appStartup()
     return 0;
 }
 
-inline int baslerCtrl::appLogic()
+int baslerCtrl::appLogic()
 {
     // and run stdCamera's appLogic
     if( dev::stdCamera<baslerCtrl>::appLogic() < 0 )
@@ -435,7 +462,7 @@ inline int baslerCtrl::appLogic()
     return 0;
 }
 
-inline int baslerCtrl::appShutdown()
+int baslerCtrl::appShutdown()
 {
     dev::stdCamera<baslerCtrl>::appShutdown();
 
@@ -451,7 +478,7 @@ inline int baslerCtrl::appShutdown()
     return 0;
 }
 
-inline int baslerCtrl::connect()
+int baslerCtrl::connect()
 {
     CDeviceInfo info;
     // info.SetDeviceClass(Camera_t::DeviceClass());
@@ -657,30 +684,25 @@ inline int baslerCtrl::connect()
         */
     }
 
-    m_full_w = m_camera->SensorWidth.GetValue();
-    m_full_h = m_camera->SensorHeight.GetValue();
-    m_full_x = 0.5 * ( (float)m_full_w - 1.0 );
-    m_full_y = 0.5 * ( (float)m_full_h - 1.0 );
+    if(m_full_w != m_camera->SensorWidth.GetValue())
+    {
+        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI w (camera.full_w) mismatch with camera"});
+    }
 
-    if( m_default_w == 0 )
-        m_default_w = m_full_w;
-    if( m_default_h == 0 )
-        m_default_h = m_full_h;
-    if( m_default_x == 0 )
-        m_default_x = m_full_x;
-    if( m_default_y == 0 )
-        m_default_y = m_full_y;
-    if( m_default_bin_x == 0 )
-        m_default_bin_x = m_binXs[0];
-    if( m_default_bin_y == 0 )
-        m_default_bin_y = m_binYs[0];
+    if(m_full_h != m_camera->SensorHeight.GetValue())
+    {
+        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI h (camera.full_h) mismatch with camera"});
+    }
+    
+    if(m_full_x != 0.5 * ( (float)m_full_w - 1.0 ))
+    {
+        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI x (camera.full_x) mismatch with camera"});
+    }
 
-    m_nextROI.x     = m_default_x;
-    m_nextROI.y     = m_default_y;
-    m_nextROI.w     = m_default_w;
-    m_nextROI.h     = m_default_h;
-    m_nextROI.bin_x = m_default_bin_x;
-    m_nextROI.bin_y = m_default_bin_y;
+    if(m_full_y != 0.5 * ( (float)m_full_h - 1.0 ))
+    {
+        return log<software_critical,-1>({__FILE__, __LINE__, "full ROI y (camera.full_y) mismatch with camera"});
+    }
 
     return 0;
 }
@@ -688,7 +710,9 @@ inline int baslerCtrl::connect()
 int baslerCtrl::configureAcquisition()
 {
     if( !m_camera )
+    {
         return -1;
+    }
 
     try
     {
@@ -742,6 +766,7 @@ int baslerCtrl::configureAcquisition()
         }
         else
         {
+            std::cerr << "m_nextROI.x: " << m_nextROI.x << " m_nextROI.w:" << m_nextROI.w << '\n';
             xoff = m_nextROI.x - 0.5 * ( (float)m_nextROI.w - 1 );
         }
 
@@ -751,6 +776,7 @@ int baslerCtrl::configureAcquisition()
         }
         else
         {
+            std::cerr << "m_nextROI.y: " << m_nextROI.y << " m_nextROI.h:" << m_nextROI.h << '\n';
             yoff = m_nextROI.y - 0.5 * ( (float)m_nextROI.h - 1 );
         }
 
@@ -762,6 +788,8 @@ int baslerCtrl::configureAcquisition()
 
         m_camera->Width.SetValue( m_nextROI.w );
         m_camera->Height.SetValue( m_nextROI.h );
+
+        std::cerr << "xoff: " << xoff << " yoff: " << yoff << '\n';
 
         m_camera->OffsetX.SetValue( xoff );
         m_camera->OffsetY.SetValue( yoff );
@@ -927,7 +955,7 @@ int baslerCtrl::reconfig()
     return 0;
 }
 
-inline int baslerCtrl::getTemp()
+int baslerCtrl::getTemp()
 {
     if( m_camera == nullptr )
         return 0;
@@ -958,7 +986,7 @@ inline int baslerCtrl::getTemp()
     return 0;
 }
 
-inline int baslerCtrl::getExpTime()
+int baslerCtrl::getExpTime()
 {
     if( m_camera == nullptr )
         return 0;
@@ -979,7 +1007,7 @@ inline int baslerCtrl::getExpTime()
     return 0;
 }
 
-inline int baslerCtrl::getFPS()
+int baslerCtrl::getFPS()
 {
     if( m_camera == nullptr )
         return 0;
@@ -1005,19 +1033,19 @@ inline float baslerCtrl::fps()
     return m_fps;
 }
 
-inline int baslerCtrl::powerOnDefaults()
+int baslerCtrl::powerOnDefaults()
 {
-    m_nextROI.x     = m_default_x;
+    /*m_nextROI.x     = m_default_x;
     m_nextROI.y     = m_default_y;
     m_nextROI.w     = m_default_w;
     m_nextROI.h     = m_default_h;
     m_nextROI.bin_x = m_default_bin_x;
-    m_nextROI.bin_y = m_default_bin_y;
+    m_nextROI.bin_y = m_default_bin_y;*/
 
     return 0;
 }
 
-inline int baslerCtrl::setFPS()
+int baslerCtrl::setFPS()
 {
     if( m_camera == nullptr )
         return 0;
@@ -1051,7 +1079,7 @@ inline int baslerCtrl::setFPS()
     return 0;
 }
 
-inline int baslerCtrl::setExpTime()
+int baslerCtrl::setExpTime()
 {
     if( m_camera == nullptr )
         return 0;
@@ -1072,7 +1100,7 @@ inline int baslerCtrl::setExpTime()
     return 0;
 }
 
-inline int baslerCtrl::checkNextROI()
+int baslerCtrl::checkNextROI()
 {
     std::cerr << "checkNextROI!\n";
 
@@ -1226,7 +1254,7 @@ inline int baslerCtrl::checkNextROI()
     }
 }
 
-inline int baslerCtrl::setNextROI()
+int baslerCtrl::setNextROI()
 {
     std::cerr << "setNextROI:\n";
     std::cerr << "  m_nextROI.x = " << m_nextROI.x << "\n";
@@ -1263,12 +1291,12 @@ bool baslerCtrl::stateStringValid()
     return true;
 }
 
-inline int baslerCtrl::checkRecordTimes()
+int baslerCtrl::checkRecordTimes()
 {
     return telemeter<baslerCtrl>::checkRecordTimes( telem_stdcam() );
 }
 
-inline int baslerCtrl::recordTelem( const telem_stdcam * )
+int baslerCtrl::recordTelem( const telem_stdcam * )
 {
     return recordCamera( true );
 }

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -1464,7 +1464,7 @@ int picamCtrl::configureAcquisition()
    nextrois.roi_count = 1;
    
    int roi_err = false;
-   if(m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR)
+   if(m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR)
    {
       nextroi.x = ((1023-m_nextROI.x) - 0.5*( (float) m_nextROI.w - 1.0));
    }
@@ -1486,7 +1486,7 @@ int picamCtrl::configureAcquisition()
    }
    
 
-   if(m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR)
+   if(m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR)
    {
       nextroi.y = ((1023 - m_nextROI.y) - 0.5*( (float) m_nextROI.h - 1.0));
    }
@@ -1628,7 +1628,7 @@ int picamCtrl::configureAcquisition()
    std::cerr << 0.5*( (float) (rois->roi_array[0].width - 1.0)) << "\n";
    
 
-   if(m_currentFlip == fgFlipLR || m_currentFlip == fgFlipUDLR)
+   if(m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR)
    {
       m_currentROI.x = (1023.0-rois->roi_array[0].x) - 0.5*( (float) (rois->roi_array[0].width - 1.0)) ;
       //nextroi.x = ((1023-m_nextROI.x) - 0.5*( (float) m_nextROI.w - 1.0));
@@ -1639,7 +1639,7 @@ int picamCtrl::configureAcquisition()
    }
 
    
-   if(m_currentFlip == fgFlipUD || m_currentFlip == fgFlipUDLR)
+   if(m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR)
    {
       m_currentROI.y = (1023.0-rois->roi_array[0].y) - 0.5*( (float) (rois->roi_array[0].height - 1.0)) ;
       //nextroi.y = ((1023 - m_nextROI.y) - 0.5*( (float) m_nextROI.h - 1.0));

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -1085,19 +1085,19 @@ int picamCtrl::getTemps()
       return -1;
    }
 
-   if(status == 1) 
+   if(status == PicamSensorTemperatureStatus_Unlocked) 
    {
       m_tempControlStatus = true;
       m_tempControlOnTarget = false;
       m_tempControlStatusStr = "UNLOCKED";
    }
-   else if(status == 2) 
+   else if(status == PicamSensorTemperatureStatus_Locked) 
    {
       m_tempControlStatus = true;
       m_tempControlOnTarget = true;
       m_tempControlStatusStr = "LOCKED";
    }
-   else if(status == 3) 
+   else if(status == PicamSensorTemperatureStatus_Faulted) 
    {
       m_tempControlStatus = false;
       m_tempControlOnTarget = false;

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -384,12 +384,6 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
    m_defaultVShiftSpeed = "1_2us";
    m_vShiftSpeedNames = {"0_7us", "1_2us", "2_0us", "5_0us"};
    m_vShiftSpeedNameLabels = {"0.7 us", "1.2 us", "2.0 us", "5.0 us"};
-   
-   
-   m_default_x = 511.5; 
-   m_default_y = 511.5; 
-   m_default_w = 1024;  
-   m_default_h = 1024;  
       
    m_full_x = 511.5; 
    m_full_y = 511.5; 
@@ -1134,12 +1128,12 @@ int picamCtrl::powerOnDefaults()
 {
    m_ccdTempSetpt = -55; //This is the power on setpoint
 
-   m_currentROI.x = 511.5;
+   /*m_currentROI.x = 511.5;
    m_currentROI.y = 511.5;
    m_currentROI.w = 1024;
    m_currentROI.h = 1024;
    m_currentROI.bin_x = 1;
-   m_currentROI.bin_y = 1;
+   m_currentROI.bin_y = 1;*/
 
    m_readoutSpeedName = "emccd_05MHz";
    m_vShiftSpeedName = "1_2us";

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -319,8 +319,8 @@ pvcamCtrl::pvcamCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 
     m_default_x     = 1599.5;
     m_default_y     = 1599.5;
-    m_default_w     = 3200;
-    m_default_h     = 3200;
+    m_default_w     = 512; //we make this smaller by default
+    m_default_h     = 512;
     m_default_bin_x = 1;
     m_default_bin_y = 1;
 
@@ -329,19 +329,6 @@ pvcamCtrl::pvcamCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
     m_full_w = 3200;
     m_full_h = 3200;
 
-    m_currentROI.x     = m_default_x;
-    m_currentROI.y     = m_default_y;
-    m_currentROI.w     = m_default_w;
-    m_currentROI.h     = m_default_h;
-    m_currentROI.bin_x = m_default_bin_x;
-    m_currentROI.bin_y = m_default_bin_y;
-
-    m_nextROI.x     = m_currentROI.x;
-    m_nextROI.y     = m_currentROI.y;
-    m_nextROI.w     = m_currentROI.w;
-    m_nextROI.h     = m_currentROI.h;
-    m_nextROI.bin_x = m_currentROI.bin_x;
-    m_nextROI.bin_y = m_currentROI.bin_y;
 
     m_defaultReadoutSpeed    = "dynamic_range";
     m_readoutSpeedNames      = { "sensitivity", "speed", "dynamic_range", "sub_electron" };
@@ -407,20 +394,6 @@ int pvcamCtrl::loadConfigImpl( mx::app::appConfigurator &_config )
     }
 
     STDCAMERA_LOAD_CONFIG( _config );
-
-    m_currentROI.x     = m_default_x;
-    m_currentROI.y     = m_default_y;
-    m_currentROI.w     = m_default_w;
-    m_currentROI.h     = m_default_h;
-    m_currentROI.bin_x = m_default_bin_x;
-    m_currentROI.bin_y = m_default_bin_y;
-
-    m_nextROI.x     = m_currentROI.x;
-    m_nextROI.y     = m_currentROI.y;
-    m_nextROI.w     = m_currentROI.w;
-    m_nextROI.h     = m_currentROI.h;
-    m_nextROI.bin_x = m_currentROI.bin_x;
-    m_nextROI.bin_y = m_currentROI.bin_y;
 
     FRAMEGRABBER_LOAD_CONFIG( _config );
 
@@ -578,20 +551,6 @@ int pvcamCtrl::powerOnDefaults()
 {
     m_expTime    = 0.01;
     m_expTimeSet = 0.01;
-
-    m_currentROI.x     = m_default_x;
-    m_currentROI.y     = m_default_y;
-    m_currentROI.w     = m_default_w;
-    m_currentROI.h     = m_default_h;
-    m_currentROI.bin_x = m_default_bin_x;
-    m_currentROI.bin_y = m_default_bin_y;
-
-    m_nextROI.x     = m_default_x;
-    m_nextROI.y     = m_default_y;
-    m_nextROI.w     = m_default_w;
-    m_nextROI.h     = m_default_h;
-    m_nextROI.bin_x = m_default_bin_x;
-    m_nextROI.bin_y = m_default_bin_y;
 
     m_readoutSpeedName    = m_defaultReadoutSpeed;
     m_readoutSpeedNameSet = m_defaultReadoutSpeed;

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -135,7 +135,7 @@ class pvcamCtrl : public MagAOXApp<true>,
         false; ///< app::dev confg to tell stdCamera to expose the state string property
 
     static constexpr bool c_frameGrabber_flippable =
-        false; ///< app:dev config to tell framegrabber this camera can be flipped
+        false; ///< app:dev config to tell framegrabber this camera can not be flipped
 
     ///@}
 

--- a/libMagAOX/app/dev/edtCamera.hpp
+++ b/libMagAOX/app/dev/edtCamera.hpp
@@ -265,7 +265,7 @@ int edtCamera<derivedT>::pdvSerialWriteRead( std::string & response,
                                              const std::string & command
                                            )
 {
-   char    buf[MAGAOX_PDV_SERBUFSIZE+1];
+   char buf[MAGAOX_PDV_SERBUFSIZE+1];
 
    // Flush the channel first.
    // This does not indicate errors, so no checks possible.
@@ -289,7 +289,8 @@ int edtCamera<derivedT>::pdvSerialWriteRead( std::string & response,
       return -1;
    }
 
-   u_char  lastbyte, waitc;
+   u_char  lastbyte = 0;
+   u_char waitc = 0;
 
    response.clear();
 
@@ -299,8 +300,7 @@ int edtCamera<derivedT>::pdvSerialWriteRead( std::string & response,
 
       if(ret > 0) response += buf;
 
-      //Check for last char, wait for more otherwise.
-      if (*buf) lastbyte = (u_char)buf[strnlen(buf, sizeof(buf))-1];
+      lastbyte = (u_char)buf[strnlen(buf, sizeof(buf))-1];
 
       if (pdv_get_waitchar(m_pdv, &waitc) && (lastbyte == waitc))
       {

--- a/libMagAOX/app/dev/frameGrabber.hpp
+++ b/libMagAOX/app/dev/frameGrabber.hpp
@@ -127,8 +127,6 @@ class frameGrabber
 
     ///@}
 
-    int m_currentFlip{ fgFlipNone };
-
     uint32_t m_width{ 0 };  ///< The width of the image, once deinterlaced etc.
     uint32_t m_height{ 0 }; ///< The height of the image, once deinterlaced etc.
 
@@ -417,7 +415,9 @@ int frameGrabber<derivedT>::loadConfig( mx::app::appConfigurator &config )
     if( derivedT::c_frameGrabber_flippable )
     {
         std::string flip = "flipNone";
+        
         config( flip, "framegrabber.defaultFlip" );
+
         if( flip == "flipNone" )
         {
             m_defaultFlip = fgFlipNone;
@@ -436,13 +436,14 @@ int frameGrabber<derivedT>::loadConfig( mx::app::appConfigurator &config )
         }
         else
         {
-            derivedT::template log<text_log>(
-                { std::string( "invalid framegrabber flip specification (" ) + flip + "), setting flipNone" },
-                logPrio::LOG_ERROR );
+            derivedT::template log<text_log>( { std::string( "invalid framegrabber flip"
+                                                             "specification (" ) +
+                                                flip + "), setting flipNone" },
+                                              logPrio::LOG_ERROR );
+
             m_defaultFlip = fgFlipNone;
         }
 
-        m_currentFlip = m_defaultFlip;
     }
 
     return 0;
@@ -795,9 +796,6 @@ void frameGrabber<derivedT>::fgThreadExec()
 
         m_typeSize = ImageStreamIO_typesize( m_dataType );
 
-        // Here we resolve currentFlip somehow.
-        //m_currentFlip = m_defaultFlip; //-delete after testing.  
-
         if( configCircBuffs() < 0 )
         {
             derivedT::template log<software_error>( { __FILE__, __LINE__, "error configuring latency circ. buffs" } );
@@ -969,7 +967,7 @@ void *frameGrabber<derivedT>::loadImageIntoStreamCopy( void *dest, void *src, si
     }
     else
     {
-        switch( m_currentFlip )
+        switch( m_defaultFlip )
         {
         case fgFlipNone:
             return mx::improc::imcpy( dest, src, width, height, szof );

--- a/libMagAOX/app/dev/frameGrabber.hpp
+++ b/libMagAOX/app/dev/frameGrabber.hpp
@@ -441,6 +441,8 @@ int frameGrabber<derivedT>::loadConfig( mx::app::appConfigurator &config )
                 logPrio::LOG_ERROR );
             m_defaultFlip = fgFlipNone;
         }
+
+        m_currentFlip = m_defaultFlip;
     }
 
     return 0;
@@ -794,7 +796,7 @@ void frameGrabber<derivedT>::fgThreadExec()
         m_typeSize = ImageStreamIO_typesize( m_dataType );
 
         // Here we resolve currentFlip somehow.
-        m_currentFlip = m_defaultFlip;
+        //m_currentFlip = m_defaultFlip; //-delete after testing.  
 
         if( configCircBuffs() < 0 )
         {

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -224,7 +224,8 @@ int loadCameraConfig( cameraConfigMap &ccmap, ///< [out] the map in which to pla
  *             static constexpr bool c_stdCamera_usesROI = true; //or: false
  *         \endcode
  *
- *       - The default values of m_currentROI should be set before calling stdCamera::appStartup().
+ *       - The default values of m_full_x/y/w/h must be set before calling stdCamera::appStartup(). These 
+ *         are configured by stdCamera::loadConfig(), but only if set in the config file.
  *
  *       - The derived class must implement:
  *         \code

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -3259,6 +3259,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
     static bool        last_synchro      = false;
     static float       last_vshiftSpeed  = -1;
     static bool        last_cropMode     = false;
+    static std::string last_readoutSpeed;
 
     if( force || m_modeName != last_mode || m_currentROI.x != last_roi.x || m_currentROI.y != last_roi.y ||
         m_currentROI.w != last_roi.w || m_currentROI.h != last_roi.h || m_currentROI.bin_x != last_roi.bin_x ||
@@ -3267,7 +3268,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
         m_ccdTempSetpt != last_ccdTempSetpt || m_tempControlStatus != last_tempControlStatus ||
         m_tempControlOnTarget != last_tempControlOnTarget || m_tempControlStatusStr != last_tempControlStatusStr ||
         m_shutterStatus != last_shutterStatus || m_shutterState != last_shutterState || m_synchro != last_synchro ||
-        m_vshiftSpeed != last_vshiftSpeed || m_cropMode != last_cropMode )
+        m_vshiftSpeed != last_vshiftSpeed || m_cropMode != last_cropMode || m_readoutSpeedName != last_readoutSpeed)
     {
         derived().template telem<telem_stdcam>( { m_modeName,
                                                   m_currentROI.x,
@@ -3289,7 +3290,8 @@ int stdCamera<derivedT>::recordCamera( bool force )
                                                   (int8_t)m_shutterState,
                                                   (uint8_t)m_synchro,
                                                   m_vshiftSpeed,
-                                                  (uint8_t)m_cropMode } );
+                                                  (uint8_t)m_cropMode,
+                                                  m_readoutSpeedName } );
 
         last_mode                 = m_modeName;
         last_roi                  = m_currentROI;
@@ -3307,6 +3309,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
         last_synchro              = m_synchro;
         last_vshiftSpeed          = m_vshiftSpeed;
         last_cropMode             = m_cropMode;
+        last_readoutSpeed         = m_readoutSpeedName;
     }
 
     return 0;

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -1131,6 +1131,7 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     false,
                     "float",
                     "The default ROI x position." );
+
         config.add( "camera.default_y",
                     "",
                     "camera.default_y",
@@ -1140,6 +1141,7 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     false,
                     "float",
                     "The default ROI y position." );
+
         config.add( "camera.default_w",
                     "",
                     "camera.default_w",
@@ -1149,6 +1151,7 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     false,
                     "int",
                     "The default ROI width." );
+
         config.add( "camera.default_h",
                     "",
                     "camera.default_h",
@@ -1158,6 +1161,7 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     false,
                     "int",
                     "The default ROI height." );
+
         config.add( "camera.default_bin_x",
                     "",
                     "camera.default_bin_x",
@@ -1167,6 +1171,7 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     false,
                     "int",
                     "The default ROI x binning." );
+
         config.add( "camera.default_bin_y",
                     "",
                     "camera.default_bin_y",
@@ -1221,12 +1226,83 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
 
     if( derivedT::c_stdCamera_usesROI )
     {
+        config( m_full_x, "camera.full_x" );
+        config( m_full_y, "camera.full_y" );
+        config( m_full_w, "camera.full_w" );
+        config( m_full_h, "camera.full_h" );
+        config( m_full_bin_x, "camera.full_bin_x" );
+        config( m_full_bin_y, "camera.full_bin_y" );
+
+        if( m_full_x == 0 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI x (camera.full_x) not set" } );
+        }
+
+        if( m_full_y == 0 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI y (camera.full_y) not set" } );
+        }
+
+        if( m_full_w == 0 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI w (camera.full_w) not set" } );
+        }
+
+        if( m_full_h == 0 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI h (camera.full_h) not set" } );
+        }
+
+        if( m_full_bin_x < 1 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI bin-x (camera.full_bin_x) not set" } );
+        }
+
+        if( m_full_bin_y < 1 )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__, __LINE__, "full ROI bin-y (camera.full_bin_y) not set" } );
+        }
+
         config( m_default_x, "camera.default_x" );
         config( m_default_y, "camera.default_y" );
         config( m_default_w, "camera.default_w" );
         config( m_default_h, "camera.default_h" );
         config( m_default_bin_x, "camera.default_bin_x" );
         config( m_default_bin_y, "camera.default_bin_y" );
+
+        // If default is not setup properly, it defaults to full
+        if( m_default_x == 0 || m_default_y == 0 || m_default_w == 0 || m_default_h == 0 || m_default_bin_x < 1 ||
+            m_default_bin_y < 1 )
+        {
+            m_default_x     = m_full_x;
+            m_default_y     = m_full_y;
+            m_default_w     = m_full_w;
+            m_default_h     = m_full_h;
+            m_default_bin_x = m_default_bin_x;
+            m_default_bin_y = m_default_bin_y;
+        }
+
+        // now always start with current and next set to default
+
+        m_currentROI.x     = m_default_x;
+        m_currentROI.y     = m_default_y;
+        m_currentROI.w     = m_default_w;
+        m_currentROI.h     = m_default_h;
+        m_currentROI.bin_x = m_default_bin_x;
+        m_currentROI.bin_y = m_default_bin_y;
+
+        m_nextROI.x     = m_default_x;
+        m_nextROI.y     = m_default_y;
+        m_nextROI.w     = m_default_w;
+        m_nextROI.h     = m_default_h;
+        m_nextROI.bin_x = m_default_bin_x;
+        m_nextROI.bin_y = m_default_bin_y;
     }
 
     return 0;
@@ -1669,6 +1745,20 @@ int stdCamera<derivedT>::appLogic()
             {
                 derived().state( stateCodes::NOTCONNECTED );
 
+                m_currentROI.x     = m_default_x;
+                m_currentROI.y     = m_default_y;
+                m_currentROI.w     = m_default_w;
+                m_currentROI.h     = m_default_h;
+                m_currentROI.bin_x = m_default_bin_x;
+                m_currentROI.bin_y = m_default_bin_y;
+
+                m_nextROI.x     = m_default_x;
+                m_nextROI.y     = m_default_y;
+                m_nextROI.w     = m_default_w;
+                m_nextROI.h     = m_default_h;
+                m_nextROI.bin_x = m_default_bin_x;
+                m_nextROI.bin_y = m_default_bin_y;
+
                 // Set power-on defaults
                 derived().powerOnDefaults();
 
@@ -1790,6 +1880,7 @@ int stdCamera<derivedT>::onPowerOff()
 
     if( derivedT::c_stdCamera_usesROI )
     {
+        // Blank these values
         indi::updateIfChanged( m_indiP_roi_x, "current", std::string( "" ), derived().m_indiDriver, INDI_IDLE );
         indi::updateIfChanged( m_indiP_roi_x, "target", std::string( "" ), derived().m_indiDriver, INDI_IDLE );
 
@@ -1807,6 +1898,21 @@ int stdCamera<derivedT>::onPowerOff()
 
         indi::updateIfChanged( m_indiP_roi_bin_y, "current", std::string( "" ), derived().m_indiDriver, INDI_IDLE );
         indi::updateIfChanged( m_indiP_roi_bin_y, "target", std::string( "" ), derived().m_indiDriver, INDI_IDLE );
+
+        // But we also set these to their defaults so that when we power up it's all good
+        m_currentROI.x     = m_default_x;
+        m_currentROI.y     = m_default_y;
+        m_currentROI.w     = m_default_w;
+        m_currentROI.h     = m_default_h;
+        m_currentROI.bin_x = m_default_bin_x;
+        m_currentROI.bin_y = m_default_bin_y;
+
+        m_nextROI.x     = m_default_x;
+        m_nextROI.y     = m_default_y;
+        m_nextROI.w     = m_default_w;
+        m_nextROI.h     = m_default_h;
+        m_nextROI.bin_x = m_default_bin_x;
+        m_nextROI.bin_y = m_default_bin_y;
     }
 
     // Shutters can be independent pieces of hardware . . .
@@ -3205,55 +3311,54 @@ int stdCamera<derivedT>::recordCamera( bool force )
     return 0;
 }
 
-
 /// Call stdCameraT::setupConfig with error checking for stdCamera
 /**
-  * \param cfig the application configurator
-  */
-#define STDCAMERA_SETUP_CONFIG( cfig )                                                   \
-    if(stdCameraT::setupConfig(cfig) < 0)                                                \
-    {                                                                                    \
-        log<software_error>({__FILE__, __LINE__, "Error from stdCameraT::setupConfig"}); \
-        m_shutdown = true;                                                               \
-        return;                                                                          \
+ * \param cfig the application configurator
+ */
+#define STDCAMERA_SETUP_CONFIG( cfig )                                                                                 \
+    if( stdCameraT::setupConfig( cfig ) < 0 )                                                                          \
+    {                                                                                                                  \
+        log<software_error>( { __FILE__, __LINE__, "Error from stdCameraT::setupConfig" } );                           \
+        m_shutdown = true;                                                                                             \
+        return;                                                                                                        \
     }
 
- /// Call stdCameraT::loadConfig with error checking for stdCamera
+/// Call stdCameraT::loadConfig with error checking for stdCamera
 /** This must be inside a function that returns int, e.g. the standard loadConfigImpl.
-  * \param cfig the application configurator
-  */
-#define STDCAMERA_LOAD_CONFIG( cfig )                                                             \
-    if(stdCameraT::loadConfig(cfig) < 0)                                                          \
-    {                                                                                             \
-        return log<software_error,-1>({__FILE__, __LINE__, "Error from stdCameraT::loadConfig"}); \
+ * \param cfig the application configurator
+ */
+#define STDCAMERA_LOAD_CONFIG( cfig )                                                                                  \
+    if( stdCameraT::loadConfig( cfig ) < 0 )                                                                           \
+    {                                                                                                                  \
+        return log<software_error, -1>( { __FILE__, __LINE__, "Error from stdCameraT::loadConfig" } );                 \
     }
 
 /// Call stdCameraT::appStartup with error checking for stdCamera
-#define STDCAMERA_APP_STARTUP                                                                     \
-    if(stdCameraT::appStartup() < 0)                                                              \
-    {                                                                                             \
-        return log<software_error,-1>({__FILE__, __LINE__, "Error from stdCameraT::appStartup"}); \
+#define STDCAMERA_APP_STARTUP                                                                                          \
+    if( stdCameraT::appStartup() < 0 )                                                                                 \
+    {                                                                                                                  \
+        return log<software_error, -1>( { __FILE__, __LINE__, "Error from stdCameraT::appStartup" } );                 \
     }
 
 /// Call stdCameraT::appLogic with error checking for stdCamera
-#define STDCAMERA_APP_LOGIC                                                                     \
-    if(stdCameraT::appLogic() < 0)                                                              \
-    {                                                                                           \
-        return log<software_error,-1>({__FILE__, __LINE__, "Error from stdCameraT::appLogic"}); \
+#define STDCAMERA_APP_LOGIC                                                                                            \
+    if( stdCameraT::appLogic() < 0 )                                                                                   \
+    {                                                                                                                  \
+        return log<software_error, -1>( { __FILE__, __LINE__, "Error from stdCameraT::appLogic" } );                   \
     }
 
 /// Call stdCameraT::updateINDI with error checking for stdCamera
-#define STDCAMERA_UPDATE_INDI                                                                     \
-    if(stdCameraT::updateINDI() < 0)                                                              \
-    {                                                                                             \
-        return log<software_error,-1>({__FILE__, __LINE__, "Error from stdCameraT::updateINDI"}); \
+#define STDCAMERA_UPDATE_INDI                                                                                          \
+    if( stdCameraT::updateINDI() < 0 )                                                                                 \
+    {                                                                                                                  \
+        return log<software_error, -1>( { __FILE__, __LINE__, "Error from stdCameraT::updateINDI" } );                 \
     }
 
 /// Call stdCameraT::appShutdown with error checking for stdCamera
-#define STDCAMERA_APP_SHUTDOWN                                                                     \
-    if(stdCameraT::appShutdown() < 0)                                                              \
-    {                                                                                              \
-        return log<software_error,-1>({__FILE__, __LINE__, "Error from stdCameraT::appShutdown"}); \
+#define STDCAMERA_APP_SHUTDOWN                                                                                         \
+    if( stdCameraT::appShutdown() < 0 )                                                                                \
+    {                                                                                                                  \
+        return log<software_error, -1>( { __FILE__, __LINE__, "Error from stdCameraT::appShutdown" } );                \
     }
 
 } // namespace dev

--- a/libMagAOX/logger/types/schemas/telem_stdcam.fbs
+++ b/libMagAOX/logger/types/schemas/telem_stdcam.fbs
@@ -50,6 +50,8 @@ table Telem_stdcam_fb
 
    cropMode:int8 = -1;
 
+   readout_speed:string;
+
 }
 
 root_type Telem_stdcam_fb;

--- a/libMagAOX/logger/types/telem_stdcam.hpp
+++ b/libMagAOX/logger/types/telem_stdcam.hpp
@@ -56,7 +56,8 @@ struct telem_stdcam : public flatbuffer_log
                 const int8_t & shutterState,         ///<[in]
                 const uint8_t & synchro,             ///<[in]
                 const float & vshift,                ///<[in]
-                const uint8_t & cropMode             ///<[in]
+                const uint8_t & cropMode,            ///<[in]
+                const std::string & readout_speed     ///<[in]
               )
       {
          auto _mode = builder.CreateString(mode);
@@ -68,42 +69,9 @@ struct telem_stdcam : public flatbuffer_log
          auto _shutterStatusStr = builder.CreateString(shutterStatusSr);
          auto _shutter = CreateShutter(builder, _shutterStatusStr, shutterState);
 
-         auto fp = CreateTelem_stdcam_fb(builder, _mode, _roi, exptime, fps, emGain, adcSpeed, _tempCtrl, _shutter, synchro, vshift, cropMode);
-         builder.Finish(fp);
-      }
+         auto _readoutSpeed = builder.CreateString(readout_speed);
 
-      ///Construct from components, without vShift and cropMode for backwards compat.
-      messageT( const std::string & mode,            ///<[in]
-                const float & xcen,                  ///<[in]
-                const float & ycen,                  ///<[in]
-                const int & width,                   ///<[in]
-                const int & height,                  ///<[in]
-                const int & xbin,                    ///<[in]
-                const int & ybin,                    ///<[in]
-                const float & exptime,               ///<[in]
-                const float & fps,                   ///<[in]
-                const float & emGain,                ///<[in]
-                const float & adcSpeed,              ///<[in]
-                const float & temp,                  ///<[in]
-                const float & setpt,                 ///<[in]
-                const uint8_t & status,              ///<[in]
-                const uint8_t & ontarget,            ///<[in]
-                const std::string & statusStr,       ///<[in]
-                const std::string & shutterStatusSr, ///<[in]
-                const int8_t & shutterState,         ///<[in]
-                const uint8_t & synchro              ///<[in]
-              )
-      {
-         auto _mode = builder.CreateString(mode);
-         auto _roi = CreateROI(builder,xcen, ycen, width, height, xbin, ybin);
-
-         auto _statusStr = builder.CreateString(statusStr);
-         auto _tempCtrl = CreateTempCtrl(builder, temp, setpt, status, ontarget, _statusStr);
-
-         auto _shutterStatusStr = builder.CreateString(shutterStatusSr);
-         auto _shutter = CreateShutter(builder, _shutterStatusStr, shutterState);
-
-         auto fp = CreateTelem_stdcam_fb(builder, _mode, _roi, exptime, fps, emGain, adcSpeed, _tempCtrl, _shutter, synchro, 0, -1);
+         auto fp = CreateTelem_stdcam_fb(builder, _mode, _roi, exptime, fps, emGain, adcSpeed, _tempCtrl, _shutter, synchro, vshift, cropMode, _readoutSpeed);
          builder.Finish(fp);
       }
 
@@ -213,6 +181,12 @@ struct telem_stdcam : public flatbuffer_log
       if(fbs->cropMode()==-1) msg += "---";
       else if(fbs->cropMode()==1) msg += "ON";
       else msg += "OFF";
+
+      if(fbs->readout_speed() != nullptr)
+      {
+         msg += " rospd: ";
+         msg += fbs->readout_speed()->c_str();
+      }
 
       return msg;
 
@@ -378,6 +352,16 @@ struct telem_stdcam : public flatbuffer_log
       else return false;
    }
 
+   static std::string readout_speed( void * msgBuffer )
+   {
+      auto fbs = GetTelem_stdcam_fb(msgBuffer);
+      if(fbs->readout_speed() != nullptr)
+      {
+         return std::string(fbs->readout_speed()->c_str());
+      }
+      else return "";
+   }
+
    /// Get the logMetaDetail for a member by name
    /**
      * \returns the a logMetaDetail filled in with the appropriate details
@@ -404,8 +388,9 @@ struct telem_stdcam : public flatbuffer_log
       else if(member == "shutterStatusStr") return logMetaDetail({"SHUTTER STATUS", logMeta::valTypes::String, logMeta::metaTypes::State, reinterpret_cast<void*>(&shutterStatusStr)});
       else if(member == "shutterState") return logMetaDetail({"SHUTTER", logMeta::valTypes::String, logMeta::metaTypes::State, reinterpret_cast<void*>(&shutterState)});
       else if(member == "synchro") return logMetaDetail({"SYNCHRO", logMeta::valTypes::Bool, logMeta::metaTypes::State, reinterpret_cast<void*>(&synchro)});
-      else if(member == "vshift") return logMetaDetail({"VSHIFTSPD", logMeta::valTypes::Float, logMeta::metaTypes::State, reinterpret_cast<void*>(&vshift)});
-      else if(member == "cropMode") return logMetaDetail({"CROPMODE", logMeta::valTypes::Bool, logMeta::metaTypes::State, reinterpret_cast<void*>(&cropMode)});
+      else if(member == "vshift") return logMetaDetail({"VERT SHIFT SPEED", logMeta::valTypes::Float, logMeta::metaTypes::State, reinterpret_cast<void*>(&vshift)});
+      else if(member == "cropMode") return logMetaDetail({"CROP MODE", logMeta::valTypes::Bool, logMeta::metaTypes::State, reinterpret_cast<void*>(&cropMode)});
+      else if(member == "readout_speed") return logMetaDetail({"READOUT SPEED", logMeta::valTypes::String, logMeta::metaTypes::State, reinterpret_cast<void*>(&readout_speed)});
       else
       {
          std::cerr << "No member " << member << " in telem_stdcam\n";

--- a/libMagAOX/logger/types/telem_stdcam.hpp
+++ b/libMagAOX/logger/types/telem_stdcam.hpp
@@ -184,8 +184,11 @@ struct telem_stdcam : public flatbuffer_log
 
       if(fbs->readout_speed() != nullptr)
       {
-         msg += " rospd: ";
-         msg += fbs->readout_speed()->c_str();
+         if(fbs->readout_speed()->Length() > 0)
+         {
+            msg += " rospd: ";
+            msg += fbs->readout_speed()->c_str();
+         }
       }
 
       return msg;

--- a/setup/steps/install_pvcam.sh
+++ b/setup/steps/install_pvcam.sh
@@ -32,6 +32,11 @@ else
     log_info "Existing PVCam install found, use the originall installer or /opt/pvcam/pvcam.uninstall.sh to remove"
 fi
 
+chcon -t modules_object_t /opt/pvcam/drivers/in-kernel/pcie/pvcam_pcie.ko
+
+if [ ! -f /etc/modules-load.d/pvcam_pcie.conf ]; then
+    echo pvcam_pcie > /etc/modules-load.d/pvcam_pcie.conf
+fi
 
 # if [[ ! -e /opt/PrincetonInstruments/picam ]]; then
 #     # This (|| true) isn't great, but sometimes it has a nonzero


### PR DESCRIPTION
a startup ROI was getting applied before the flip was first applied due to a logic error in how flips were handled, causing the ROI to be in the wrong place.  Also adds missing readout speed to stdcamera telem and updates pvcam (kinetix) install to load driver at boot.