### PR TITLE
add projection for python interface ncpc dm

### DIFF
--- a/python/magaox/deformable_mirror.py
+++ b/python/magaox/deformable_mirror.py
@@ -43,7 +43,7 @@ class XDeformableMirror(DeformableMirror):
         self.dmwrite = ImageStream('dm0{:d}disp0{:d}'.format(self.dmindex, channel))
         
         # The DM modes
-        self.grid = make_pupil_grid(self.num_across, 1)
+        self.grid = make_pupil_grid(self.num_across, self.size)
         modes = mode_basis_generator(self.grid)
         super().__init__(modes)
 


### PR DESCRIPTION
The dm interface didn't take the projection into account for the ncpc dm. We should merge this only if there is no other code that depends on this and does an additional projection to this