### PR TITLE
Camsci TTL sync

### DIFF
--- a/apps/corAlign/xapp/corAlign/utils.py
+++ b/apps/corAlign/xapp/corAlign/utils.py
@@ -1,62 +1,189 @@
-#!/usr/bin/env python
-from hcipy import *
+import hcipy import hp
 import numpy as np
-from skimage import feature
+import time 
+import datetime
+import os 
 
-def measure_center_position(image, threshold=1, mask_diameter=20):
-    center_mask = make_circular_aperture(mask_diameter)(image.grid)
-    mask = center_mask * ((image / np.nanstd(image)) < threshold)
+### Make the save directory
+def make_savedir_for_today(start_path='./Data/'):
+    ct = datetime.datetime.now()
+    savedir = start_path + '{:>04d}{:>02d}{:>02d}/'.format(ct.year, ct.month, ct.day)
+    make_savedir(savedir)
+    return savedir
 
-    if np.sum(mask) > 0:
-        xc = np.sum(mask * image.grid.x) / np.sum(mask)
-        yc = np.sum(mask * image.grid.y) / np.sum(mask)
-        return np.array([xc, yc])
+def make_savedir(new_path):
+    try:
+        os.makedirs(new_path, exist_ok=True)
+    except FileExistsError:
+        print("Directory already exists.")
+
+def make_time_stamp():
+    t = time.time()
+    t_seconds = int(t)
+    ms = int(1000 * (t - t_seconds))
+    stamp = '{:d}{:d}'.format(t_seconds, ms)
+    return stamp
+
+def wait_for_ready(client, device, timeout=0.1):
+    time.sleep(timeout)
+    while client[device + '.fsm.state'] != 'READY':
+        time.sleep(timeout)
+
+def make_horizontal_probe(grid, direction='left'):
+    probe = grid.zeros()
+    probe = probe.shaped
+    
+    width = 4
+    height = 4
+    x = (-1.0)**(np.arange(width) - width//2)
+    y = (-1.0)**(np.arange(height) - height//2)
+    
+    # 34 - 15 16 17 18 19 20
+    probe[15:19, 6:10] = np.outer(x, y)
+    probe[15:19, 6:10] = np.outer(y, x)
+    if direction == 'right':
+        probe = probe[:,::-1]
+    
+    return probe.ravel()
+
+def make_vertical_probe(grid, direction='down'):
+    probe = grid.zeros()
+    probe = probe.shaped
+    
+    width = 4
+    height = 4
+    x = (-1.0)**(np.arange(width) - width//2)
+    y = (-1.0)**(np.arange(height) - height//2)
+
+    # 34 - 15 16 17 18 19 20
+    probe[8:12, 15:19] = np.outer(y, x)
+    probe[8:12, 15:19] = np.outer(x, y)
+    probe = np.sign(probe)
+    if direction == 'up':
+        probe = probe[::-1,:]
+    
+    return probe.ravel()
+
+def make_ncpc_alignment_poke_pattern():
+    ncpc_act_grid = hp.make_pupil_grid(34, 34/30.0 * np.array([1.0, np.sqrt(2)]))
+    probe = make_vertical_probe(ncpc_act_grid) + make_vertical_probe(ncpc_act_grid, 'up')
+    probe += make_horizontal_probe(ncpc_act_grid) + make_horizontal_probe(ncpc_act_grid, 'right')
+    return probe
+
+
+def wait_for_state(client, indi_property, value, wait_time=1, tolerance=None):
+    if tolerance is None:
+        while not (client[indi_property] == value):
+            print("Waiting...")
+            time.sleep(wait_time)
     else:
-        return np.array([0.0, 0.0])
+        while not abs(client[indi_property] - value) < tolerance:
+            print("Waiting...")
+            time.sleep(wait_time)
 
-def knife_edge_dist(image, theta=-0.47, mask_diameter=200, threshold=0.5):
-    '''Measure the distance from the knife edge focal plane mask to the center of an image.
-
-
-        Parameters
-        ----------
-        image : array of floats 
-            Default: None.
-        theta: integer
-            The knife edge mask angle with respect to the image's x-axis. Default: 0.
-            mask_diameter: The diameter of the circular mask applied to the image for edge detection. Default: 200.
-            threshold: The sigma used to mask pixels along the circular mask edge. Default: 0.5.
-
-        Returns
-        -------
-        np.array()
-            A NumPy array containing the knife edge distance in X and Y with respect to the image center.
-        '''
-    THETA  = np.deg2rad(theta) # Angle measured from x-axis
+def calibrate_indi_device(client, device_name, device_property, delta_pertubation, camera, measurement_function, num_stack=50, do_wait=False):
+    client.get_properties('{:s}'.format(device_name))
     
-    grid = image.grid
+    property_current = '{:s}.{:s}.current'.format(device_name, device_property)
+    property_target = '{:s}.{:s}.target'.format(device_name, device_property)
+    current_position = client[property_current]
+    print("Probe to {:f} +- {:f}".format(current_position, delta_pertubation))
+    slope = 0
+    for s in [-1, 1]:
+        client[property_target] = current_position + s * delta_pertubation
+        if do_wait:
+            wait_for_state(client, property_current, current_position + s * delta_pertubation, tolerance=0.1 * delta_pertubation)
+        else:
+            time.sleep(5)
 
-    center_mask = make_circular_aperture(mask_diameter)(grid)
-    mask = ((image / np.std(image)) < threshold)
+        # Take measurement
+        camera.grab_stack(3)
+        im = camera.grab_stack(num_stack)
+       
+        measurement = measurement_function(im)
+        slope += s * measurement / (2 * delta_pertubation)
 
-    # Apply circular aperture mask to thresholded field
-    masked_im = (center_mask*mask)
-
-    # Detect edge and convert edge arr back to Field obj
-    edge = feature.canny(masked_im.shaped, sigma=4) # Widened Gaussian filter for edge detection on noisier images
-
-    edge_field = Field(edge.ravel(), image.grid)
-
-    # Get x, y edge coords from edge Field obj
-    x_edge = image.grid.x[edge_field>0]
-    y_edge = image.grid.y[edge_field>0]
-
-    # Project x, y coords onto x and y axes
-    d_normal = x_edge * np.sin(THETA) + y_edge * np.cos(THETA) 
-    d_parallel = x_edge * np.sin(THETA + np.pi/2) + y_edge * np.cos(THETA + np.pi/2) 
-    d = np.hypot(d_normal, d_parallel)
+    client[property_target] = current_position
+    if do_wait:
+        wait_for_state(client, property_current, current_position, tolerance=0.1 * delta_pertubation)
+    else:
+        time.sleep(2)
     
-    # Identify minimum absolute distance from the origin
-    min_dist_indx = np.argmin(abs(d))
+    return slope
 
-    return np.array([0.0, y_edge[min_dist_indx]])
+class XCorrShift():
+    def __init__(self, reference_image, domain_pixels=480, domain_size=40, filter_size=None):
+        self._reference_image = reference_image
+        self._xgrid = hp.make_pupil_grid(domain_pixels, domain_size)
+        
+        self._fft = hp.FastFourierTransform(self._reference_image.grid)
+        self._mft = hp.MatrixFourierTransform(self._xgrid, self._fft.output_grid)
+        
+        self._filter_size = filter_size
+        if filter_size is not None:
+            # Change this to a super gaussian filter to remove ringing.
+            self._spatial_filter = hp.make_circular_aperture(self._filter_size)(self._fft.output_grid)
+        else:
+            self._spatial_filter = 1
+
+        self._kernel = np.conj(self._fft.forward(self._reference_image + 0j))
+
+    def cross_correlate(self, image):
+        xcorr = np.real(self._mft.backward(self._fft.forward(image + 0j) * self._spatial_filter * self._kernel))
+        return xcorr
+        
+    def measure(self, image):           
+        # Do a cross-correlation and find the peak pixel
+        # TODO: implement sub-pixel precision with polynomial fitting
+        xcorr = self.cross_correlate(image)
+        indx_max = np.argmax(xcorr)
+        return self._xgrid.points[indx_max]
+
+
+def align_pupil_mask(camera, reference_image, client, indi_targets, reconstruction_matrix, num_steps=None, shift_offset = np.array([0,0]), options = {'num_stack' : 4}, do_pad=False):
+
+    xcorr_class = XCorrShift(reference_image, 1001, 101, filter_size=1)
+    
+    cmd = np.array([0,0])
+    current_positions = [client['{:s}.current'.format(indi_targets[i])] for i in [0, 1]]
+
+    if num_steps is not None:
+        for k in range(num_steps):      
+            im = camera.grab_stack(options['num_stack'])
+            shift = xcorr_class.measure(im) - shift_offset
+            print(shift)            
+            
+            err = reconstruction_matrix.dot(shift)
+            cmd = cmd - 0.25 * err
+            
+            client['{:s}.target'.format(indi_targets[0])] = current_positions[0] + cmd[0]
+            client['{:s}.target'.format(indi_targets[1])] = current_positions[1] + cmd[1]
+            time.sleep(2)
+    else:
+        not_aligned = True
+        while not_aligned:
+            im = camera.grab_stack(options['num_stack'])
+            if im.shape[0] != 1024 and do_pad:
+                roi_state = camera._get_roi_state
+                roi_h = roi_state['roi_region_h']
+                roi_w = roi_state['roi_region_w']
+
+                w_center = (1024 - roi_w // 2)
+                h_center = (1024 - roi_h // 2)
+                
+                im_padded = np.zeros(1024, 1024)
+                im_padded = im[h_center:h_center + roi_h//2, w_center:w_center + roi_w//2]
+                im = im_padded.copy()
+                
+            shift = xcorr_class.measure(im) - shift_offset
+            print(shift)
+            
+            err = reconstruction_matrix.dot(shift)
+            cmd = cmd - 0.25 * err
+    
+            client['{:s}.target'.format(indi_targets[0])] = current_positions[0] + cmd[0]
+            client['{:s}.target'.format(indi_targets[1])] = current_positions[1] + cmd[1]
+            time.sleep(2)
+
+            if abs(shift[0]) <= 0.11 and abs(shift[1]) <0.11:
+                not_aligned = False

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -81,7 +81,7 @@ int readoutParams( piint & adcQual,
    {
       return -1;
    }
-   
+
    return 0;
 }
 
@@ -109,7 +109,7 @@ int vshiftParams( piflt & vss,
    {
       return -1;
    }
-   
+
    return 0;
 }
 
@@ -149,37 +149,36 @@ public:
      *@{
      */
    static constexpr bool c_stdCamera_tempControl = true; ///< app::dev config to tell stdCamera to expose temperature controls
-   
+
    static constexpr bool c_stdCamera_temp = true; ///< app::dev config to tell stdCamera to expose temperature
-   
+
    static constexpr bool c_stdCamera_readoutSpeed = true; ///< app::dev config to tell stdCamera to expose readout speed controls
-   
+
    static constexpr bool c_stdCamera_vShiftSpeed = true; ///< app:dev config to tell stdCamera to expose vertical shift speed control
 
-   static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls 
+   static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls
 
    static constexpr bool c_stdCamera_exptimeCtrl = true; ///< app::dev config to tell stdCamera to expose exposure time controls
-   
+
    static constexpr bool c_stdCamera_fpsCtrl = false; ///< app::dev config to tell stdCamera not to expose FPS controls
 
    static constexpr bool c_stdCamera_fps = true; ///< app::dev config to tell stdCamera not to expose FPS status
-   
-   static constexpr bool c_stdCamera_synchro = false; ///< app::dev config to tell stdCamera to not expose synchro mode controls
-   
+
+   static constexpr bool c_stdCamera_synchro = true; ///< app::dev config to tell stdCamera to not expose synchro mode controls
+
    static constexpr bool c_stdCamera_usesModes = false; ///< app:dev config to tell stdCamera not to expose mode controls
-   
+
    static constexpr bool c_stdCamera_usesROI = true; ///< app:dev config to tell stdCamera to expose ROI controls
 
    static constexpr bool c_stdCamera_cropMode = false; ///< app:dev config to tell stdCamera to expose Crop Mode controls
-   
+
    static constexpr bool c_stdCamera_hasShutter = true; ///< app:dev config to tell stdCamera to expose shutter controls
-      
+
    static constexpr bool c_stdCamera_usesStateString = false; ///< app::dev confg to tell stdCamera to expose the state string property
-   
+
    static constexpr bool c_frameGrabber_flippable = true; ///< app:dev config to tell framegrabber this camera can be flipped
-   
    ///@}
-   
+
 protected:
 
    /** \name configurable parameters
@@ -191,19 +190,19 @@ protected:
    ///@}
 
    int m_depth {0};
-   
+
    piint m_timeStampMask {PicamTimeStampsMask_ExposureStarted}; // time stamp at end of exposure
    pi64s m_tsRes; // time stamp resolution
    piint m_frameSize;
    double m_camera_timestamp {0.0};
    piflt m_FrameRateCalculation;
    piflt m_ReadOutTimeCalculation;
-   
-   
-   
-   
 
-   
+
+
+
+
+
 
    PicamHandle m_cameraHandle {0};
    PicamHandle m_modelHandle {0};
@@ -300,7 +299,7 @@ protected:
    int setPicamParameterOnline( PicamParameter parameter,
                                 piint value
                               );
-   
+
    int connect();
 
    int getAcquisitionState();
@@ -308,13 +307,13 @@ protected:
    int getTemps();
 
    // stdCamera interface:
-   
+
    //This must set the power-on default values of
    /* -- m_ccdTempSetpt
-    * -- m_currentROI 
+    * -- m_currentROI
     */
    int powerOnDefaults();
-   
+
    int setTempControl();
    int setTempSetPt();
    int setReadoutSpeed();
@@ -323,6 +322,7 @@ protected:
    int setExpTime();
    int capExpTime(piflt& exptime);
    int setFPS();
+   int setSynchro();
 
    /// Check the next ROI
    /** Checks if the target values are valid and adjusts them to the closest valid values if needed.
@@ -339,7 +339,7 @@ protected:
      * \returns 0 always
      */
    int setShutter(int sh);
-   
+
    //Framegrabber interface:
    int configureAcquisition();
    float fps();
@@ -353,21 +353,37 @@ protected:
 protected:
 
    pcf::IndiProperty m_indiP_readouttime;
+   pcf::IndiProperty m_indiP_fxngensync;
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
 
    /** \name Telemeter Interface
-     * 
+     *
      * @{
-     */ 
+     */
    int checkRecordTimes();
-   
+
    int recordTelem( const telem_stdcam * );
-   
-   
+
+
    ///@}
 };
+
+// float picamCtrl::getTrigFreq()
+// {
+//    // trig width is exposure time
+//    // trig shift time is num_rows * vertical shift time
+//    float shift_time = m_vshiftSpeed * 1e-6 * (m_width + 2); // seconds
+//    return 1 / (m_expTime + shift_time);
+// }
+
+// void picamCtrl::setExtTrig()
+// {
+//    if (m_extTrig) return;
+//    m_extTrig = true;
+
+// }
 
 inline
 picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
@@ -380,18 +396,21 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
    m_defaultReadoutSpeed  = "emccd_05MHz";
    m_readoutSpeedNames = {"ccd_00_1MHz", "ccd_01MHz", "emccd_05MHz", "emccd_10MHz", "emccd_20MHz", "emccd_30MHz"};
    m_readoutSpeedNameLabels = {"CCD 0.1 MHz", "CCD 1 MHz", "EMCCD 5 MHz", "EMCCD 10 MHz", "EMCCD 20 MHz", "EMCCD 30 MHz"};
-   
+
    m_defaultVShiftSpeed = "1_2us";
    m_vShiftSpeedNames = {"0_7us", "1_2us", "2_0us", "5_0us"};
    m_vShiftSpeedNameLabels = {"0.7 us", "1.2 us", "2.0 us", "5.0 us"};
-      
-   m_full_x = 511.5; 
-   m_full_y = 511.5; 
-   m_full_w = 1024; 
-   m_full_h = 1024; 
-   
+
+   m_full_x = 511.5;
+   m_full_y = 511.5;
+   m_full_w = 1024;
+   m_full_h = 1024;
+
    m_maxEMGain = 1000;
-   
+
+   // pcf::IndiProperty m_indiP_fxngensync = ;
+
+
    return;
 }
 
@@ -404,6 +423,18 @@ picamCtrl::~picamCtrl() noexcept
    }
 
    return;
+}
+
+
+/// Interface to setSynchro when the derivedT has synchronization
+   /** Tag-dispatch resolution of c_stdCamera_synchro==true will call this function.
+   * Calls derivedT::setSynchro.
+   */
+int picamCtrl::setSynchro()
+{
+   m_reconfig = true;
+   recordCamera(true);
+   return 0;
 }
 
 inline
@@ -427,7 +458,7 @@ void picamCtrl::loadConfig()
    dev::frameGrabber<picamCtrl>::loadConfig(config);
    dev::dssShutter<picamCtrl>::loadConfig(config);
    dev::telemeter<picamCtrl>::loadConfig(config);
-   
+
 
 }
 
@@ -442,40 +473,40 @@ int picamCtrl::appStartup()
    indi::addNumberElement<float>( m_indiP_readouttime, "value", 0.0, std::numeric_limits<float>::max(), 0.0,  "%0.1f", "readout time");
    registerIndiPropertyReadOnly( m_indiP_readouttime );
 
-   
+
    m_minTemp = -55;
    m_maxTemp = 25;
    m_stepTemp = 0;
-   
+
    m_minROIx = 0;
    m_maxROIx = 1023;
    m_stepROIx = 0;
-   
+
    m_minROIy = 0;
    m_maxROIy = 1023;
    m_stepROIy = 0;
-   
+
    m_minROIWidth = 1;
    m_maxROIWidth = 1024;
    m_stepROIWidth = 4;
-   
+
    m_minROIHeight = 1;
    m_maxROIHeight = 1024;
    m_stepROIHeight = 1;
-   
+
    m_minROIBinning_x = 1;
    m_maxROIBinning_x = 32;
    m_stepROIBinning_x = 1;
-   
+
    m_minROIBinning_y = 1;
    m_maxROIBinning_y = 1024;
    m_stepROIBinning_y = 1;
-   
+
    if(dev::stdCamera<picamCtrl>::appStartup() < 0)
    {
       return log<software_critical,-1>({__FILE__,__LINE__});
    }
-   
+
    if(dev::frameGrabber<picamCtrl>::appStartup() < 0)
    {
       return log<software_critical,-1>({__FILE__,__LINE__});
@@ -490,7 +521,7 @@ int picamCtrl::appStartup()
    {
       return log<software_error,-1>({__FILE__,__LINE__});
    }
-   
+
    return 0;
 
 }
@@ -503,7 +534,7 @@ int picamCtrl::appLogic()
    {
       return log<software_error, -1>({__FILE__, __LINE__});
    }
-   
+
    //first run frameGrabber's appLogic to see if the f.g. thread has exited.
    if(dev::frameGrabber<picamCtrl>::appLogic() < 0)
    {
@@ -552,15 +583,15 @@ int picamCtrl::appLogic()
          return log<software_error,0>({__FILE__,__LINE__});
       }
 
-      
+
       if(frameGrabber<picamCtrl>::updateINDI() < 0)
       {
          return log<software_error,0>({__FILE__,__LINE__});
       }
-      
+
       setPicamParameter(m_modelHandle, PicamParameter_DisableCoolingFan, PicamCoolingFanStatus_On);
-      
-      
+
+
    }
 
    if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
@@ -579,7 +610,7 @@ int picamCtrl::appLogic()
          return 0;
       }
 
-      
+
 
       if(getTemps() < 0)
       {
@@ -593,7 +624,7 @@ int picamCtrl::appLogic()
       {
          return log<software_error,0>({__FILE__,__LINE__});
       }
-      
+
       if(frameGrabber<picamCtrl>::updateINDI() < 0)
       {
          return log<software_error,0>({__FILE__,__LINE__});
@@ -634,7 +665,7 @@ int picamCtrl::onPowerOff()
    {
       log<software_error>({__FILE__, __LINE__});
    }
-   
+
    return 0;
 }
 
@@ -650,7 +681,7 @@ int picamCtrl::whilePowerOff()
    {
       log<software_error>({__FILE__, __LINE__});
    }
-   
+
    return 0;
 }
 
@@ -727,7 +758,7 @@ int picamCtrl::setPicamParameter( PicamParameter parameter,
    }
 
    if(!commit) return 0;
-   
+
    const PicamParameter* failed_parameters;
    piint failed_parameters_count;
 
@@ -738,7 +769,7 @@ int picamCtrl::setPicamParameter( PicamParameter parameter,
       log<software_error>({__FILE__, __LINE__, 0, error, PicamEnum2String(PicamEnumeratedType_Error, error)});
       return -1;
    }
-   
+
    for( int i=0; i< failed_parameters_count; ++i)
    {
       if( failed_parameters[i] ==  parameter)
@@ -747,7 +778,7 @@ int picamCtrl::setPicamParameter( PicamParameter parameter,
          return log<text_log,-1>( "Parameter not committed");
       }
    }
-   
+
    Picam_DestroyParameters( failed_parameters );
 
    return 0;
@@ -769,7 +800,7 @@ int picamCtrl::setPicamParameter( PicamHandle handle,
    }
 
    if(!commit) return 0;
-   
+
    const PicamParameter* failed_parameters;
    piint failed_parameters_count;
 
@@ -811,7 +842,7 @@ int picamCtrl::setPicamParameter( PicamHandle handle,
    }
 
    if(!commit) return 0;
-   
+
    const PicamParameter* failed_parameters;
    piint failed_parameters_count;
 
@@ -946,7 +977,7 @@ int picamCtrl::connect()
    if(powerState() != 1 || powerStateTarget() != 1) return 0;
 
    std::cerr << __LINE__ << '\n';
-   
+
    if(id_count == 0)
    {
       Picam_DestroyCameraIDs(id_array);
@@ -960,7 +991,7 @@ int picamCtrl::connect()
       }
       return 0;
    }
-   else 
+   else
    {
       std::cerr << "found " << id_count << " PI cameras.\n";
    }
@@ -990,7 +1021,7 @@ int picamCtrl::connect()
 
             m_readoutSpeedNameSet = m_defaultReadoutSpeed;
             m_vShiftSpeedNameSet = m_defaultVShiftSpeed;
-            
+
             return 0;
          }
          else
@@ -1004,7 +1035,7 @@ int picamCtrl::connect()
             }
 
             Picam_DestroyCameraIDs(id_array);
-            
+
             Picam_UninitializeLibrary();
             return -1;
          }
@@ -1072,7 +1103,7 @@ int picamCtrl::getTemps()
    }
 
    m_ccdTemp = currTemperature;
-   
+
    //PicamSensorTemperatureStatus
    piint status;
 
@@ -1085,19 +1116,19 @@ int picamCtrl::getTemps()
       return -1;
    }
 
-   if(status == PicamSensorTemperatureStatus_Unlocked) 
+   if(status == PicamSensorTemperatureStatus_Unlocked)
    {
       m_tempControlStatus = true;
       m_tempControlOnTarget = false;
       m_tempControlStatusStr = "UNLOCKED";
    }
-   else if(status == PicamSensorTemperatureStatus_Locked) 
+   else if(status == PicamSensorTemperatureStatus_Locked)
    {
       m_tempControlStatus = true;
       m_tempControlOnTarget = true;
       m_tempControlStatusStr = "LOCKED";
    }
-   else if(status == PicamSensorTemperatureStatus_Faulted) 
+   else if(status == PicamSensorTemperatureStatus_Faulted)
    {
       m_tempControlStatus = false;
       m_tempControlOnTarget = false;
@@ -1109,7 +1140,7 @@ int picamCtrl::getTemps()
       m_tempControlStatus = false;
       m_tempControlOnTarget = false;
       m_tempControlStatusStr = "UNKNOWN";
-   }   
+   }
 
    recordCamera();
 
@@ -1123,7 +1154,7 @@ int picamCtrl::setFPS()
    return 0;
 }
 
-inline 
+inline
 int picamCtrl::powerOnDefaults()
 {
    m_ccdTempSetpt = -55; //This is the power on setpoint
@@ -1140,7 +1171,7 @@ int picamCtrl::powerOnDefaults()
    return 0;
 }
 
-inline 
+inline
 int picamCtrl::setTempControl()
 {
    //Always on
@@ -1151,7 +1182,7 @@ int picamCtrl::setTempControl()
    return 0;
 }
 
-inline 
+inline
 int picamCtrl::setTempSetPt()
 {
    ///\todo bounds check here.
@@ -1161,7 +1192,7 @@ int picamCtrl::setTempSetPt()
    return 0;
 }
 
-inline 
+inline
 int picamCtrl::setReadoutSpeed()
 {
    m_reconfig = true;
@@ -1169,7 +1200,7 @@ int picamCtrl::setReadoutSpeed()
    return 0;
 }
 
-inline 
+inline
 int picamCtrl::setVShiftSpeed()
 {
    m_reconfig = true;
@@ -1182,14 +1213,14 @@ int picamCtrl::setEMGain()
 {
    piint adcQual;
    piflt adcSpeed;
-   
+
    if(readoutParams(adcQual, adcSpeed, m_readoutSpeedName) < 0)
    {
       log<software_error>({__FILE__, __LINE__, "Invalid readout speed: " + m_readoutSpeedNameSet});
       state(stateCodes::ERROR);
       return -1;
    }
-   
+
    if(adcQual != PicamAdcQuality_ElectronMultiplied)
    {
       m_emGain = 1;
@@ -1198,20 +1229,20 @@ int picamCtrl::setEMGain()
       log<text_log>("Attempt to set EM gain while in conventional amplifier.", logPrio::LOG_NOTICE);
       return 0;
    }
-   
+
    piint emg = m_emGainSet;
    if(emg < 0)
    {
       emg = 0;
       log<text_log>("EM gain limited to 0", logPrio::LOG_WARNING);
    }
-   
+
    if(emg > m_maxEMGain)
    {
       emg = m_maxEMGain;
       log<text_log>("EM gain limited to maxEMGain = " + std::to_string(emg), logPrio::LOG_WARNING);
    }
-   
+
    recordCamera(true);
    if(setPicamParameterOnline(m_modelHandle, PicamParameter_AdcEMGain, emg) < 0)
    {
@@ -1219,7 +1250,7 @@ int picamCtrl::setEMGain()
       log<software_error>({__FILE__, __LINE__, "Error setting EM gain"});
       return -1;
    }
-   
+
    piint AdcEMGain;
    if(getPicamParameter(AdcEMGain, PicamParameter_AdcEMGain) < 0)
    {
@@ -1240,12 +1271,12 @@ int picamCtrl::setExpTime()
    capExpTime(exptime);
 
    int rv;
-   
+
    recordCamera(true);
 
    if(state() == stateCodes::OPERATING)
    {
-      rv = setPicamParameterOnline(m_modelHandle, PicamParameter_ExposureTime, exptime);      
+      rv = setPicamParameterOnline(m_modelHandle, PicamParameter_ExposureTime, exptime);
    }
    else
    {
@@ -1271,7 +1302,7 @@ int picamCtrl::setExpTime()
       log<software_error>({__FILE__, __LINE__, "could not get FrameRateCalculation"});
    }
    m_fps = m_FrameRateCalculation;
-   
+
    recordCamera(true);
 
    return 0;
@@ -1288,7 +1319,7 @@ int picamCtrl::capExpTime(piflt& exptime)
       long intexptime = m_ReadOutTimeCalculation * 10000 + 0.5;
       exptime = ((double)intexptime)/10000;
    }
-   
+
    return 0;
 }
 
@@ -1299,20 +1330,20 @@ int picamCtrl::checkNextROI()
 }
 
 //Set ROI property to busy if accepted, set toggle to Off and Idlw either way.
-//Set ROI actual 
+//Set ROI actual
 //Update current values (including struct and indiP) and set to OK when done
-inline 
+inline
 int picamCtrl::setNextROI()
-{   
+{
    m_reconfig = true;
 
    updateSwitchIfChanged(m_indiP_roi_set, "request", pcf::IndiElement::Off, INDI_IDLE);
-   
+
    return 0;
-   
+
 }
 
-inline 
+inline
 int picamCtrl::setShutter( int sh )
 {
    return dssShutter<picamCtrl>::setShutterState(sh);
@@ -1390,7 +1421,7 @@ int picamCtrl::configureAcquisition()
 
    piint adcQual;
    piflt adcSpeed;
-   
+
    if(readoutParams(adcQual, adcSpeed, m_readoutSpeedNameSet) < 0)
    {
       if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1398,7 +1429,7 @@ int picamCtrl::configureAcquisition()
       state(stateCodes::ERROR);
       return -1;
    }
-   
+
    if( setPicamParameter(m_modelHandle, PicamParameter_AdcSpeed, adcSpeed, false) < 0) //don't commit b/c it will error if quality mismatched
    {
       if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1406,7 +1437,7 @@ int picamCtrl::configureAcquisition()
       //state(stateCodes::ERROR);
       //return -1;
    }
-   
+
    if( setPicamParameter(m_modelHandle, PicamParameter_AdcQuality, adcQual) < 0)
    {
       if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1429,7 +1460,7 @@ int picamCtrl::configureAcquisition()
    // Vertical Shift Rate
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
-   
+
    piflt vss;
    if(vshiftParams(vss, m_vShiftSpeedNameSet) < 0)
    {
@@ -1438,7 +1469,7 @@ int picamCtrl::configureAcquisition()
       state(stateCodes::ERROR);
       return -1;
    }
-   
+
    if( setPicamParameter(m_modelHandle, PicamParameter_VerticalShiftRate, vss) < 0)
    {
       if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1456,13 +1487,13 @@ int picamCtrl::configureAcquisition()
    // Dimensions
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
-   
+
    PicamRois  nextrois;
    PicamRoi nextroi;
-   
+
    nextrois.roi_array = &nextroi;
    nextrois.roi_count = 1;
-   
+
    int roi_err = false;
    if(m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR)
    {
@@ -1472,19 +1503,19 @@ int picamCtrl::configureAcquisition()
    {
       nextroi.x = (m_nextROI.x - 0.5*( (float) m_nextROI.w - 1.0));
    }
-   
+
    if(nextroi.x < 0)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to x center < 0"});
       roi_err = true;
    }
 
-   if(nextroi.x > 1023) 
+   if(nextroi.x > 1023)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to x center > 1023"});
       roi_err = true;
    }
-   
+
 
    if(m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR)
    {
@@ -1494,14 +1525,14 @@ int picamCtrl::configureAcquisition()
    {
       nextroi.y = (m_nextROI.y - 0.5*( (float) m_nextROI.h - 1.0));
    }
-   
+
    if(nextroi.y < 0)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to y center < 0"});
       roi_err = true;
    }
 
-   if(nextroi.y > 1023) 
+   if(nextroi.y > 1023)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to y center > 1023"});
       roi_err = true;
@@ -1515,7 +1546,7 @@ int picamCtrl::configureAcquisition()
       roi_err = true;
    }
 
-   if(nextroi.x + nextroi.width  > 1024) 
+   if(nextroi.x + nextroi.width  > 1024)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to width such that edge is > 1023"});
       roi_err = true;
@@ -1523,7 +1554,7 @@ int picamCtrl::configureAcquisition()
 
    nextroi.height = m_nextROI.h;
 
-   if(nextroi.y + nextroi.height > 1024) 
+   if(nextroi.y + nextroi.height > 1024)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI to height such that edge is > 1023"});
       roi_err = true;
@@ -1536,7 +1567,7 @@ int picamCtrl::configureAcquisition()
    }
 
    nextroi.x_binning = m_nextROI.bin_x;
-   
+
    if(nextroi.x_binning < 0)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI x binning < 0"});
@@ -1544,7 +1575,7 @@ int picamCtrl::configureAcquisition()
    }
 
    nextroi.y_binning = m_nextROI.bin_y;
-   
+
    if(nextroi.y_binning < 0)
    {
       log<software_error>({__FILE__, __LINE__, "can't set ROI y binning < 0"});
@@ -1555,7 +1586,7 @@ int picamCtrl::configureAcquisition()
 
    if(!roi_err)
    {
-      error = Picam_SetParameterRoisValue( m_cameraHandle, PicamParameter_Rois, &nextrois);   
+      error = Picam_SetParameterRoisValue( m_cameraHandle, PicamParameter_Rois, &nextrois);
       if( error != PicamError_None )
       {
          if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1565,7 +1596,7 @@ int picamCtrl::configureAcquisition()
          return -1;
       }
    }
-   
+
    if(getPicamParameter(readoutStride, PicamParameter_ReadoutStride) < 0)
    {
       if(powerState() != 1 || powerStateTarget() != 1) return -1;
@@ -1621,12 +1652,12 @@ int picamCtrl::configureAcquisition()
    m_currentROI.bin_x = m_xbinning;
    m_ybinning = rois->roi_array[0].y_binning;
    m_currentROI.bin_y = m_ybinning;
-   
+
    std::cerr << rois->roi_array[0].x << "\n";
    std::cerr << (rois->roi_array[0].x-1) << "\n";
    std::cerr << rois->roi_array[0].width << "\n";
    std::cerr << 0.5*( (float) (rois->roi_array[0].width - 1.0)) << "\n";
-   
+
 
    if(m_defaultFlip == fgFlipLR || m_defaultFlip == fgFlipUDLR)
    {
@@ -1638,7 +1669,7 @@ int picamCtrl::configureAcquisition()
       m_currentROI.x = (rois->roi_array[0].x) + 0.5*( (float) (rois->roi_array[0].width - 1.0)) ;
    }
 
-   
+
    if(m_defaultFlip == fgFlipUD || m_defaultFlip == fgFlipUDLR)
    {
       m_currentROI.y = (1023.0-rois->roi_array[0].y) - 0.5*( (float) (rois->roi_array[0].height - 1.0)) ;
@@ -1651,11 +1682,11 @@ int picamCtrl::configureAcquisition()
 
 
 
-   
-   
+
+
    m_currentROI.w = rois->roi_array[0].width;
    m_currentROI.h = rois->roi_array[0].height;
-   
+
    m_width  = rois->roi_array[0].width  / rois->roi_array[0].x_binning;
    m_height = rois->roi_array[0].height / rois->roi_array[0].y_binning;
    Picam_DestroyRois( rois );
@@ -1683,8 +1714,8 @@ int picamCtrl::configureAcquisition()
    updateIfChanged( m_indiP_roi_h, "target", m_currentROI.h, INDI_OK);
    updateIfChanged( m_indiP_roi_bin_x, "target", m_currentROI.bin_x, INDI_OK);
    updateIfChanged( m_indiP_roi_bin_y, "target", m_currentROI.bin_y, INDI_OK);
-   
-   
+
+
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
    //=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
    // Exposure Time and Frame Rate
@@ -1693,7 +1724,7 @@ int picamCtrl::configureAcquisition()
 
    if(getPicamParameter(m_ReadOutTimeCalculation, PicamParameter_ReadoutTimeCalculation) < 0)
    {
-      if(powerState() != 1 || powerStateTarget() != 1) return -1; 
+      if(powerState() != 1 || powerStateTarget() != 1) return -1;
       return log<software_error, -1>({__FILE__, __LINE__, "could not get ReadOutTimeCalculation"});
    }
    std::cerr << "Readout time is: " <<  m_ReadOutTimeCalculation << "\n";
@@ -1705,7 +1736,7 @@ int picamCtrl::configureAcquisition()
 
    if(constraint_count != 1)
    {
-      if(powerState() != 1 || powerStateTarget() != 1) return -1; 
+      if(powerState() != 1 || powerStateTarget() != 1) return -1;
       log<text_log>("Constraint count is not 1: " + std::to_string(constraint_count) + " constraints",logPrio::LOG_ERROR);
    }
    else
@@ -1717,7 +1748,7 @@ int picamCtrl::configureAcquisition()
       m_indiP_exptime["current"].setMin(m_minExpTime);
       m_indiP_exptime["current"].setMax(m_maxExpTime);
       m_indiP_exptime["current"].setStep(m_stepExpTime);
-   
+
       m_indiP_exptime["target"].setMin(m_minExpTime);
       m_indiP_exptime["target"].setMax(m_maxExpTime);
       m_indiP_exptime["target"].setStep(m_stepExpTime);
@@ -1733,15 +1764,15 @@ int picamCtrl::configureAcquisition()
 
       if(rv < 0)
       {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1; 
+         if(powerState() != 1 || powerStateTarget() != 1) return -1;
          return log<software_error, -1>({__FILE__, __LINE__, "Error setting exposure time"});
       }
    }
-   
+
    piflt exptime;
    if(getPicamParameter(exptime, PicamParameter_ExposureTime) < 0)
    {
-      if(powerState() != 1 || powerStateTarget() != 1) return -1; 
+      if(powerState() != 1 || powerStateTarget() != 1) return -1;
       return log<software_error,-1>({__FILE__, __LINE__, "Error getting exposure time"});
    }
    else
@@ -1755,7 +1786,7 @@ int picamCtrl::configureAcquisition()
 
    if(getPicamParameter(m_FrameRateCalculation, PicamParameter_FrameRateCalculation) < 0)
    {
-      if(powerState() != 1 || powerStateTarget() != 1) return -1; 
+      if(powerState() != 1 || powerStateTarget() != 1) return -1;
       return log<software_error,-1>({__FILE__, __LINE__, "Error getting frame rate"});
    }
    else
@@ -1764,7 +1795,7 @@ int picamCtrl::configureAcquisition()
       updateIfChanged(m_indiP_fps, "current", m_fps, INDI_IDLE);
    }
    std::cerr << "FrameRate is: " <<  m_FrameRateCalculation << "\n";
-   
+
    piint AdcQuality;
    if(getPicamParameter(AdcQuality, PicamParameter_AdcQuality) < 0)
    {
@@ -1789,8 +1820,8 @@ int picamCtrl::configureAcquisition()
 
 
    std::cerr << "************************************************************\n";
-   
-   
+
+
    piint AdcAnalogGain;
    if(getPicamParameter(AdcAnalogGain, PicamParameter_AdcAnalogGain) < 0)
    {
@@ -1812,7 +1843,7 @@ int picamCtrl::configureAcquisition()
       }
       m_emGain = AdcEMGain;
    }
-   
+
 /*
    std::cerr << "Onlineable:\n";
    pibln onlineable;
@@ -1866,6 +1897,26 @@ int picamCtrl::configureAcquisition()
       }
    }
 
+   // Hardware trigger
+   if (m_synchroSet)
+   {
+      
+
+
+      std::cerr << "Turning synchro on" << std::endl;
+      setPicamParameter(m_cameraHandle, PicamParameter_TriggerDetermination, PicamTriggerDetermination_RisingEdge);
+      setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_ExposeDuringTriggerPulse);
+      m_synchro = true;
+      updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_IDLE);
+   } 
+   else
+   {
+      std::cerr << "Turning synchro off" << std::endl;
+      setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_NoResponse);
+      m_synchro = false;
+      updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE);
+   }
+
    //Start continuous acquisition
    if(setPicamParameter(PicamParameter_ReadoutCount,(pi64s) 0) < 0)
    {
@@ -1875,7 +1926,7 @@ int picamCtrl::configureAcquisition()
    }
 
    recordCamera();
-   
+
    error = Picam_StartAcquisition(m_cameraHandle);
    if(error != PicamError_None)
    {
@@ -1886,7 +1937,7 @@ int picamCtrl::configureAcquisition()
    }
 
    m_dataType = _DATATYPE_UINT16; //Where does this go?
-    
+
    return 0;
 
 }
@@ -1915,7 +1966,7 @@ int picamCtrl::acquireAndCheckValid()
    PicamError error;
    error = Picam_WaitForAcquisitionUpdate(m_cameraHandle, camTimeOut, &available, &status);
 
-   if(error == PicamError_TimeOutOccurred) 
+   if(error == PicamError_TimeOutOccurred)
    {
       return 1; //This sends it back to framegrabber to check for reconfig, etc.
    }
@@ -1929,7 +1980,7 @@ int picamCtrl::acquireAndCheckValid()
 
       return -1;
    }
-      
+
    m_available.initial_readout = available.initial_readout;
    m_available.readout_count = available.readout_count;
 
@@ -1978,7 +2029,7 @@ inline
 int picamCtrl::reconfig()
 {
    ///\todo clean this up.  Just need to wait on acquisition update the first time probably.
-   
+
    PicamError error = Picam_StopAcquisition(m_cameraHandle);
    if(error != PicamError_None)
    {
@@ -2023,7 +2074,7 @@ int picamCtrl::reconfig()
 //       if(! status.running )
 //       {
 //          std::cerr << "Not running \n";
-// 
+//
 //          std::cerr << "status.running: " << status.running << "\n";
 //          std::cerr << "status.errors: " << status.errors << "\n";
 //          std::cerr << "CameraFaulted: " << (int)(status.errors & PicamAcquisitionErrorsMask_CameraFaulted) << "\n";
@@ -2053,7 +2104,7 @@ int picamCtrl::checkRecordTimes()
 {
    return telemeter<picamCtrl>::checkRecordTimes(telem_stdcam());
 }
-   
+
 int picamCtrl::recordTelem(const telem_stdcam *)
 {
    return recordCamera(true);

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -1262,7 +1262,7 @@ void picamCtrl::updateFxnGenSync()
 {
 
    std::cerr << "Setting fxngen frequency to " << std::to_string(m_fps) << " Hz" << std::endl;
-   m_indiP_fxngensync["target"] = freq;
+   m_indiP_fxngensync["target"] = m_fps;
    sendNewProperty(m_indiP_fxngensync);
 }
 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -355,13 +355,21 @@ protected:
 protected:
 
    pcf::IndiProperty m_indiP_readouttime;
-   pcf::IndiProperty m_indiP_fxngensync_freq;
-   pcf::IndiProperty m_indiP_fxngensync_output;
-   pcf::IndiProperty m_indiP_otherCamExptime;
-   pcf::IndiProperty m_indiP_otherCamSynchro;
+   pcf::IndiProperty m_indiP_fxngensync_freq; ///< Property for setting fxngensync frequency
+   pcf::IndiProperty m_indiP_fxngensync_output; ///< Proprety for turning on fxngensync
+
+   pcf::IndiProperty m_indiP_receiveSynchro; ///< Synchro that can only be triggered from the otherCam
+   pcf::IndiProperty m_indiP_receiveExptime; ///< Exptime that can only be triggered from the otherCam
+
+   pcf::IndiProperty m_indiP_otherCamExptime; ///< Property for setting otherCam exptime
+   pcf::IndiProperty m_indiP_otherCamSynchro; ///< Property for setting otherCam synchro
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
+
+   INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_receiveSynchro);
+
+   INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_receiveExptime);
 
    /** \name Telemeter Interface
      *
@@ -420,7 +428,25 @@ picamCtrl::~picamCtrl() noexcept
 int picamCtrl::setSynchro()
 {
    m_reconfig = true;
+
+   if (!m_otherCamName.empty())
+   {
+      if (m_synchroSet)
+      {
+         std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
+         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
+         sendNewProperty(m_indiP_otherCamSynchro);
+      }
+      else
+      {
+         std::cerr << "Turning synchro off for " << m_otherCamName << std::endl;
+         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::Off;
+         sendNewProperty(m_indiP_otherCamSynchro);
+      }
+   }
+
    recordCamera(true);
+
    return 0;
 }
 
@@ -526,15 +552,20 @@ int picamCtrl::appStartup()
    m_indiP_fxngensync_output.setDevice( m_fxngenName );
    m_indiP_fxngensync_output.setName( m_fxngenCh + "outp" );
    m_indiP_fxngensync_output.add( pcf::IndiElement( "value" ) );
-   
+
+
+   CREATE_REG_INDI_NEW_NUMBERD(m_indiP_receiveExptime, "receiveExptime", m_minExpTime, m_maxExpTime, m_stepExpTime, "%0.3f", "Exptime", "Other cam");
+   CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_receiveSynchro, "receiveSynchro");
+
+
    m_indiP_otherCamExptime = pcf::IndiProperty( pcf::IndiProperty::Number );
    m_indiP_otherCamExptime.setDevice( m_otherCamName );
-   m_indiP_otherCamExptime.setName( "exptime" );
+   m_indiP_otherCamExptime.setName( "receiveExptime" );
    m_indiP_otherCamExptime.add( pcf::IndiElement( "target" ) );
 
    m_indiP_otherCamSynchro = pcf::IndiProperty( pcf::IndiProperty::Switch );
    m_indiP_otherCamSynchro.setDevice( m_otherCamName );
-   m_indiP_otherCamSynchro.setName( "synchro" );
+   m_indiP_otherCamSynchro.setName( "receiveSynchro" );
    m_indiP_otherCamSynchro.add( pcf::IndiElement( "toggle" ) );
 
    return 0;
@@ -1281,7 +1312,7 @@ int picamCtrl::setEMGain()
 
 void picamCtrl::updateFxnGenSync()
 {
-   
+
    std::cerr << "Setting fxngen frequency to " << std::to_string(m_fps) << " Hz" << std::endl;
    m_indiP_fxngensync_freq["target"] = m_fps;
    sendNewProperty(m_indiP_fxngensync_freq);
@@ -1331,6 +1362,7 @@ int picamCtrl::setExpTime()
    }
    m_fps = m_FrameRateCalculation;
 
+
    if (m_synchro && !m_otherCamName.empty())
    {
       std::cerr << "Setting " << m_otherCamName << " exptime to " << std::to_string(m_expTime) << std::endl;
@@ -1341,7 +1373,6 @@ int picamCtrl::setExpTime()
    }
 
    recordCamera(true);
-
 
    return 0;
 }
@@ -1945,27 +1976,13 @@ int picamCtrl::configureAcquisition()
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_ReadoutPerTrigger);
       m_synchro = true;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_IDLE);
-
-      if (!m_otherCamName.empty())
-      {
-         std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
-         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
-         sendNewProperty(m_indiP_otherCamSynchro);
-      }
-   } 
+   }
    else
    {
       std::cerr << "Turning synchro off" << std::endl;
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_NoResponse);
       m_synchro = false;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE);
-
-      if (!m_otherCamName.empty())
-      {
-         std::cerr << "Turning synchro off for " << m_otherCamName << std::endl;
-         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::Off;
-         sendNewProperty(m_indiP_otherCamSynchro);
-      }
    }
 
    //Start continuous acquisition
@@ -2159,6 +2176,68 @@ int picamCtrl::checkRecordTimes()
 int picamCtrl::recordTelem(const telem_stdcam *)
 {
    return recordCamera(true);
+}
+
+
+INDI_NEWCALLBACK_DEFN( picamCtrl, m_indiP_receiveSynchro )( const pcf::IndiProperty &ipRecv )
+{
+
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_receiveSynchro, ipRecv );
+
+    if( ipRecv.getName() != m_indiP_receiveSynchro.getName() )
+    {
+        log<software_error>( { __FILE__, __LINE__, "wrong INDI property received" } );
+
+        return -1;
+    }
+
+    if( !ipRecv.find( "toggle" ) )
+    {
+        return 0;
+    }
+
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
+    {
+        updateSwitchIfChanged( m_indiP_receiveSynchro, "toggle", pcf::IndiElement::On, INDI_IDLE );
+
+        m_synchroSet = true;
+
+    }
+    else
+    {
+        updateSwitchIfChanged( m_indiP_receiveSynchro, "toggle", pcf::IndiElement::Off, INDI_IDLE );
+
+        m_synchroSet = false;
+    }
+
+    m_reconfig = true;
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( picamCtrl, m_indiP_receiveExptime )( const pcf::IndiProperty &ipRecv )
+{
+
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_receiveExptime, ipRecv );
+
+    if( ipRecv.getName() != m_indiP_receiveExptime.getName() )
+    {
+        log<software_error>( { __FILE__, __LINE__, "wrong INDI property received" } );
+
+        return -1;
+    }
+
+    if( !ipRecv.find( "target" ) )
+    {
+        return 0;
+    }
+
+    double val = ipRecv["target"].get<double>();
+    std::cerr << "Received exptime from otherCam: " << std::to_string(val) << std::endl;
+    std::cerr << "Doing nothing for now in " << __FILE__ << " " << __LINE__ << std::endl;
+   //  updatesIfChanged<double>(m_indiP_receiveExptime, { "current" }, { m_setExpTime });
+
+    return 0;
 }
 
 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -201,7 +201,7 @@ protected:
    std::string m_fxngenName { "fxngensync" }; ///< Default fxngen device name
    std::string m_fxngenCh { "C2" }; ///< Default fxngen channel
 
-
+   std::string m_otherCamName;
 
 
 
@@ -356,6 +356,7 @@ protected:
 
    pcf::IndiProperty m_indiP_readouttime;
    pcf::IndiProperty m_indiP_fxngensync;
+   pcf::IndiProperty m_indiP_otherCamExptime;
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
@@ -399,6 +400,11 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
    m_indiP_fxngensync.setDevice( m_fxngenName );
    m_indiP_fxngensync.setName( m_fxngenCh + "freq" );
    m_indiP_fxngensync.add( pcf::IndiElement( "target" ) );
+   
+   m_indiP_otherCamExptime = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_otherCamExptime.setDevice( m_otherCamName );
+   m_indiP_otherCamExptime.setName( "exptime" );
+   m_indiP_otherCamExptime.add( pcf::IndiElement( "target" ) );
 
    return;
 }
@@ -431,8 +437,9 @@ void picamCtrl::setupConfig()
 {
    config.add("camera.serialNumber", "", "camera.serialNumber", argType::Required, "camera", "serialNumber", false, "int", "The identifying serial number of the camera.");
 
-   config.add("syncro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen device name used for synchronizing the camera.");
-   config.add("syncro.channel", "", "synchro.channel", argType::Required, "synchro", "channel", false, "string", "The fxngen channel used for synchronizing the camera.");
+   config.add("synchro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen device name used for synchronizing the camera.");
+   config.add("synchro.channel", "", "synchro.channel", argType::Required, "synchro", "channel", false, "string", "The fxngen channel used for synchronizing the camera.");
+   config.add("synchro.otherCamName", "", "synchro.otherCamName", argType::Required, "synchro", "otherCamName", false, "string", "The other camera (used for synchronizing exposure time while synchro'd)");
 
    dev::stdCamera<picamCtrl>::setupConfig(config);
    dev::frameGrabber<picamCtrl>::setupConfig(config);
@@ -447,6 +454,7 @@ void picamCtrl::loadConfig()
    config(m_serialNumber, "camera.serialNumber");
    config(m_fxngenName, "synchro.deviceName");
    config(m_fxngenCh, "synchro.channel");
+   config(m_otherCamName, "synchro.otherCamName");
 
    dev::stdCamera<picamCtrl>::loadConfig(config);
    dev::frameGrabber<picamCtrl>::loadConfig(config);
@@ -1306,7 +1314,13 @@ int picamCtrl::setExpTime()
    }
    m_fps = m_FrameRateCalculation;
 
-   if (m_synchro) updateFxnGenSync();
+   if (m_synchro)
+   {
+      m_indiP_otherCamExptime["target"] = m_expTime;
+      sendNewProperty(m_indiP_otherCamExptime);
+
+      updateFxnGenSync();
+   }
 
    recordCamera(true);
 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -639,7 +639,7 @@ int picamCtrl::appLogic()
          return log<software_error,0>({__FILE__,__LINE__});
       }
 
-      setPicamParameter(m_modelHandle, PicamParameter_DisableCoolingFan, PicamCoolingFanStatus_On);
+      setPicamParameter(m_modelHandle, PicamParameter_DisableCoolingFan, PicamCoolingFanStatus_Off);
 
 
    }

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -396,16 +396,6 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
 
    m_maxEMGain = 1000;
 
-   m_indiP_fxngensync = pcf::IndiProperty( pcf::IndiProperty::Number );
-   m_indiP_fxngensync.setDevice( m_fxngenName );
-   m_indiP_fxngensync.setName( m_fxngenCh + "freq" );
-   m_indiP_fxngensync.add( pcf::IndiElement( "target" ) );
-   
-   m_indiP_otherCamExptime = pcf::IndiProperty( pcf::IndiProperty::Number );
-   m_indiP_otherCamExptime.setDevice( m_otherCamName );
-   m_indiP_otherCamExptime.setName( "exptime" );
-   m_indiP_otherCamExptime.add( pcf::IndiElement( "target" ) );
-
    return;
 }
 
@@ -439,7 +429,7 @@ void picamCtrl::setupConfig()
 
    config.add("synchro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen device name used for synchronizing the camera.");
    config.add("synchro.channel", "", "synchro.channel", argType::Required, "synchro", "channel", false, "string", "The fxngen channel used for synchronizing the camera.");
-   config.add("synchro.otherCamName", "", "synchro.otherCamName", argType::Required, "synchro", "otherCamName", false, "string", "The other camera (used for synchronizing exposure time while synchro'd)");
+   config.add("synchro.otherCamName", "", "synchro.otherCamName", argType::Required, "synchro", "otherCamName", false, "string", "The other camera (used for coupling exposure time while synchro'd)");
 
    dev::stdCamera<picamCtrl>::setupConfig(config);
    dev::frameGrabber<picamCtrl>::setupConfig(config);
@@ -523,6 +513,17 @@ int picamCtrl::appStartup()
    {
       return log<software_error,-1>({__FILE__,__LINE__});
    }
+
+
+   m_indiP_fxngensync = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_fxngensync.setDevice( m_fxngenName );
+   m_indiP_fxngensync.setName( m_fxngenCh + "freq" );
+   m_indiP_fxngensync.add( pcf::IndiElement( "target" ) );
+   
+   m_indiP_otherCamExptime = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_otherCamExptime.setDevice( m_otherCamName );
+   m_indiP_otherCamExptime.setName( "exptime" );
+   m_indiP_otherCamExptime.add( pcf::IndiElement( "target" ) );
 
    return 0;
 
@@ -1316,6 +1317,7 @@ int picamCtrl::setExpTime()
 
    if (m_synchro)
    {
+      std::cerr << "Setting " << m_otherCamName << " exptime to " << std::to_string(m_expTime) << std::endl;
       m_indiP_otherCamExptime["target"] = m_expTime;
       sendNewProperty(m_indiP_otherCamExptime);
 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -198,7 +198,7 @@ protected:
    piflt m_FrameRateCalculation;
    piflt m_ReadOutTimeCalculation;
 
-
+   std::string m_fxngenName { "fxngensync" };
 
 
 
@@ -323,6 +323,7 @@ protected:
    int capExpTime(piflt& exptime);
    int setFPS();
    int setSynchro();
+   void updateFxnGenSync();
 
    /// Check the next ROI
    /** Checks if the target values are valid and adjusts them to the closest valid values if needed.
@@ -353,7 +354,8 @@ protected:
 protected:
 
    pcf::IndiProperty m_indiP_readouttime;
-   pcf::IndiProperty m_indiP_fxngensync;
+   pcf::IndiProperty m_indiP_fxngensync_freq;
+   pcf::IndiProperty m_indiP_fxngensync_width;
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
@@ -369,21 +371,6 @@ public:
 
    ///@}
 };
-
-// float picamCtrl::getTrigFreq()
-// {
-//    // trig width is exposure time
-//    // trig shift time is num_rows * vertical shift time
-//    float shift_time = m_vshiftSpeed * 1e-6 * (m_width + 2); // seconds
-//    return 1 / (m_expTime + shift_time);
-// }
-
-// void picamCtrl::setExtTrig()
-// {
-//    if (m_extTrig) return;
-//    m_extTrig = true;
-
-// }
 
 inline
 picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
@@ -408,8 +395,15 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
 
    m_maxEMGain = 1000;
 
-   // pcf::IndiProperty m_indiP_fxngensync = ;
-
+   m_indiP_fxngensync_freq = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_fxngensync_freq.setDevice( m_fxngenName );
+   m_indiP_fxngensync_freq.setName( "C2freq" );
+   m_indiP_fxngensync_freq.add( pcf::IndiElement( "target" ) );
+   
+   m_indiP_fxngensync_width = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_fxngensync_width.setDevice( m_fxngenName );
+   m_indiP_fxngensync_width.setName( "C2wdth" );
+   m_indiP_fxngensync_width.add( pcf::IndiElement( "value" ) );
 
    return;
 }
@@ -442,6 +436,8 @@ void picamCtrl::setupConfig()
 {
    config.add("camera.serialNumber", "", "camera.serialNumber", argType::Required, "camera", "serialNumber", false, "int", "The identifying serial number of the camera.");
 
+   config.add("syncro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen used for synchronizing the camera.");
+
    dev::stdCamera<picamCtrl>::setupConfig(config);
    dev::frameGrabber<picamCtrl>::setupConfig(config);
    dev::dssShutter<picamCtrl>::setupConfig(config);
@@ -453,6 +449,7 @@ void picamCtrl::loadConfig()
 {
 
    config(m_serialNumber, "camera.serialNumber");
+   config(m_fxngenName, "synchro.deviceName");
 
    dev::stdCamera<picamCtrl>::loadConfig(config);
    dev::frameGrabber<picamCtrl>::loadConfig(config);
@@ -1263,6 +1260,21 @@ int picamCtrl::setEMGain()
    return 0;
 }
 
+
+void picamCtrl::updateFxnGenSync()
+{
+   double shift_time = m_vshiftSpeed * 1e-6 * (m_width + 2); // seconds
+   double freq = 1 / (m_expTime + shift_time);
+   std::cerr << "Synchro shift time " << std::to_string(shift_time) << " s" << std::endl;
+   std::cerr << "Synchro frequency " << std::to_string(freq) << " Hz" << std::endl;
+   // note: must set frequency FIRST then width due to automatically 
+   // determined pulse width in siglentSDG app
+   m_indiP_fxngensync_freq["target"] = freq;
+   sendNewProperty(m_indiP_fxngensync_freq);
+   m_indiP_fxngensync_width["value"] = m_expTime;
+   sendNewProperty(m_indiP_fxngensync_width);
+}
+
 inline
 int picamCtrl::setExpTime()
 {
@@ -1304,6 +1316,8 @@ int picamCtrl::setExpTime()
    m_fps = m_FrameRateCalculation;
 
    recordCamera(true);
+
+   if (m_synchro) updateFxnGenSync();
 
    return 0;
 }
@@ -1900,8 +1914,7 @@ int picamCtrl::configureAcquisition()
    // Hardware trigger
    if (m_synchroSet)
    {
-      
-
+      updateFxnGenSync();
 
       std::cerr << "Turning synchro on" << std::endl;
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerDetermination, PicamTriggerDetermination_RisingEdge);

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -198,7 +198,8 @@ protected:
    piflt m_FrameRateCalculation;
    piflt m_ReadOutTimeCalculation;
 
-   std::string m_fxngenName { "fxngensync" };
+   std::string m_fxngenName { "fxngensync" }; ///< Default fxngen device name
+   std::string m_fxngenCh { "C2" }; ///< Default fxngen channel
 
 
 
@@ -354,8 +355,7 @@ protected:
 protected:
 
    pcf::IndiProperty m_indiP_readouttime;
-   pcf::IndiProperty m_indiP_fxngensync_freq;
-   pcf::IndiProperty m_indiP_fxngensync_width;
+   pcf::IndiProperty m_indiP_fxngensync;
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
@@ -395,15 +395,10 @@ picamCtrl::picamCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
 
    m_maxEMGain = 1000;
 
-   m_indiP_fxngensync_freq = pcf::IndiProperty( pcf::IndiProperty::Number );
-   m_indiP_fxngensync_freq.setDevice( m_fxngenName );
-   m_indiP_fxngensync_freq.setName( "C2freq" );
-   m_indiP_fxngensync_freq.add( pcf::IndiElement( "target" ) );
-   
-   m_indiP_fxngensync_width = pcf::IndiProperty( pcf::IndiProperty::Number );
-   m_indiP_fxngensync_width.setDevice( m_fxngenName );
-   m_indiP_fxngensync_width.setName( "C2wdth" );
-   m_indiP_fxngensync_width.add( pcf::IndiElement( "value" ) );
+   m_indiP_fxngensync = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_fxngensync.setDevice( m_fxngenName );
+   m_indiP_fxngensync.setName( m_fxngenCh + "freq" );
+   m_indiP_fxngensync.add( pcf::IndiElement( "target" ) );
 
    return;
 }
@@ -436,7 +431,8 @@ void picamCtrl::setupConfig()
 {
    config.add("camera.serialNumber", "", "camera.serialNumber", argType::Required, "camera", "serialNumber", false, "int", "The identifying serial number of the camera.");
 
-   config.add("syncro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen used for synchronizing the camera.");
+   config.add("syncro.deviceName", "", "synchro.deviceName", argType::Required, "synchro", "deviceName", false, "string", "The fxngen device name used for synchronizing the camera.");
+   config.add("syncro.channel", "", "synchro.channel", argType::Required, "synchro", "channel", false, "string", "The fxngen channel used for synchronizing the camera.");
 
    dev::stdCamera<picamCtrl>::setupConfig(config);
    dev::frameGrabber<picamCtrl>::setupConfig(config);
@@ -450,6 +446,7 @@ void picamCtrl::loadConfig()
 
    config(m_serialNumber, "camera.serialNumber");
    config(m_fxngenName, "synchro.deviceName");
+   config(m_fxngenCh, "synchro.channel");
 
    dev::stdCamera<picamCtrl>::loadConfig(config);
    dev::frameGrabber<picamCtrl>::loadConfig(config);
@@ -1263,16 +1260,10 @@ int picamCtrl::setEMGain()
 
 void picamCtrl::updateFxnGenSync()
 {
-   double shift_time = m_vshiftSpeed * 1e-6 * (m_width + 2); // seconds
-   double freq = 1 / (m_expTime + shift_time);
-   std::cerr << "Synchro shift time " << std::to_string(shift_time) << " s" << std::endl;
-   std::cerr << "Synchro frequency " << std::to_string(freq) << " Hz" << std::endl;
-   // note: must set frequency FIRST then width due to automatically 
-   // determined pulse width in siglentSDG app
-   m_indiP_fxngensync_freq["target"] = freq;
-   sendNewProperty(m_indiP_fxngensync_freq);
-   m_indiP_fxngensync_width["value"] = m_expTime;
-   sendNewProperty(m_indiP_fxngensync_width);
+
+   std::cerr << "Setting fxngen frequency to " << std::to_string(m_fps) << " Hz" << std::endl;
+   m_indiP_fxngensync["target"] = freq;
+   sendNewProperty(m_indiP_fxngensync);
 }
 
 inline
@@ -1315,9 +1306,10 @@ int picamCtrl::setExpTime()
    }
    m_fps = m_FrameRateCalculation;
 
+   if (m_synchro) updateFxnGenSync();
+
    recordCamera(true);
 
-   if (m_synchro) updateFxnGenSync();
 
    return 0;
 }
@@ -1918,7 +1910,7 @@ int picamCtrl::configureAcquisition()
 
       std::cerr << "Turning synchro on" << std::endl;
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerDetermination, PicamTriggerDetermination_RisingEdge);
-      setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_ExposeDuringTriggerPulse);
+      setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_ReadoutPerTrigger);
       m_synchro = true;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_IDLE);
    } 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -1331,7 +1331,7 @@ int picamCtrl::setExpTime()
    }
    m_fps = m_FrameRateCalculation;
 
-   if (m_synchro)
+   if (m_synchro && !m_otherCamName.empty())
    {
       std::cerr << "Setting " << m_otherCamName << " exptime to " << std::to_string(m_expTime) << std::endl;
       m_indiP_otherCamExptime["target"] = m_expTime;
@@ -1946,9 +1946,12 @@ int picamCtrl::configureAcquisition()
       m_synchro = true;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_IDLE);
 
-      std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
-      m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
-      sendNewProperty(m_indiP_otherCamSynchro);
+      if (!m_otherCamName.empty())
+      {
+         std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
+         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
+         sendNewProperty(m_indiP_otherCamSynchro);
+      }
    } 
    else
    {
@@ -1957,9 +1960,12 @@ int picamCtrl::configureAcquisition()
       m_synchro = false;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE);
 
-      std::cerr << "Turning synchro off for " << m_otherCamName << std::endl;
-      m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::Off;
-      sendNewProperty(m_indiP_otherCamSynchro);
+      if (!m_otherCamName.empty())
+      {
+         std::cerr << "Turning synchro off for " << m_otherCamName << std::endl;
+         m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::Off;
+         sendNewProperty(m_indiP_otherCamSynchro);
+      }
    }
 
    //Start continuous acquisition

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -436,6 +436,10 @@ int picamCtrl::setSynchro()
          std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
          m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
          sendNewProperty(m_indiP_otherCamSynchro);
+
+         std::cerr << "Setting " << m_otherCamName << "'s exposure time" << std::endl;
+         m_indiP_otherCamExptime["target"] = m_expTime;
+         sendNewProperty(m_indiP_otherCamExptime);
       }
       else
       {
@@ -2232,10 +2236,13 @@ INDI_NEWCALLBACK_DEFN( picamCtrl, m_indiP_receiveExptime )( const pcf::IndiPrope
         return 0;
     }
 
-    double val = ipRecv["target"].get<double>();
-    std::cerr << "Received exptime from otherCam: " << std::to_string(val) << std::endl;
-    std::cerr << "Doing nothing for now in " << __FILE__ << " " << __LINE__ << std::endl;
-   //  updatesIfChanged<double>(m_indiP_receiveExptime, { "current" }, { m_setExpTime });
+    m_expTimeSet = ipRecv["target"].get<double>();
+
+    updatesIfChanged<double>(m_indiP_receiveExptime, { "current" }, { m_expTimeSet });
+    
+    // we don't need to strictly reconfig because setExpTime works online, but this
+    // eludes an infinite loop of triggering the 'otherCam' in setExptime 
+    m_reconfig = 1;
 
     return 0;
 }

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -355,8 +355,10 @@ protected:
 protected:
 
    pcf::IndiProperty m_indiP_readouttime;
-   pcf::IndiProperty m_indiP_fxngensync;
+   pcf::IndiProperty m_indiP_fxngensync_freq;
+   pcf::IndiProperty m_indiP_fxngensync_output;
    pcf::IndiProperty m_indiP_otherCamExptime;
+   pcf::IndiProperty m_indiP_otherCamSynchro;
 
 public:
    INDI_NEWCALLBACK_DECL(picamCtrl, m_indiP_adcquality);
@@ -515,15 +517,25 @@ int picamCtrl::appStartup()
    }
 
 
-   m_indiP_fxngensync = pcf::IndiProperty( pcf::IndiProperty::Number );
-   m_indiP_fxngensync.setDevice( m_fxngenName );
-   m_indiP_fxngensync.setName( m_fxngenCh + "freq" );
-   m_indiP_fxngensync.add( pcf::IndiElement( "target" ) );
+   m_indiP_fxngensync_freq = pcf::IndiProperty( pcf::IndiProperty::Number );
+   m_indiP_fxngensync_freq.setDevice( m_fxngenName );
+   m_indiP_fxngensync_freq.setName( m_fxngenCh + "freq" );
+   m_indiP_fxngensync_freq.add( pcf::IndiElement( "target" ) );
+
+   m_indiP_fxngensync_output = pcf::IndiProperty( pcf::IndiProperty::Text );
+   m_indiP_fxngensync_output.setDevice( m_fxngenName );
+   m_indiP_fxngensync_output.setName( m_fxngenCh + "outp" );
+   m_indiP_fxngensync_output.add( pcf::IndiElement( "value" ) );
    
    m_indiP_otherCamExptime = pcf::IndiProperty( pcf::IndiProperty::Number );
    m_indiP_otherCamExptime.setDevice( m_otherCamName );
    m_indiP_otherCamExptime.setName( "exptime" );
    m_indiP_otherCamExptime.add( pcf::IndiElement( "target" ) );
+
+   m_indiP_otherCamSynchro = pcf::IndiProperty( pcf::IndiProperty::Switch );
+   m_indiP_otherCamSynchro.setDevice( m_otherCamName );
+   m_indiP_otherCamSynchro.setName( "synchro" );
+   m_indiP_otherCamSynchro.add( pcf::IndiElement( "toggle" ) );
 
    return 0;
 
@@ -1269,10 +1281,14 @@ int picamCtrl::setEMGain()
 
 void picamCtrl::updateFxnGenSync()
 {
-
+   
    std::cerr << "Setting fxngen frequency to " << std::to_string(m_fps) << " Hz" << std::endl;
-   m_indiP_fxngensync["target"] = m_fps;
-   sendNewProperty(m_indiP_fxngensync);
+   m_indiP_fxngensync_freq["target"] = m_fps;
+   sendNewProperty(m_indiP_fxngensync_freq);
+
+   // make sure fxngen is on!
+   m_indiP_fxngensync_output["value"] = "On";
+   sendNewProperty(m_indiP_fxngensync_output);
 }
 
 inline
@@ -1929,6 +1945,10 @@ int picamCtrl::configureAcquisition()
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_ReadoutPerTrigger);
       m_synchro = true;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_IDLE);
+
+      std::cerr << "Turning synchro on for " << m_otherCamName << std::endl;
+      m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::On;
+      sendNewProperty(m_indiP_otherCamSynchro);
    } 
    else
    {
@@ -1936,6 +1956,10 @@ int picamCtrl::configureAcquisition()
       setPicamParameter(m_cameraHandle, PicamParameter_TriggerResponse, PicamTriggerResponse_NoResponse);
       m_synchro = false;
       updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE);
+
+      std::cerr << "Turning synchro off for " << m_otherCamName << std::endl;
+      m_indiP_otherCamSynchro["toggle"] = pcf::IndiElement::Off;
+      sendNewProperty(m_indiP_otherCamSynchro);
    }
 
    //Start continuous acquisition

--- a/apps/pupilCorAlign/pupilCorAlign.py
+++ b/apps/pupilCorAlign/pupilCorAlign.py
@@ -1,0 +1,86 @@
+import sys
+import logging
+from enum import Enum
+import time
+import numpy as np
+
+import xconf
+
+from magaox.indi.device import XDevice, BaseConfig
+from magaox.camera import XCam
+from magaox.constants import StateCodes
+from magaox.state_manager import XStateMachine
+
+from purepyindi2 import device, properties, constants
+from purepyindi2.messages import DefNumber, DefSwitch, DefLight, DefText
+
+@xconf.config
+class CameraConfig:
+    """
+    """
+    shmim : str = xconf.field(help="Name of the camera device (specifically, the associated shmim, if different)")
+    dark_shmim : str = xconf.field(help="Name of the dark frame shmim associated with this camera device")
+
+@xconf.config
+class CalibrationConfig:
+    """
+    """
+    calibration_path : str = xconf.field(help="Path to the calibration files for the pupil alignment.")
+
+@xconf.config
+class pupilCorAlignConfig(BaseConfig):
+    """Automatic coronagraph alignment assistant
+    """
+    camera : CameraConfig = xconf.field(help="Camera to use")
+    calibration : CalibrationConfig = xconf.field(help='Calibration parameters')
+
+class States(Enum):
+    IDLE = 0
+    CLOSED_LOOP = 1
+    PUPIL_REF = 2
+    CENTROID_REF = 3
+
+class PupilState(Enum):
+    IDLE = 0        # This is a safety state for enthousiastic button clickers
+    ACTUATOR = 1
+    BUMPMASK = 2
+    LYOTSTOP = 3
+
+class pupilCorAlign(XDevice):
+    config : pupilCorAlignConfig
+    
+    def setup(self):
+        self.log.debug(f"I was configured! See? {self.config=}")
+        fsm = properties.TextVector(name='fsm')
+        fsm.add_element(DefText(name='state', _value=StateCodes.INITIALIZED.name))
+        self.add_property(fsm)
+
+        self.log.info("Found camera: {:s}".format(self.config.camera.shmim))
+        self.camera = XCam(self.config.camera.shmim, use_hcipy=True)
+        self._state = States.IDLE
+
+        fsm = properties.TextVector(name='fsm')
+        fsm.add_element(DefText(name='state', _value=StateCodes.INITIALIZED.name))
+        self.add_property(fsm)
+
+        self._state_names = ['idle', 'closedLoop', 'pupilRef', 'centroidRef']
+        self._state_callbacks = [self.handle_idle, self.handle_closed_loop, self.handle_pupil_ref, self.handle_centroid_ref]
+        self._state_machine = XStateMachine(self, self._state_names, States, self._state_callbacks)
+
+        # This select what pupil plane we are aligning to
+        self._pupil_state = PupilState.IDLE
+    
+    def handle_idle(self):
+        print("handle_idle")
+    
+    def handle_closed_loop(self):
+        print("handle_closed_loop")
+
+    def handle_pupil_ref(self):
+        print("handle_pupil_ref")
+
+    def handle_centroid_ref(self):
+        print("handle_centroid_ref")
+
+    def loop(self):
+        self._state_machine.loop()

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -36,7 +36,7 @@ class siglentSDG : public MagAOXApp<>, public dev::telemeter<siglentSDG>
    //constexpr static double cs_MaxFreq = 3622.0;//101;//3622.0;
 
 private:
-   std::vector<double> m_maxAmp = {1.2801,   1.2801,  1.0201};//0.71,  0.83, 0.88, 1.05, 1.15, 3.45}; //1.5,     1.2,     1.1     };
+   std::vector<double> m_ampMax = {1.2801,   1.2801,  1.0201};//0.71,  0.83, 0.88, 1.05, 1.15, 3.45}; //1.5,     1.2,     1.1     };
    std::vector<double> m_maxFreq = {0.0,   2000,      3000};//100.0,   150,  200,  250,  300, 1000}; //2999.99, 3499.99, 3500.01};
    //todo: do we need to add max and min pulse variables?
 protected:
@@ -74,6 +74,7 @@ protected:
    double m_C1phse {0}; ///< The phase of channel 1 (SINE only)
    double m_C1wdth {0}; ///< The width of channel 1 (PULSE only)
    std::string m_C1wvtp; ///< The wave type of channel 1
+   double m_C1ampMax {5.0}; ///< The maximum voltage output for channel 1
 
    uint8_t m_C2outp {0}; ///<  The output status channel 2
    double m_C2frequency {0}; ///< The output frequency of channel 2
@@ -83,6 +84,7 @@ protected:
    double m_C2phse {0}; ///< The phase of channel 2 (SINE only)
    double m_C2wdth {0}; ///< The width of channel 2 (PULSE only)
    std::string m_C2wvtp; ///< The wave type of channel 2
+   double m_C2ampMax {5.0}; ///< The maximum voltage output for channel 2
 
    double m_C1frequency_tgt {-1};
    double m_C1vpp_tgt {-1};
@@ -462,6 +464,9 @@ void siglentSDG::setupConfig()
    
    config.add("fxngen.C1ampDefault", "", "fxngen.C1ampDefault", argType::Required, "fxngen", "C1ampDefault", false, "float", "C1 Default P2V Amplitude of waveform . Default = 0.0");
    config.add("fxngen.C2ampDefault", "", "fxngen.C2ampDefault", argType::Required, "fxngen", "C2ampDefault", false, "float", "C2 Default P2V Amplitude of waveform . Default = 0.0");
+   
+   config.add("fxngen.C1ampMax", "", "fxngen.C1ampMax", argType::Required, "fxngen", "C1ampMax", false, "float", "C1 Maximum amplitude");
+   config.add("fxngen.C2ampMax", "", "fxngen.C2ampMax", argType::Required, "fxngen", "C2ampMax", false, "float", "C2 Maximum amplitude");
 
    dev::telemeter<siglentSDG>::setupConfig(config);
 }
@@ -480,6 +485,9 @@ void siglentSDG::loadConfig()
 
    config(m_C1vppDefault, "fxngen.C1ampDefault");
    config(m_C2vppDefault, "fxngen.C2ampDefault");
+
+   config(m_C1ampMax, "fxngen.C1ampMax");
+   config(m_C2ampMax, "fxngen.C2ampMax");
    /// config(m_clock, "fxngen.clock");
 
    dev::telemeter<siglentSDG>::loadConfig(config);
@@ -1790,15 +1798,15 @@ int siglentSDG::changeFreq( int channel,
       if(channel == 2) amp = m_C2vpp_tgt;
       
       size_t i =0;
-      while( i < m_maxAmp.size())
+      while( i < m_ampMax.size())
       {
          if(m_maxFreq[i] >= newFreq) break;
          ++i;
       }
       
-      std::cerr << "Max Amp @ " << amp << " = " << m_maxAmp[i] << " (freq)\n"; 
+      std::cerr << "Max Amp @ " << amp << " = " << m_ampMax[i] << " (freq)\n"; 
       
-      if( amp > m_maxAmp[i] )
+      if( amp > m_ampMax[i] )
       {
          log<text_log>("Ch. " + std::to_string(channel) + " FREQ not set due to amplitude exceeding limit for " + std::to_string(newFreq), logPrio::LOG_WARNING);
          return 0;
@@ -1895,6 +1903,9 @@ int siglentSDG::changeAmp( int channel,
 
    double offst = m_C1ofst;
    if(channel == 2) offst = m_C2ofst;
+
+   double confAmpMax = m_C1ampMax;
+   if(channel == 2) confAmpMax = m_C2ampMax;
    
    // Do not limit freq if a PULSE wave
    if(m_waveform != "PULSE")
@@ -1916,21 +1927,21 @@ int siglentSDG::changeAmp( int channel,
       double freq = m_C1frequency_tgt;
       if(channel == 2) freq = m_C2frequency_tgt;
       
-      double maxAmp;
+      double ampMax;
       size_t i=0;
-      while(i < m_maxAmp.size())
+      while(i < m_ampMax.size())
       {
          if( m_maxFreq[i] >= freq ) break;
          ++i;
       }
-      maxAmp = m_maxAmp[i];
+      ampMax = fmin(m_ampMax[i], confAmpMax);
       
-      std::cerr << "Max Amp @ " << freq << " = " << maxAmp << "\n";
+      std::cerr << "Max Amp @ " << freq << " = " << ampMax << "\n";
       
       //Ensure we don't exced safe ranges for device
-      if(newAmp > maxAmp)
+      if(newAmp > ampMax)
       {
-         newAmp = maxAmp;
+         newAmp = ampMax;
          log<text_log>("Ch. " + std::to_string(channel) + " AMP max-limited to " + std::to_string(newAmp), logPrio::LOG_WARNING);
       }
 

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -57,7 +57,7 @@ protected:
    double m_C2setVoltage {5.0}; ///< the set position voltage of Ch. 2.
 
    bool m_C1outpOn {false}; /**< Flag controlling if C1 output is on after normalization. */
-   bool m_C2outpOn {false}; /**< Flag controlling if C1 output is on after normalization.
+   bool m_C2outpOn {false}; /**< Flag controlling if C2 output is on after normalization.
                                  This will only have an effect if m_C1wvtp is "pulse" */
 
    ///@}
@@ -467,6 +467,9 @@ void siglentSDG::setupConfig()
    
    config.add("fxngen.C1ampDefault", "", "fxngen.C1ampDefault", argType::Required, "fxngen", "C1ampDefault", false, "float", "C1 Default P2V Amplitude of waveform . Default = 0.0");
    config.add("fxngen.C2ampDefault", "", "fxngen.C2ampDefault", argType::Required, "fxngen", "C2ampDefault", false, "float", "C2 Default P2V Amplitude of waveform . Default = 0.0");
+
+   config.add("fxngen.C1ofstDefault", "", "fxngen.C1ofstDefault", argType::Required, "fxngen", "C1ofstDefault", false, "float", "C1 Default Offset Amplitude of waveform . Default = 0.0");
+   config.add("fxngen.C2ofstDefault", "", "fxngen.C2ofstDefault", argType::Required, "fxngen", "C2ofstDefault", false, "float", "C2 Default Offset Amplitude of waveform . Default = 0.0");
    
    config.add("fxngen.C1ampMax", "", "fxngen.C1ampMax", argType::Required, "fxngen", "C1ampMax", false, "float", "C1 Maximum amplitude");
    config.add("fxngen.C2ampMax", "", "fxngen.C2ampMax", argType::Required, "fxngen", "C2ampMax", false, "float", "C2 Maximum amplitude");
@@ -489,6 +492,9 @@ void siglentSDG::loadConfig()
 
    config(m_C1vppDefault, "fxngen.C1ampDefault");
    config(m_C2vppDefault, "fxngen.C2ampDefault");
+
+   config(m_C1ofst, "fxngen.C1ofstDefault");
+   config(m_C2ofst, "fxngen.C2ofstDefault");
 
    config(m_C1ampMax, "fxngen.C1ampMax");
    config(m_C2ampMax, "fxngen.C2ampMax");
@@ -1672,14 +1678,12 @@ int siglentSDG::normalizeSetup()
       changeWdth(2, 0);
    }
 
-   changeOfst(1, 0.0);
-   changeOfst(2, 0.0);
+   changeOfst(1, m_C1ofst);
+   changeOfst(2, m_C2ofst);
 
    changeWvtp(1, "DC");
    changeWvtp(2, "DC");
 
-   changeOfst(1, 0.0);
-   changeOfst(2, 0.0);
 
    if(m_C1outpOn && m_waveform == "PULSE")
    {
@@ -1689,8 +1693,14 @@ int siglentSDG::normalizeSetup()
    {
       changeOutp(1, "OFF");
    }
-
-   changeOutp(2, "OFF");
+   if(m_C2outpOn && m_waveform == "PULSE")
+   {
+      changeOutp(2, "ON");
+   }
+   else 
+   {
+      changeOutp(2, "OFF");
+   }
 
    changeWvtp(1, m_waveform);
    changeWvtp(2, m_waveform);
@@ -1910,6 +1920,13 @@ int siglentSDG::changeAmp( int channel,
 
    double confAmpMax = m_C1ampMax;
    if(channel == 2) confAmpMax = m_C2ampMax;
+
+   if (0.5 * newAmp + offst > confAmpMax)
+   {
+      newAmp = 2 * (confAmpMax - offst);
+      log<text_log>("Ch. " + std::to_string(channel) + " AMP max-limited by config value to " + std::to_string(newAmp), logPrio::LOG_WARNING);
+
+   }
    
    // Do not limit freq if a PULSE wave
    if(m_waveform != "PULSE")
@@ -1938,7 +1955,6 @@ int siglentSDG::changeAmp( int channel,
          if( m_maxFreq[i] >= freq ) break;
          ++i;
       }
-      ampMax = fmin(m_ampMax[i], confAmpMax);
       
       std::cerr << "Max Amp @ " << freq << " = " << ampMax << "\n";
       
@@ -1948,7 +1964,7 @@ int siglentSDG::changeAmp( int channel,
          newAmp = ampMax;
          log<text_log>("Ch. " + std::to_string(channel) + " AMP max-limited to " + std::to_string(newAmp), logPrio::LOG_WARNING);
       }
-
+      
       if(newAmp < 0)
       {
          newAmp = 0;
@@ -2028,11 +2044,15 @@ int siglentSDG::changeOfst( int channel,
 
    double amp = m_C1vpp; 
    if(channel == 2) amp = m_C2vpp;
+
+   double ampMax = m_C1ampMax;
+   if(channel == 2) ampMax = m_C2ampMax;
+
    
-   if(newOfst + 0.5*amp > 10) 
+   if(newOfst + 0.5*amp > ampMax) 
    {
-      newOfst = 10 - 0.5*amp;
-      log<text_log>("Ch. " + std::to_string(channel) + " OFST limited at 10 V by AMP to " + std::to_string(newOfst), logPrio::LOG_WARNING);
+      newOfst = ampMax - 0.5*amp;
+      log<text_log>("Ch. " + std::to_string(channel) + " OFST limited at " + std::to_string(ampMax) + " V by AMP to " + std::to_string(newOfst), logPrio::LOG_WARNING);
    }
    
    if(newOfst - 0.5*amp < 0)

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -465,11 +465,11 @@ void siglentSDG::setupConfig()
    config.add("fxngen.C1outpOn", "", "fxngen.C1outpOn", argType::Required, "fxngen", "C1outpOn", false, "bool", "Whether (true) or not (false) C1 output is enabled at startup. Only effective wavefrom is pulse. Default is false.");
    config.add("fxngen.C2outpOn", "", "fxngen.C2outpOn", argType::Required, "fxngen", "C2outpOn", false, "bool", "Whether (true) or not (false) C2 output is enabled at startup. Only effective wavefrom is pulse. Default is false.");
    
-   config.add("fxngen.C1ampDefault", "", "fxngen.C1ampDefault", argType::Required, "fxngen", "C1ampDefault", false, "float", "C1 Default P2V Amplitude of waveform . Default = 0.0");
-   config.add("fxngen.C2ampDefault", "", "fxngen.C2ampDefault", argType::Required, "fxngen", "C2ampDefault", false, "float", "C2 Default P2V Amplitude of waveform . Default = 0.0");
+   config.add("fxngen.C1ampDefault", "", "fxngen.C1ampDefault", argType::Required, "fxngen", "C1ampDefault", false, "float", "C1 Default P2V Amplitude of waveform. Default = 0.0");
+   config.add("fxngen.C2ampDefault", "", "fxngen.C2ampDefault", argType::Required, "fxngen", "C2ampDefault", false, "float", "C2 Default P2V Amplitude of waveform. Default = 0.0");
 
-   config.add("fxngen.C1ofstDefault", "", "fxngen.C1ofstDefault", argType::Required, "fxngen", "C1ofstDefault", false, "float", "C1 Default Offset Amplitude of waveform . Default = 0.0");
-   config.add("fxngen.C2ofstDefault", "", "fxngen.C2ofstDefault", argType::Required, "fxngen", "C2ofstDefault", false, "float", "C2 Default Offset Amplitude of waveform . Default = 0.0");
+   config.add("fxngen.C1ofstDefault", "", "fxngen.C1ofstDefault", argType::Required, "fxngen", "C1ofstDefault", false, "float", "C1 Default Offset Amplitude of waveform. Default = 0.0");
+   config.add("fxngen.C2ofstDefault", "", "fxngen.C2ofstDefault", argType::Required, "fxngen", "C2ofstDefault", false, "float", "C2 Default Offset Amplitude of waveform. Default = 0.0");
    
    config.add("fxngen.C1ampMax", "", "fxngen.C1ampMax", argType::Required, "fxngen", "C1ampMax", false, "float", "C1 Maximum amplitude");
    config.add("fxngen.C2ampMax", "", "fxngen.C2ampMax", argType::Required, "fxngen", "C2ampMax", false, "float", "C2 Maximum amplitude");

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -56,7 +56,8 @@ protected:
    double m_C1setVoltage {5.0}; ///< the set position voltage of Ch. 1.
    double m_C2setVoltage {5.0}; ///< the set position voltage of Ch. 2.
 
-   bool m_C1outpOn {false}; /**< Flag controlling if C1 output is on after normalization.
+   bool m_C1outpOn {false}; /**< Flag controlling if C1 output is on after normalization. */
+   bool m_C2outpOn {false}; /**< Flag controlling if C1 output is on after normalization.
                                  This will only have an effect if m_C1wvtp is "pulse" */
 
    ///@}
@@ -74,7 +75,7 @@ protected:
    double m_C1phse {0}; ///< The phase of channel 1 (SINE only)
    double m_C1wdth {0}; ///< The width of channel 1 (PULSE only)
    std::string m_C1wvtp; ///< The wave type of channel 1
-   double m_C1ampMax {5.0}; ///< The maximum voltage output for channel 1
+   double m_C1ampMax {10.0}; ///< The maximum voltage output for channel 1
 
    uint8_t m_C2outp {0}; ///<  The output status channel 2
    double m_C2frequency {0}; ///< The output frequency of channel 2
@@ -84,7 +85,7 @@ protected:
    double m_C2phse {0}; ///< The phase of channel 2 (SINE only)
    double m_C2wdth {0}; ///< The width of channel 2 (PULSE only)
    std::string m_C2wvtp; ///< The wave type of channel 2
-   double m_C2ampMax {5.0}; ///< The maximum voltage output for channel 2
+   double m_C2ampMax {10.0}; ///< The maximum voltage output for channel 2
 
    double m_C1frequency_tgt {-1};
    double m_C1vpp_tgt {-1};
@@ -459,8 +460,10 @@ void siglentSDG::setupConfig()
    config.add("timeouts.write", "", "timeouts.write", argType::Required, "timeouts", "write", false, "int", "The timeout for writing to the device [msec]. Default = 1000");
    config.add("timeouts.read", "", "timeouts.read", argType::Required, "timeouts", "read", false, "int", "The timeout for reading the device [msec]. Default = 2000");
    
-   config.add("fxngen.C1outpOn", "", "fxngen.C1outpOn", argType::Required, "fxngen", "C1outpOn", false, "bool", "Whether (true) or not (false) C1 output is enabled at startup. Only effective wavefrom is pulse. Default is false.");
    config.add("fxngen.waveform", "w", "fxngen.waveform", argType::Required, "fxngen", "waveform", false, "string", "The waveform to populate function.");
+   
+   config.add("fxngen.C1outpOn", "", "fxngen.C1outpOn", argType::Required, "fxngen", "C1outpOn", false, "bool", "Whether (true) or not (false) C1 output is enabled at startup. Only effective wavefrom is pulse. Default is false.");
+   config.add("fxngen.C2outpOn", "", "fxngen.C2outpOn", argType::Required, "fxngen", "C2outpOn", false, "bool", "Whether (true) or not (false) C2 output is enabled at startup. Only effective wavefrom is pulse. Default is false.");
    
    config.add("fxngen.C1ampDefault", "", "fxngen.C1ampDefault", argType::Required, "fxngen", "C1ampDefault", false, "float", "C1 Default P2V Amplitude of waveform . Default = 0.0");
    config.add("fxngen.C2ampDefault", "", "fxngen.C2ampDefault", argType::Required, "fxngen", "C2ampDefault", false, "float", "C2 Default P2V Amplitude of waveform . Default = 0.0");
@@ -480,8 +483,9 @@ void siglentSDG::loadConfig()
    config(m_writeTimeOut, "timeouts.write");
    config(m_readTimeOut, "timeouts.read");
    
-   config(m_C1outpOn, "fxngen.C1outpOn");
    config(m_waveform, "fxngen.waveform"); // todo: check if this is a valid waveform?
+   config(m_C1outpOn, "fxngen.C1outpOn");
+   config(m_C2outpOn, "fxngen.C2outpOn");
 
    config(m_C1vppDefault, "fxngen.C1ampDefault");
    config(m_C2vppDefault, "fxngen.C2ampDefault");


### PR DESCRIPTION
Rewrite siglent code to have a maximum absolute amplitude config value along with logic in `changeAmp` and `changeOfst` to obey. Also added an offset value to the configuration so that channels can be set up for 0V/+3.3V TTL on startup

I didn't mess with the code that calculates the pulse width based on the frequency, therefore it is critical that when setting fxngen settings for camera syncrho that you change the frequency first and the width second.

TODO: implement camera triggering settings in picam app