### PR TITLE
siglent rework

### DIFF
--- a/apps/dbIngest/xapp/dbIngest_BACKUP_104355.py
+++ b/apps/dbIngest/xapp/dbIngest_BACKUP_104355.py
@@ -1,0 +1,363 @@
+import glob
+from purepyindi2 import device, properties, constants, messages
+from purepyindi2.messages import DefNumber, DefSwitch, DefText
+import sys
+import logging
+import xconf
+import psycopg
+from magaox.indi.device import XDevice
+from magaox.constants import DEFAULT_PREFIX
+from magaox.db.config import BaseDbDeviceConfig
+from magaox.db import Telem, FileOrigin, UserLog
+from magaox.db import ingest
+from magaox.utils import parse_iso_datetime_as_utc, creation_time_from_filename
+
+import json
+import orjson
+import xconf
+import subprocess
+import queue
+import socket
+import threading
+import pathlib
+import time
+import os.path
+import os
+import sys
+import datetime
+from datetime import timezone
+from watchdog.observers import Observer, BaseObserverSubclassCallable
+from watchdog.events import FileSystemEventHandler
+
+log = logging.getLogger(__name__)
+
+class TimeoutError(Exception):
+    pass
+
+class QueryCancellationWatchdog(threading.Thread):
+    dt_sec : float = 0.1
+    def __init__(self, conn: psycopg.Connection, timeout_sec=30.0):
+        self.exit = False
+        self.conn = conn
+        self.timeout_sec = 30.0
+        super().__init__(target=self.run)
+    def complete(self):
+        self.exit = True
+    def run(self):
+        total_wait_sec = 0.0
+        while not self.exit and total_wait_sec < self.timeout_sec:
+            time.sleep(self.dt_sec)
+            total_wait_sec += self.dt_sec
+        if self.exit:
+            return
+        else:
+            self.conn.cancel_safe()
+            raise TimeoutError()
+
+class NewXFilesHandler(FileSystemEventHandler):
+    def __init__(self, host, events_queue, log_name):
+        self.host = host
+        self.events_queue = events_queue
+        self.log = logging.getLogger(log_name)
+
+    def construct_message(self, stat_result, event, is_new_file=False):
+        return FileOrigin(
+            origin_host=self.host,
+            origin_path=event.src_path,
+            creation_time=creation_time_from_filename(event.src_path, stat_result=stat_result),
+            modification_time=datetime.datetime.fromtimestamp(stat_result.st_mtime),
+            size_bytes=stat_result.st_size,
+        )
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=True))
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=False))
+
+RETRY_WAIT_SEC = 2
+CREATE_CONNECTION_TIMEOUT_SEC = 2
+EXIT_TIMEOUT_SEC = 2
+
+def _run_logdump_thread(logger_name, logdump_dir, logdump_args, name, message_queue, record_class):
+    # filter what content from user_logs gets put into db
+    log = logging.getLogger(logger_name)
+    while True:
+        try:
+            args = logdump_args + ('--dir='+logdump_dir, '-J', '-f', name)
+            log.debug(f"Running logdump command {repr(' '.join(args))} for {name} in follow mode")
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+            for line in p.stdout:
+                message = record_class.from_json(name, line)
+                message_queue.put(message)
+            p.wait()  # stdout is over when the process exits
+            if p.returncode != 0:
+                raise RuntimeError(f"{name} logdump exited with {p.returncode} ({repr(' '.join(args))})")
+        except Exception as e:
+            glob_pattern = logdump_dir + f"/{name}/*/{name}_*"
+            if len(glob.glob(glob_pattern + ".ndjson.gz")):
+                log.info(f"Looks like {name} is a Python app; support is TODO")
+                return
+            if len(glob.glob(glob_pattern)):
+                log.exception(f"Exception in log/telem follower for {name}")
+            else:
+                log.info(f"No files found for {name}, waiting for them to appear")
+            while not len(glob.glob(glob_pattern)):
+                time.sleep(RETRY_WAIT_SEC)
+
+@xconf.config
+class dbIngestConfig(BaseDbDeviceConfig):
+    proclist : str = xconf.field(default="/opt/MagAOX/config/proclist_%s.txt", help="Path to process list file, %s will be replaced with the value of $MAGAOX_ROLE (or an empty string if absent from the environment)")
+    query_timeout_sec : float = xconf.field(default=30.0, help="Number of seconds after which to (attempt to) cancel an insert query under the assumption the connection's gone bad")
+    logdump_exe : str = xconf.field(default="/opt/MagAOX/bin/logdump", help="logdump (a.k.a. teldump) executable to use")
+
+class dbIngest(XDevice):
+    config : dbIngestConfig
+    telem_threads : list[tuple[str, threading.Thread]]
+    telem_queue : queue.Queue
+    fs_observer : BaseObserverSubclassCallable
+    fs_queue : queue.Queue
+    last_update_ts_sec : float
+    startup_ts_sec : float
+    records_since_startup : float
+    _connections : dict[str, psycopg.Connection]
+    _connections_to_attempt : set[str]
+
+    #add user_log support here
+    user_log_threads : list[tuple[str, threading.Thread]]
+    user_log_queue : queue.Queue
+
+    def launch_followers(self, dev):
+        telem_args = self.log.name + '.' + dev, '/opt/MagAOX/telem', (self.config.logdump_exe, '--ext=.bintel'), dev, self.telem_queue, Telem
+        telem_thread = threading.Thread(target=_run_logdump_thread, args=telem_args, daemon=True)
+        telem_thread.start()
+        self.log.debug(f"Watching {dev} for incoming telem")
+        self.telem_threads.append((dev, telem_thread))
+
+        if dev == "observers":
+            ULog_args = self.log.name + '.' + dev, '/opt/MagAOX/logs', (self.config.logdump_exe, '--ext=.binlog'), dev, self.user_log_queue, UserLog
+            user_log_thread = threading.Thread(target=_run_logdump_thread, args= ULog_args, daemon=True)
+            user_log_thread.start()
+            self.log.debug(f"Watching {dev} for incoming user logs")
+            self.user_log_threads.append((dev, user_log_thread))
+
+    def refresh_properties(self):
+        self.properties['last_update']['timestamp'] = self.last_update_ts_sec
+        self.update_property(self.properties['last_update'])
+        self.properties['records']['since_startup'] = self.records_since_startup
+        self.properties['records']['per_sec'] = self.records_since_startup / (time.time() - self.startup_ts_sec)
+        self.update_property(self.properties['records'])
+
+    def setup(self):
+        self.last_update_ts_sec = time.time()
+        self._connections = {}
+        self._connections_to_attempt = set(self.config.databases.keys())
+        self.records_since_startup = 0
+        self.records_per_sec = 0.0
+        last_update = properties.NumberVector(name="last_update", perm=constants.PropertyPerm.READ_ONLY)
+        last_update.add_element(DefNumber(
+            name="timestamp",
+            _value=self.last_update_ts_sec,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        self.add_property(last_update)
+
+        records = properties.NumberVector(name="records", perm=constants.PropertyPerm.READ_ONLY)
+        records.add_element(DefNumber(
+            name="per_sec",
+            _value=0.0,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        records.add_element(DefNumber(
+            name="since_startup",
+            _value=0,
+            min=0, max=1_000_000_000, format='%i',
+            step=1,
+        ))
+        self.add_property(records)
+
+        role = os.environ.get('MAGAOX_ROLE', '')
+        proclist = pathlib.Path(self.config.proclist.replace('%s', role))
+        if not proclist.exists():
+            raise RuntimeError(f"No process list at {proclist}")
+
+        device_names = set()
+
+        with proclist.open() as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                if line.strip()[0] == '#':
+                    continue
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    raise RuntimeError(f"Got malformed proclist line: {repr(line)}")
+                device_names.add(parts[0])
+
+        self.user_log_queue = queue.Queue()
+        self.user_log_threads = []
+
+        self.telem_queue = queue.Queue()
+        self.telem_threads = []
+        for dev in device_names:
+            self.launch_followers(dev)
+
+        self.startup_ts_sec = time.time()
+
+        self.fs_queue = queue.Queue()
+        event_handler = NewXFilesHandler(self.config.hostname, self.fs_queue, self.log.name + '.fs_observer')
+        self.fs_observer = Observer()
+        for dirname in self.config.data_dirs:
+            dirpath = self.config.common_path_prefix / dirname
+            if not dirpath.exists():
+                self.log.debug(f"No {dirpath} to watch")
+                continue
+            self.fs_observer.schedule(event_handler, dirpath, recursive=True)
+            self.log.info(f"Watching {dirpath} for changes")
+        self.fs_observer.start()
+
+<<<<<<< HEAD
+    def ingest_line(self, line):
+        # avoid infinite loop of modifying log file and getting notified of the modification
+        if self.log_file_name.encode('utf8') not in line:
+            self.log.debug(line)
+
+    def _ensure_connected(self):
+        for configkey in self.config.databases.keys():
+            if configkey in self._connections_to_attempt or self._connections[configkey].closed:
+                connections_to_reattempt = set()
+                for configkey in self._connections_to_attempt:
+                    try:
+                        self._connections[configkey].close()
+                    except Exception:
+                        pass
+                    try:
+                        self._connections[configkey] = self.config.databases[configkey].connect()
+                        self.log.info(f"Connected to {configkey} db")
+                    except Exception:
+                        self.log.exception(f"Failed to connect to {configkey} ({self.config.databases[configkey]})")
+                        connections_to_reattempt.add(configkey)
+                self._connections_to_attempt = connections_to_reattempt
+=======
+
+    def rescan_files(self):
+        search_paths = [self.config.common_path_prefix / name for name in self.config.data_dirs]
+        for conn in self.config.databases:
+            try:
+                with self.config.databases[conn].cursor() as cur:
+                    # n.b. the state of the file inventory and which files
+                    # are 'new' can be different depending on which
+                    # database we're talking about, so we rescan once
+                    # per connection
+                    self.log.debug(f"Scanning for new files for database {conn}")
+                    ingest.update_file_inventory(
+                        cur,
+                        self.config.hostname,
+                        search_paths,
+                        self.config.ignore_patterns.files, self.config.ignore_patterns.directories
+                    )
+            except Exception:
+                self.log.exception(f"Failed to rescan/inventory files for database {conn}, attempting to reconnect")
+                self._connections_to_attempt.add(conn)
+        self.log.info(f"Completed startup rescan of file inventory for {self.config.hostname} from {search_paths}")
+
+    def loop(self):
+        connections_to_reattempt = set()
+        if len(self._connections_to_attempt):
+            for configkey in self._connections_to_attempt:
+                try:
+                    self._connections[configkey].close()
+                except Exception:
+                    pass
+                try:
+                    self._connections[configkey] = self.config.databases[configkey].connect()
+                    connections_to_reattempt.add(configkey)
+                except Exception:
+                    self.log.exception(f"Failed to connect to {configkey} ({self.config.databases[configkey]})")
+            self._connections_to_attempt = connections_to_reattempt
+>>>>>>> 79ca0f66 (dbIngest: remove dead code)
+
+    def loop(self):
+        self._ensure_connected()
+        telems = []
+        try:
+            while rec := self.telem_queue.get(timeout=0.1):
+                telems.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        fs_events = []
+        try:
+            while rec := self.fs_queue.get(timeout=0.1):
+                fs_events.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        user_logs = []
+        try:
+            while rec := self.user_log_queue.get(timeout=0.1):
+                user_logs.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        for connkey in self._connections:
+            conn = self._connections[connkey]
+            self.log.debug(f"Batching ingest for {connkey}")
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_telem(conn, telems)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch telem ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_file_origins(conn, fs_events)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch file origins ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_user_log(conn, user_logs)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch user log ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+        this_ts_sec = time.time()
+        self.last_update_ts_sec = this_ts_sec
+        self.refresh_properties()
+
+main = dbIngest.console_app

--- a/apps/dbIngest/xapp/dbIngest_BASE_104355.py
+++ b/apps/dbIngest/xapp/dbIngest_BASE_104355.py
@@ -1,0 +1,294 @@
+import glob
+from purepyindi2 import device, properties, constants, messages
+from purepyindi2.messages import DefNumber, DefSwitch, DefText
+import sys
+import logging
+import xconf
+import psycopg
+from magaox.indi.device import XDevice
+from magaox.constants import DEFAULT_PREFIX
+from magaox.db.config import BaseDbDeviceConfig
+from magaox.db import Telem, FileOrigin, UserLog
+from magaox.db import ingest
+from magaox.utils import parse_iso_datetime_as_utc, creation_time_from_filename
+
+import json
+import orjson
+import xconf
+import subprocess
+import queue
+import socket
+import threading
+import pathlib
+import time
+import os.path
+import os
+import sys
+import datetime
+from datetime import timezone
+from watchdog.observers import Observer, BaseObserverSubclassCallable
+from watchdog.events import FileSystemEventHandler
+
+class NewXFilesHandler(FileSystemEventHandler):
+    def __init__(self, host, events_queue, log_name):
+        self.host = host
+        self.events_queue = events_queue
+        self.log = logging.getLogger(log_name)
+
+    def construct_message(self, stat_result, event, is_new_file=False):
+        return FileOrigin(
+            origin_host=self.host,
+            origin_path=event.src_path,
+            creation_time=creation_time_from_filename(event.src_path, stat_result=stat_result),
+            modification_time=datetime.datetime.fromtimestamp(stat_result.st_mtime),
+            size_bytes=stat_result.st_size,
+        )
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=True))
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=False))
+
+RETRY_WAIT_SEC = 2
+CREATE_CONNECTION_TIMEOUT_SEC = 2
+EXIT_TIMEOUT_SEC = 2
+
+def _run_logdump_thread(logger_name, logdump_dir, logdump_args, name, message_queue, record_class):
+    # filter what content from user_logs gets put into db
+    log = logging.getLogger(logger_name)
+    while True:
+        try:
+            args = logdump_args + ('--dir='+logdump_dir, '-J', '-f', name)
+            log.debug(f"Running logdump command {repr(' '.join(args))} for {name} in follow mode")
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+            for line in p.stdout:
+                message = record_class.from_json(name, line)
+                message_queue.put(message)
+            p.wait()  # stdout is over when the process exits
+            if p.returncode != 0:
+                raise RuntimeError(f"{name} logdump exited with {p.returncode} ({repr(' '.join(args))})")
+        except Exception as e:
+            glob_pattern = logdump_dir + f"/{name}/*/{name}_*"
+            if len(glob.glob(glob_pattern + ".ndjson.gz")):
+                log.info(f"Looks like {name} is a Python app; support is TODO")
+                return
+            if len(glob.glob(glob_pattern)):
+                log.exception(f"Exception in log/telem follower for {name}")
+            else:
+                log.info(f"No files found for {name}, waiting for them to appear")
+            while not len(glob.glob(glob_pattern)):
+                time.sleep(RETRY_WAIT_SEC)
+
+@xconf.config
+class dbIngestConfig(BaseDbDeviceConfig):
+    proclist : str = xconf.field(default="/opt/MagAOX/config/proclist_%s.txt", help="Path to process list file, %s will be replaced with the value of $MAGAOX_ROLE (or an empty string if absent from the environment)")
+    logdump_exe : str = xconf.field(default="/opt/MagAOX/bin/logdump", help="logdump (a.k.a. teldump) executable to use")
+
+class dbIngest(XDevice):
+    config : dbIngestConfig
+    telem_threads : list[tuple[str, threading.Thread]]
+    telem_queue : queue.Queue
+    fs_observer : BaseObserverSubclassCallable
+    fs_queue : queue.Queue
+    last_update_ts_sec : float
+    startup_ts_sec : float
+    records_since_startup : float
+    _connections : dict[str, psycopg.Connection]
+    _connections_to_attempt : set[str]
+
+    #add user_log support here
+    user_log_threads : list[tuple[str, threading.Thread]]
+    user_log_queue : queue.Queue
+
+    def launch_followers(self, dev):
+        telem_args = self.log.name + '.' + dev, '/opt/MagAOX/telem', (self.config.logdump_exe, '--ext=.bintel'), dev, self.telem_queue, Telem
+        telem_thread = threading.Thread(target=_run_logdump_thread, args=telem_args, daemon=True)
+        telem_thread.start()
+        self.log.debug(f"Watching {dev} for incoming telem")
+        self.telem_threads.append((dev, telem_thread))
+
+        if dev == "observers":
+            ULog_args = self.log.name + '.' + dev, '/opt/MagAOX/logs', (self.config.logdump_exe, '--ext=.binlog'), dev, self.user_log_queue, UserLog
+            user_log_thread = threading.Thread(target=_run_logdump_thread, args= ULog_args, daemon=True)
+            user_log_thread.start()
+            self.log.debug(f"Watching {dev} for incoming user logs")
+            self.user_log_threads.append((dev, user_log_thread))
+
+    def refresh_properties(self):
+        self.properties['last_update']['timestamp'] = self.last_update_ts_sec
+        self.update_property(self.properties['last_update'])
+        self.properties['records']['since_startup'] = self.records_since_startup
+        self.properties['records']['per_sec'] = self.records_since_startup / (time.time() - self.startup_ts_sec)
+        self.update_property(self.properties['records'])
+
+    def setup(self):
+        self.last_update_ts_sec = time.time()
+        self._connections = {}
+        self._connections_to_attempt = set(self.config.databases.keys())
+        self.records_since_startup = 0
+        self.records_per_sec = 0.0
+        last_update = properties.NumberVector(name="last_update", perm=constants.PropertyPerm.READ_ONLY)
+        last_update.add_element(DefNumber(
+            name="timestamp",
+            _value=self.last_update_ts_sec,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        self.add_property(last_update)
+
+        records = properties.NumberVector(name="records", perm=constants.PropertyPerm.READ_ONLY)
+        records.add_element(DefNumber(
+            name="per_sec",
+            _value=0.0,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        records.add_element(DefNumber(
+            name="since_startup",
+            _value=0,
+            min=0, max=1_000_000_000, format='%i',
+            step=1,
+        ))
+        self.add_property(records)
+
+        role = os.environ.get('MAGAOX_ROLE', '')
+        proclist = pathlib.Path(self.config.proclist.replace('%s', role))
+        if not proclist.exists():
+            raise RuntimeError(f"No process list at {proclist}")
+
+        device_names = set()
+
+        with proclist.open() as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                if line.strip()[0] == '#':
+                    continue
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    raise RuntimeError(f"Got malformed proclist line: {repr(line)}")
+                device_names.add(parts[0])
+
+        self.user_log_queue = queue.Queue()
+        self.user_log_threads = []
+
+        self.telem_queue = queue.Queue()
+        self.telem_threads = []
+        for dev in device_names:
+            self.launch_followers(dev)
+
+        self.startup_ts_sec = time.time()
+
+        # rescan for inventory
+        self.rescan_files()
+
+        self.fs_queue = queue.Queue()
+        event_handler = NewXFilesHandler(self.config.hostname, self.fs_queue, self.log.name + '.fs_observer')
+        self.fs_observer = Observer()
+        for dirname in self.config.data_dirs:
+            dirpath = self.config.common_path_prefix / dirname
+            if not dirpath.exists():
+                self.log.debug(f"No {dirpath} to watch")
+                continue
+            self.fs_observer.schedule(event_handler, dirpath, recursive=True)
+            self.log.info(f"Watching {dirpath} for changes")
+        self.fs_observer.start()
+
+
+    def rescan_files(self):
+        search_paths = [self.config.common_path_prefix / name for name in self.config.data_dirs]
+        for conn in self.config.databases:
+            try:
+                with self.config.databases[conn].cursor() as cur:
+                    # n.b. the state of the file inventory and which files
+                    # are 'new' can be different depending on which
+                    # database we're talking about, so we rescan once
+                    # per connection
+                    self.log.debug(f"Scanning for new files for database {conn}")
+                    ingest.update_file_inventory(
+                        cur,
+                        self.config.hostname,
+                        search_paths,
+                        self.config.ignore_patterns.files, self.config.ignore_patterns.directories
+                    )
+            except Exception:
+                self.log.exception(f"Failed to rescan/inventory files for database {conn}, attempting to reconnect")
+                self._connections_to_attempt.add(conn)
+        self.log.info(f"Completed startup rescan of file inventory for {self.config.hostname} from {search_paths}")
+
+    def ingest_line(self, line):
+        # avoid infinite loop of modifying log file and getting notified of the modification
+        if self.log_file_name.encode('utf8') not in line:
+            self.log.debug(line)
+
+    def loop(self):
+        connections_to_reattempt = set()
+        if len(self._connections_to_attempt):
+            for configkey in self._connections_to_attempt:
+                try:
+                    self._connections[configkey].close()
+                except Exception:
+                    pass
+                try:
+                    self._connections[configkey] = self.config.databases[configkey].connect()
+                    connections_to_reattempt.add(configkey)
+                except Exception:
+                    self.log.exception(f"Failed to connect to {configkey} ({self.config.databases[configkey]})")
+            self._connections_to_attempt = connections_to_reattempt
+
+        telems = []
+        try:
+            while rec := self.telem_queue.get(timeout=0.1):
+                telems.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        fs_events = []
+        try:
+            while rec := self.fs_queue.get(timeout=0.1):
+                fs_events.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        #update for userlog here too
+        user_logs = []
+        try:
+            while rec := self.user_log_queue.get(timeout=0.1):
+                user_logs.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        for connkey in self._connections:
+            try:
+                self.log.debug(f"Batching ingest for {connkey}")
+                conn = self._connections[connkey]
+                with conn.transaction():
+                    cur = conn.cursor()
+                    ingest.batch_telem(cur, telems)
+                    ingest.batch_file_origins(cur, fs_events)
+                    ingest.batch_user_log(cur, user_logs)
+            except Exception as e:
+                self.log.exception(f"Caught exception in batch ingest, reconnecting {conn} on next loop()")
+                self._connections_to_attempt.add(conn)
+
+        this_ts_sec = time.time()
+        self.last_update_ts_sec = this_ts_sec
+        self.refresh_properties()
+
+main = dbIngest.console_app

--- a/apps/dbIngest/xapp/dbIngest_LOCAL_104355.py
+++ b/apps/dbIngest/xapp/dbIngest_LOCAL_104355.py
@@ -1,0 +1,324 @@
+import glob
+from purepyindi2 import device, properties, constants, messages
+from purepyindi2.messages import DefNumber, DefSwitch, DefText
+import sys
+import logging
+import xconf
+import psycopg
+from magaox.indi.device import XDevice
+from magaox.constants import DEFAULT_PREFIX
+from magaox.db.config import BaseDbDeviceConfig
+from magaox.db import Telem, FileOrigin, UserLog
+from magaox.db import ingest
+from magaox.utils import parse_iso_datetime_as_utc, creation_time_from_filename
+
+import json
+import orjson
+import xconf
+import subprocess
+import queue
+import socket
+import threading
+import pathlib
+import time
+import os.path
+import os
+import sys
+import datetime
+from datetime import timezone
+from watchdog.observers import Observer, BaseObserverSubclassCallable
+from watchdog.events import FileSystemEventHandler
+
+log = logging.getLogger(__name__)
+
+class TimeoutError(Exception):
+    pass
+
+class QueryCancellationWatchdog(threading.Thread):
+    dt_sec : float = 0.1
+    def __init__(self, conn: psycopg.Connection, timeout_sec=30.0):
+        self.exit = False
+        self.conn = conn
+        self.timeout_sec = 30.0
+        super().__init__(target=self.run)
+    def complete(self):
+        self.exit = True
+    def run(self):
+        total_wait_sec = 0.0
+        while not self.exit and total_wait_sec < self.timeout_sec:
+            time.sleep(self.dt_sec)
+            total_wait_sec += self.dt_sec
+        if self.exit:
+            return
+        else:
+            self.conn.cancel_safe()
+            raise TimeoutError()
+
+class NewXFilesHandler(FileSystemEventHandler):
+    def __init__(self, host, events_queue, log_name):
+        self.host = host
+        self.events_queue = events_queue
+        self.log = logging.getLogger(log_name)
+
+    def construct_message(self, stat_result, event, is_new_file=False):
+        return FileOrigin(
+            origin_host=self.host,
+            origin_path=event.src_path,
+            creation_time=creation_time_from_filename(event.src_path, stat_result=stat_result),
+            modification_time=datetime.datetime.fromtimestamp(stat_result.st_mtime),
+            size_bytes=stat_result.st_size,
+        )
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=True))
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=False))
+
+RETRY_WAIT_SEC = 2
+CREATE_CONNECTION_TIMEOUT_SEC = 2
+EXIT_TIMEOUT_SEC = 2
+
+def _run_logdump_thread(logger_name, logdump_dir, logdump_args, name, message_queue, record_class):
+    # filter what content from user_logs gets put into db
+    log = logging.getLogger(logger_name)
+    while True:
+        try:
+            args = logdump_args + ('--dir='+logdump_dir, '-J', '-f', name)
+            log.debug(f"Running logdump command {repr(' '.join(args))} for {name} in follow mode")
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+            for line in p.stdout:
+                message = record_class.from_json(name, line)
+                message_queue.put(message)
+            p.wait()  # stdout is over when the process exits
+            if p.returncode != 0:
+                raise RuntimeError(f"{name} logdump exited with {p.returncode} ({repr(' '.join(args))})")
+        except Exception as e:
+            glob_pattern = logdump_dir + f"/{name}/*/{name}_*"
+            if len(glob.glob(glob_pattern + ".ndjson.gz")):
+                log.info(f"Looks like {name} is a Python app; support is TODO")
+                return
+            if len(glob.glob(glob_pattern)):
+                log.exception(f"Exception in log/telem follower for {name}")
+            else:
+                log.info(f"No files found for {name}, waiting for them to appear")
+            while not len(glob.glob(glob_pattern)):
+                time.sleep(RETRY_WAIT_SEC)
+
+@xconf.config
+class dbIngestConfig(BaseDbDeviceConfig):
+    proclist : str = xconf.field(default="/opt/MagAOX/config/proclist_%s.txt", help="Path to process list file, %s will be replaced with the value of $MAGAOX_ROLE (or an empty string if absent from the environment)")
+    query_timeout_sec : float = xconf.field(default=30.0, help="Number of seconds after which to (attempt to) cancel an insert query under the assumption the connection's gone bad")
+    logdump_exe : str = xconf.field(default="/opt/MagAOX/bin/logdump", help="logdump (a.k.a. teldump) executable to use")
+
+class dbIngest(XDevice):
+    config : dbIngestConfig
+    telem_threads : list[tuple[str, threading.Thread]]
+    telem_queue : queue.Queue
+    fs_observer : BaseObserverSubclassCallable
+    fs_queue : queue.Queue
+    last_update_ts_sec : float
+    startup_ts_sec : float
+    records_since_startup : float
+    _connections : dict[str, psycopg.Connection]
+    _connections_to_attempt : set[str]
+
+    #add user_log support here
+    user_log_threads : list[tuple[str, threading.Thread]]
+    user_log_queue : queue.Queue
+
+    def launch_followers(self, dev):
+        telem_args = self.log.name + '.' + dev, '/opt/MagAOX/telem', (self.config.logdump_exe, '--ext=.bintel'), dev, self.telem_queue, Telem
+        telem_thread = threading.Thread(target=_run_logdump_thread, args=telem_args, daemon=True)
+        telem_thread.start()
+        self.log.debug(f"Watching {dev} for incoming telem")
+        self.telem_threads.append((dev, telem_thread))
+
+        if dev == "observers":
+            ULog_args = self.log.name + '.' + dev, '/opt/MagAOX/logs', (self.config.logdump_exe, '--ext=.binlog'), dev, self.user_log_queue, UserLog
+            user_log_thread = threading.Thread(target=_run_logdump_thread, args= ULog_args, daemon=True)
+            user_log_thread.start()
+            self.log.debug(f"Watching {dev} for incoming user logs")
+            self.user_log_threads.append((dev, user_log_thread))
+
+    def refresh_properties(self):
+        self.properties['last_update']['timestamp'] = self.last_update_ts_sec
+        self.update_property(self.properties['last_update'])
+        self.properties['records']['since_startup'] = self.records_since_startup
+        self.properties['records']['per_sec'] = self.records_since_startup / (time.time() - self.startup_ts_sec)
+        self.update_property(self.properties['records'])
+
+    def setup(self):
+        self.last_update_ts_sec = time.time()
+        self._connections = {}
+        self._connections_to_attempt = set(self.config.databases.keys())
+        self.records_since_startup = 0
+        self.records_per_sec = 0.0
+        last_update = properties.NumberVector(name="last_update", perm=constants.PropertyPerm.READ_ONLY)
+        last_update.add_element(DefNumber(
+            name="timestamp",
+            _value=self.last_update_ts_sec,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        self.add_property(last_update)
+
+        records = properties.NumberVector(name="records", perm=constants.PropertyPerm.READ_ONLY)
+        records.add_element(DefNumber(
+            name="per_sec",
+            _value=0.0,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        records.add_element(DefNumber(
+            name="since_startup",
+            _value=0,
+            min=0, max=1_000_000_000, format='%i',
+            step=1,
+        ))
+        self.add_property(records)
+
+        role = os.environ.get('MAGAOX_ROLE', '')
+        proclist = pathlib.Path(self.config.proclist.replace('%s', role))
+        if not proclist.exists():
+            raise RuntimeError(f"No process list at {proclist}")
+
+        device_names = set()
+
+        with proclist.open() as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                if line.strip()[0] == '#':
+                    continue
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    raise RuntimeError(f"Got malformed proclist line: {repr(line)}")
+                device_names.add(parts[0])
+
+        self.user_log_queue = queue.Queue()
+        self.user_log_threads = []
+
+        self.telem_queue = queue.Queue()
+        self.telem_threads = []
+        for dev in device_names:
+            self.launch_followers(dev)
+
+        self.startup_ts_sec = time.time()
+
+        self.fs_queue = queue.Queue()
+        event_handler = NewXFilesHandler(self.config.hostname, self.fs_queue, self.log.name + '.fs_observer')
+        self.fs_observer = Observer()
+        for dirname in self.config.data_dirs:
+            dirpath = self.config.common_path_prefix / dirname
+            if not dirpath.exists():
+                self.log.debug(f"No {dirpath} to watch")
+                continue
+            self.fs_observer.schedule(event_handler, dirpath, recursive=True)
+            self.log.info(f"Watching {dirpath} for changes")
+        self.fs_observer.start()
+
+    def ingest_line(self, line):
+        # avoid infinite loop of modifying log file and getting notified of the modification
+        if self.log_file_name.encode('utf8') not in line:
+            self.log.debug(line)
+
+    def _ensure_connected(self):
+        for configkey in self.config.databases.keys():
+            if configkey in self._connections_to_attempt or self._connections[configkey].closed:
+                connections_to_reattempt = set()
+                for configkey in self._connections_to_attempt:
+                    try:
+                        self._connections[configkey].close()
+                    except Exception:
+                        pass
+                    try:
+                        self._connections[configkey] = self.config.databases[configkey].connect()
+                        self.log.info(f"Connected to {configkey} db")
+                    except Exception:
+                        self.log.exception(f"Failed to connect to {configkey} ({self.config.databases[configkey]})")
+                        connections_to_reattempt.add(configkey)
+                self._connections_to_attempt = connections_to_reattempt
+
+    def loop(self):
+        self._ensure_connected()
+        telems = []
+        try:
+            while rec := self.telem_queue.get(timeout=0.1):
+                telems.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        fs_events = []
+        try:
+            while rec := self.fs_queue.get(timeout=0.1):
+                fs_events.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        user_logs = []
+        try:
+            while rec := self.user_log_queue.get(timeout=0.1):
+                user_logs.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        for connkey in self._connections:
+            conn = self._connections[connkey]
+            self.log.debug(f"Batching ingest for {connkey}")
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_telem(conn, telems)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch telem ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_file_origins(conn, fs_events)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch file origins ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+            query_timeout = QueryCancellationWatchdog(conn, timeout_sec=self.config.query_timeout_sec)
+            try:
+                query_timeout.start()
+                ingest.batch_user_log(conn, user_logs)
+                query_timeout.complete()
+            except Exception as e:
+                self.log.exception(f"Caught exception {e} in batch user log ingest, reconnecting {connkey} on next loop()")
+                self._connections_to_attempt.add(connkey)
+                continue
+            finally:
+                query_timeout.join()
+
+        this_ts_sec = time.time()
+        self.last_update_ts_sec = this_ts_sec
+        self.refresh_properties()
+
+main = dbIngest.console_app

--- a/apps/dbIngest/xapp/dbIngest_REMOTE_104355.py
+++ b/apps/dbIngest/xapp/dbIngest_REMOTE_104355.py
@@ -1,0 +1,289 @@
+import glob
+from purepyindi2 import device, properties, constants, messages
+from purepyindi2.messages import DefNumber, DefSwitch, DefText
+import sys
+import logging
+import xconf
+import psycopg
+from magaox.indi.device import XDevice
+from magaox.constants import DEFAULT_PREFIX
+from magaox.db.config import BaseDbDeviceConfig
+from magaox.db import Telem, FileOrigin, UserLog
+from magaox.db import ingest
+from magaox.utils import parse_iso_datetime_as_utc, creation_time_from_filename
+
+import json
+import orjson
+import xconf
+import subprocess
+import queue
+import socket
+import threading
+import pathlib
+import time
+import os.path
+import os
+import sys
+import datetime
+from datetime import timezone
+from watchdog.observers import Observer, BaseObserverSubclassCallable
+from watchdog.events import FileSystemEventHandler
+
+class NewXFilesHandler(FileSystemEventHandler):
+    def __init__(self, host, events_queue, log_name):
+        self.host = host
+        self.events_queue = events_queue
+        self.log = logging.getLogger(log_name)
+
+    def construct_message(self, stat_result, event, is_new_file=False):
+        return FileOrigin(
+            origin_host=self.host,
+            origin_path=event.src_path,
+            creation_time=creation_time_from_filename(event.src_path, stat_result=stat_result),
+            modification_time=datetime.datetime.fromtimestamp(stat_result.st_mtime),
+            size_bytes=stat_result.st_size,
+        )
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=True))
+
+    def on_modified(self, event):
+        if event.is_directory:
+            return
+        try:
+            stat_result = os.stat(event.src_path)
+        except FileNotFoundError:
+            return
+        self.events_queue.put(self.construct_message(stat_result, event, is_new_file=False))
+
+RETRY_WAIT_SEC = 2
+CREATE_CONNECTION_TIMEOUT_SEC = 2
+EXIT_TIMEOUT_SEC = 2
+
+def _run_logdump_thread(logger_name, logdump_dir, logdump_args, name, message_queue, record_class):
+    # filter what content from user_logs gets put into db
+    log = logging.getLogger(logger_name)
+    while True:
+        try:
+            args = logdump_args + ('--dir='+logdump_dir, '-J', '-f', name)
+            log.debug(f"Running logdump command {repr(' '.join(args))} for {name} in follow mode")
+            p = subprocess.Popen(args, stdout=subprocess.PIPE, stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+            for line in p.stdout:
+                message = record_class.from_json(name, line)
+                message_queue.put(message)
+            p.wait()  # stdout is over when the process exits
+            if p.returncode != 0:
+                raise RuntimeError(f"{name} logdump exited with {p.returncode} ({repr(' '.join(args))})")
+        except Exception as e:
+            glob_pattern = logdump_dir + f"/{name}/*/{name}_*"
+            if len(glob.glob(glob_pattern + ".ndjson.gz")):
+                log.info(f"Looks like {name} is a Python app; support is TODO")
+                return
+            if len(glob.glob(glob_pattern)):
+                log.exception(f"Exception in log/telem follower for {name}")
+            else:
+                log.info(f"No files found for {name}, waiting for them to appear")
+            while not len(glob.glob(glob_pattern)):
+                time.sleep(RETRY_WAIT_SEC)
+
+@xconf.config
+class dbIngestConfig(BaseDbDeviceConfig):
+    proclist : str = xconf.field(default="/opt/MagAOX/config/proclist_%s.txt", help="Path to process list file, %s will be replaced with the value of $MAGAOX_ROLE (or an empty string if absent from the environment)")
+    logdump_exe : str = xconf.field(default="/opt/MagAOX/bin/logdump", help="logdump (a.k.a. teldump) executable to use")
+
+class dbIngest(XDevice):
+    config : dbIngestConfig
+    telem_threads : list[tuple[str, threading.Thread]]
+    telem_queue : queue.Queue
+    fs_observer : BaseObserverSubclassCallable
+    fs_queue : queue.Queue
+    last_update_ts_sec : float
+    startup_ts_sec : float
+    records_since_startup : float
+    _connections : dict[str, psycopg.Connection]
+    _connections_to_attempt : set[str]
+
+    #add user_log support here
+    user_log_threads : list[tuple[str, threading.Thread]]
+    user_log_queue : queue.Queue
+
+    def launch_followers(self, dev):
+        telem_args = self.log.name + '.' + dev, '/opt/MagAOX/telem', (self.config.logdump_exe, '--ext=.bintel'), dev, self.telem_queue, Telem
+        telem_thread = threading.Thread(target=_run_logdump_thread, args=telem_args, daemon=True)
+        telem_thread.start()
+        self.log.debug(f"Watching {dev} for incoming telem")
+        self.telem_threads.append((dev, telem_thread))
+
+        if dev == "observers":
+            ULog_args = self.log.name + '.' + dev, '/opt/MagAOX/logs', (self.config.logdump_exe, '--ext=.binlog'), dev, self.user_log_queue, UserLog
+            user_log_thread = threading.Thread(target=_run_logdump_thread, args= ULog_args, daemon=True)
+            user_log_thread.start()
+            self.log.debug(f"Watching {dev} for incoming user logs")
+            self.user_log_threads.append((dev, user_log_thread))
+
+    def refresh_properties(self):
+        self.properties['last_update']['timestamp'] = self.last_update_ts_sec
+        self.update_property(self.properties['last_update'])
+        self.properties['records']['since_startup'] = self.records_since_startup
+        self.properties['records']['per_sec'] = self.records_since_startup / (time.time() - self.startup_ts_sec)
+        self.update_property(self.properties['records'])
+
+    def setup(self):
+        self.last_update_ts_sec = time.time()
+        self._connections = {}
+        self._connections_to_attempt = set(self.config.databases.keys())
+        self.records_since_startup = 0
+        self.records_per_sec = 0.0
+        last_update = properties.NumberVector(name="last_update", perm=constants.PropertyPerm.READ_ONLY)
+        last_update.add_element(DefNumber(
+            name="timestamp",
+            _value=self.last_update_ts_sec,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        self.add_property(last_update)
+
+        records = properties.NumberVector(name="records", perm=constants.PropertyPerm.READ_ONLY)
+        records.add_element(DefNumber(
+            name="per_sec",
+            _value=0.0,
+            min=0.0, max=1e200, format='%f',
+            step=1e-6,
+        ))
+        records.add_element(DefNumber(
+            name="since_startup",
+            _value=0,
+            min=0, max=1_000_000_000, format='%i',
+            step=1,
+        ))
+        self.add_property(records)
+
+        role = os.environ.get('MAGAOX_ROLE', '')
+        proclist = pathlib.Path(self.config.proclist.replace('%s', role))
+        if not proclist.exists():
+            raise RuntimeError(f"No process list at {proclist}")
+
+        device_names = set()
+
+        with proclist.open() as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                if line.strip()[0] == '#':
+                    continue
+                parts = line.split(None, 1)
+                if len(parts) != 2:
+                    raise RuntimeError(f"Got malformed proclist line: {repr(line)}")
+                device_names.add(parts[0])
+
+        self.user_log_queue = queue.Queue()
+        self.user_log_threads = []
+
+        self.telem_queue = queue.Queue()
+        self.telem_threads = []
+        for dev in device_names:
+            self.launch_followers(dev)
+
+        self.startup_ts_sec = time.time()
+
+        # rescan for inventory
+        self.rescan_files()
+
+        self.fs_queue = queue.Queue()
+        event_handler = NewXFilesHandler(self.config.hostname, self.fs_queue, self.log.name + '.fs_observer')
+        self.fs_observer = Observer()
+        for dirname in self.config.data_dirs:
+            dirpath = self.config.common_path_prefix / dirname
+            if not dirpath.exists():
+                self.log.debug(f"No {dirpath} to watch")
+                continue
+            self.fs_observer.schedule(event_handler, dirpath, recursive=True)
+            self.log.info(f"Watching {dirpath} for changes")
+        self.fs_observer.start()
+
+
+    def rescan_files(self):
+        search_paths = [self.config.common_path_prefix / name for name in self.config.data_dirs]
+        for conn in self.config.databases:
+            try:
+                with self.config.databases[conn].cursor() as cur:
+                    # n.b. the state of the file inventory and which files
+                    # are 'new' can be different depending on which
+                    # database we're talking about, so we rescan once
+                    # per connection
+                    self.log.debug(f"Scanning for new files for database {conn}")
+                    ingest.update_file_inventory(
+                        cur,
+                        self.config.hostname,
+                        search_paths,
+                        self.config.ignore_patterns.files, self.config.ignore_patterns.directories
+                    )
+            except Exception:
+                self.log.exception(f"Failed to rescan/inventory files for database {conn}, attempting to reconnect")
+                self._connections_to_attempt.add(conn)
+        self.log.info(f"Completed startup rescan of file inventory for {self.config.hostname} from {search_paths}")
+
+    def loop(self):
+        connections_to_reattempt = set()
+        if len(self._connections_to_attempt):
+            for configkey in self._connections_to_attempt:
+                try:
+                    self._connections[configkey].close()
+                except Exception:
+                    pass
+                try:
+                    self._connections[configkey] = self.config.databases[configkey].connect()
+                    connections_to_reattempt.add(configkey)
+                except Exception:
+                    self.log.exception(f"Failed to connect to {configkey} ({self.config.databases[configkey]})")
+            self._connections_to_attempt = connections_to_reattempt
+
+        telems = []
+        try:
+            while rec := self.telem_queue.get(timeout=0.1):
+                telems.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        fs_events = []
+        try:
+            while rec := self.fs_queue.get(timeout=0.1):
+                fs_events.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        #update for userlog here too
+        user_logs = []
+        try:
+            while rec := self.user_log_queue.get(timeout=0.1):
+                user_logs.append(rec)
+                self.records_since_startup += 1
+        except queue.Empty:
+            pass
+
+        for connkey in self._connections:
+            try:
+                self.log.debug(f"Batching ingest for {connkey}")
+                conn = self._connections[connkey]
+                with conn.transaction():
+                    cur = conn.cursor()
+                    ingest.batch_telem(cur, telems)
+                    ingest.batch_file_origins(cur, fs_events)
+                    ingest.batch_user_log(cur, user_logs)
+            except Exception as e:
+                self.log.exception(f"Caught exception in batch ingest, reconnecting {conn} on next loop()")
+                self._connections_to_attempt.add(conn)
+
+        this_ts_sec = time.time()
+        self.last_update_ts_sec = this_ts_sec
+        self.refresh_properties()
+
+main = dbIngest.console_app

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -552,10 +552,10 @@ int picamCtrl::appStartup()
    m_indiP_fxngensync_freq.setName( m_fxngenCh + "freq" );
    m_indiP_fxngensync_freq.add( pcf::IndiElement( "target" ) );
 
-   m_indiP_fxngensync_output = pcf::IndiProperty( pcf::IndiProperty::Text );
+   m_indiP_fxngensync_output = pcf::IndiProperty( pcf::IndiProperty::Switch );
    m_indiP_fxngensync_output.setDevice( m_fxngenName );
    m_indiP_fxngensync_output.setName( m_fxngenCh + "outp" );
-   m_indiP_fxngensync_output.add( pcf::IndiElement( "value" ) );
+   m_indiP_fxngensync_output.add( pcf::IndiElement( "toggle" ) );
 
 
    CREATE_REG_INDI_NEW_NUMBERD(m_indiP_receiveExptime, "receiveExptime", m_minExpTime, m_maxExpTime, m_stepExpTime, "%0.3f", "Exptime", "Other cam");
@@ -1322,7 +1322,7 @@ void picamCtrl::updateFxnGenSync()
    sendNewProperty(m_indiP_fxngensync_freq);
 
    // make sure fxngen is on!
-   m_indiP_fxngensync_output["value"] = "On";
+   m_indiP_fxngensync_output["toggle"] = pcf::IndiElement::On;
    sendNewProperty(m_indiP_fxngensync_output);
 }
 

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -26,9 +26,11 @@ namespace app
 class siglentSDG : public MagAOXApp<>, public dev::telemeter<siglentSDG>
 {
 
-    friend class siglentSDG_test;
+   friend class siglentSDG_test;
 
    friend class dev::telemeter<siglentSDG>;
+
+   typedef dev::telemeter<siglentSDG> telemeterT;
 
    //constexpr static double cs_MaxAmp = 0.87;//2.1;//0.87;
    constexpr static double cs_MaxOfst = 10.0;
@@ -113,6 +115,12 @@ public:
 
    /// Setup the configuration system (called by MagAOXApp::setup())
    virtual void setupConfig();
+
+    /// Implementation of loadConfig logic, separated for testing.
+    /** This is called by loadConfig().
+     */
+    int loadConfigImpl(
+        mx::app::appConfigurator &_config /**< [in] an application configuration from which to load values*/ );
 
    /// load the configuration system results (called by MagAOXApp::setup())
    virtual void loadConfig();
@@ -234,7 +242,7 @@ public:
      * \returns -1 on error.
      */
    int changeOutp( int channel,                ///< [in] the channel to send the command to.
-                   const std::string & newOutp ///< [in] The requested output state [On/Off]
+                   bool newOutp ///< [in] The requested output state [On/Off]
                  );
 
    /// Change the output status (on/off) of one channel in response to an INDI property. This locks the mutex.
@@ -474,34 +482,42 @@ void siglentSDG::setupConfig()
    config.add("fxngen.C1ampMax", "", "fxngen.C1ampMax", argType::Required, "fxngen", "C1ampMax", false, "float", "C1 Maximum amplitude");
    config.add("fxngen.C2ampMax", "", "fxngen.C2ampMax", argType::Required, "fxngen", "C2ampMax", false, "float", "C2 Maximum amplitude");
 
-   dev::telemeter<siglentSDG>::setupConfig(config);
+   TELEMETER_SETUP_CONFIG(config);
+}
+
+inline
+int siglentSDG::loadConfigImpl(mx::app::appConfigurator &_config )
+{
+   _config(m_deviceAddr, "device.address");
+   _config(m_devicePort, "device.port");
+
+   _config(m_writeTimeOut, "timeouts.write");
+   _config(m_readTimeOut, "timeouts.read");
+
+   _config(m_waveform, "fxngen.waveform"); // todo: check if this is a valid waveform?
+   _config(m_C1outpOn, "fxngen.C1outpOn");
+   _config(m_C2outpOn, "fxngen.C2outpOn");
+
+   _config(m_C1vppDefault, "fxngen.C1ampDefault");
+   _config(m_C2vppDefault, "fxngen.C2ampDefault");
+
+   _config(m_C1ofst, "fxngen.C1ofstDefault");
+   _config(m_C2ofst, "fxngen.C2ofstDefault");
+
+   _config(m_C1ampMax, "fxngen.C1ampMax");
+   _config(m_C2ampMax, "fxngen.C2ampMax");
+
+   TELEMETER_LOAD_CONFIG(_config);
+
+   return 0;
 }
 
 inline
 void siglentSDG::loadConfig()
 {
-   config(m_deviceAddr, "device.address");
-   config(m_devicePort, "device.port");
-
-   config(m_writeTimeOut, "timeouts.write");
-   config(m_readTimeOut, "timeouts.read");
-
-   config(m_waveform, "fxngen.waveform"); // todo: check if this is a valid waveform?
-   config(m_C1outpOn, "fxngen.C1outpOn");
-   config(m_C2outpOn, "fxngen.C2outpOn");
-
-   config(m_C1vppDefault, "fxngen.C1ampDefault");
-   config(m_C2vppDefault, "fxngen.C2ampDefault");
-
-   config(m_C1ofst, "fxngen.C1ofstDefault");
-   config(m_C2ofst, "fxngen.C2ofstDefault");
-
-   config(m_C1ampMax, "fxngen.C1ampMax");
-   config(m_C2ampMax, "fxngen.C2ampMax");
-   /// config(m_clock, "fxngen.clock");
-
-   dev::telemeter<siglentSDG>::loadConfig(config);
+   loadConfigImpl( config );
 }
+
 
 inline
 int siglentSDG::appStartup()
@@ -890,11 +906,7 @@ int siglentSDG::appLogic()
          recordParams(); //This will check if anything changed.
       }
 
-      if(telemeter<siglentSDG>::appLogic() < 0)
-      {
-         log<software_error>({__FILE__, __LINE__});
-         return 0;
-      }
+      TELEMETER_APP_LOGIC;
 
       return 0;
 
@@ -992,7 +1004,7 @@ int siglentSDG::whilePowerOff()
 inline
 int siglentSDG::appShutdown()
 {
-   dev::telemeter<siglentSDG>::appShutdown();
+   TELEMETER_APP_SHUTDOWN;
 
    return 0;
 }
@@ -1067,12 +1079,7 @@ std::string makeCommand( int channel,
                          const std::string & afterColon
                        )
 {
-   std::string command = "C";
-   command += mx::ioutils::convertToString<int>(channel);
-   command += ":";
-   command += afterColon;
-   command += "\r\n";
-
+   std::string command = std::format("C{}:{}\r\n", channel, afterColon);
    return command;
 }
 
@@ -1093,7 +1100,7 @@ int siglentSDG::queryMDWV( std::string & state,
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on MDWV? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on MDWV? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1138,7 +1145,7 @@ int siglentSDG::querySWWV( std::string & state,
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on SWWV? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on SWWV? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1183,7 +1190,7 @@ int siglentSDG::queryBTWV( std::string & state,
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on BTWV? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on BTWV? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1228,7 +1235,7 @@ int siglentSDG::queryARWV( int & index,
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on ARWV? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on ARWV? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1271,7 +1278,7 @@ int siglentSDG::queryBSWV( int channel)
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on BSWV? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on BSWV? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1366,7 +1373,7 @@ int siglentSDG::querySYNC( bool & sync,
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on SYNC? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on SYNC? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1409,7 +1416,7 @@ int siglentSDG::queryOUTP( int channel )
 
    if(rv < 0)
    {
-      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>("Error on OUTP? for channel " + mx::ioutils::convertToString<int>(channel), logPrio::LOG_ERROR);
+      if((m_powerState != 1 || m_powerTargetState != 1) && !m_shutdown) log<text_log>(std::format("Error on OUTP? for channel {}", channel), logPrio::LOG_ERROR);
       return -1;
    }
 
@@ -1712,7 +1719,7 @@ int siglentSDG::changeOutp( int channel,
    std::string afterColon = "OUTP " + no;
    std::string command = makeCommand(channel, afterColon);
 
-   log<text_log>("Ch. " + std::to_string(channel) + " OUTP to " + newOutp, logPrio::LOG_NOTICE);
+   log<text_log>("Ch. " + std::to_string(channel) + " OUTP to " + no, logPrio::LOG_NOTICE);
 
    recordParams(true);
    int rv = writeCommand(command);
@@ -1744,7 +1751,7 @@ int siglentSDG::changeOutp( int channel,
 
    if(state() != stateCodes::READY && state() != stateCodes::OPERATING) return 0;
 
-   bool output = ipRecv["toggle"].getSwitchState() == pcf::IndiElement:On;
+   bool output = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -1767,14 +1774,14 @@ int siglentSDG::changeFreq( int channel,
 {
    if(channel < 1 || channel > 2) return -1;
 
-   newFreq = std::clamp(newFreq, 0, m_maxFreq.back());
+   newFreq = std::clamp(newFreq, 0.0, m_maxFreq.back());
 
    if(m_waveform == "SINE"){
       // Limit amp for SINE waves
 
       double amp = (channel == 1) ? m_C1vpp_tgt : m_C2vpp_tgt;
 
-      size_t i =0
+      size_t i = 0;
       while( i < m_ampMax.size())
       {
          if(m_maxFreq[i] >= newFreq) break;
@@ -1802,7 +1809,7 @@ int siglentSDG::changeFreq( int channel,
    }
 
 
-   std::string afterColon = "BSWV FRQ," + mx::ioutils::convertToString<double>(newFreq);
+   std::string afterColon = std::format("BSWV FRQ,{}", newFreq);
    std::string command = makeCommand(channel, afterColon);
 
    log<text_log>("Ch. " + std::to_string(channel) + " FREQ to " + std::to_string(newFreq), logPrio::LOG_NOTICE);
@@ -1949,7 +1956,7 @@ int siglentSDG::changeAmp( int channel,
    }
 
 
-   std::string afterColon = "BSWV AMP," + mx::ioutils::convertToString<double>(newAmp);
+   std::string afterColon = std::format("BSWV AMP,{}", newAmp);
    std::string command = makeCommand(channel, afterColon);
 
    log<text_log>("Ch. " + std::to_string(channel) + " AMP set to " + std::to_string(newAmp), logPrio::LOG_NOTICE);
@@ -2042,7 +2049,7 @@ int siglentSDG::changeOfst( int channel,
       log<text_log>("Ch. " + std::to_string(channel) + " OFST min-limited to " + std::to_string(newOfst), logPrio::LOG_WARNING);
    }
 
-   std::string afterColon = "BSWV OFST," + mx::ioutils::convertToString<double>(newOfst);
+   std::string afterColon = std::format("BSWV OFST,{}", newOfst);
    std::string command = makeCommand(channel, afterColon);
 
    log<text_log>("Ch. " + std::to_string(channel) + " OFST set to " + std::to_string(newOfst), logPrio::LOG_NOTICE);
@@ -2107,7 +2114,7 @@ int siglentSDG::changePhse( int channel,
       return 0;
    }
 
-   std::string afterColon = "BSWV PHSE," + mx::ioutils::convertToString<double>(newPhse);
+   std::string afterColon = std::format("BSWV PHSE,{}", newPhse);
    std::string command = makeCommand(channel, afterColon);
 
    log<text_log>("Ch. " + std::to_string(channel) + " PHSE to " + std::to_string(newPhse), logPrio::LOG_NOTICE);
@@ -2172,7 +2179,7 @@ int siglentSDG::changeWdth( int channel,
       return 0;
    }
 
-   std::string afterColon = "BSWV WIDTH," + mx::ioutils::convertToString<double>(newWdth);
+   std::string afterColon = std::format("BSWV WIDTH,{}", newWdth);
    std::string command = makeCommand(channel, afterColon);
 
    log<text_log>("Ch. " + std::to_string(channel) + " WDTH to " + std::to_string(newWdth), logPrio::LOG_NOTICE);

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -506,26 +506,24 @@ void siglentSDG::loadConfig()
 inline
 int siglentSDG::appStartup()
 {
-    // set up the  INDI properties
-    REG_INDI_NEWPROP_NOCB(m_indiP_status, "status", pcf::IndiProperty::Text);
-    m_indiP_status.add (pcf::IndiElement("value"));
-    m_indiP_status["value"].set(0);
+   // set up the  INDI properties
+   REG_INDI_NEWPROP_NOCB(m_indiP_status, "status", pcf::IndiProperty::Text);
+   m_indiP_status.add (pcf::IndiElement("value"));
+   m_indiP_status["value"].set(0);
 
-    REG_INDI_NEWPROP(m_indiP_C1outp, "C1outp", pcf::IndiProperty::Text);
-    m_indiP_C1outp.add (pcf::IndiElement("value"));
-    m_indiP_C1outp["value"].set("");
+   CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C1outp, "C1outp");
 
-    //REG_INDI_NEWPROP(m_indiP_C1freq, "C1freq", pcf::IndiProperty::Number);
-    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1freq, "C1freq", -1e15, 1e15, 1, "%g", "C1freq", "C1freq");
-    //m_indiP_C1freq.add (pcf::IndiElement("value"));
-    m_indiP_C1freq["current"].set(0);
-    m_indiP_C1freq["target"].set(0);
+   //REG_INDI_NEWPROP(m_indiP_C1freq, "C1freq", pcf::IndiProperty::Number);
+   CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1freq, "C1freq", -1e15, 1e15, 1, "%g", "C1freq", "C1freq");
+   //m_indiP_C1freq.add (pcf::IndiElement("value"));
+   m_indiP_C1freq["current"].set(0);
+   m_indiP_C1freq["target"].set(0);
 
-    //REG_INDI_NEWPROP(m_indiP_C1amp, "C1amp", pcf::IndiProperty::Number);
-    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1amp, "C1amp", -1e15, 1e15, 1, "%g", "C1amp", "C1amp");
-    //m_indiP_C1amp.add (pcf::IndiElement("value"));
-    m_indiP_C1amp["current"].set(0);
-    m_indiP_C1amp["target"].set(0);
+   //REG_INDI_NEWPROP(m_indiP_C1amp, "C1amp", pcf::IndiProperty::Number);
+   CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1amp, "C1amp", -1e15, 1e15, 1, "%g", "C1amp", "C1amp");
+   //m_indiP_C1amp.add (pcf::IndiElement("value"));
+   m_indiP_C1amp["current"].set(0);
+   m_indiP_C1amp["target"].set(0);
 
    REG_INDI_NEWPROP(m_indiP_C1ofst, "C1ofst", pcf::IndiProperty::Number);
    m_indiP_C1ofst.add (pcf::IndiElement("value"));
@@ -563,16 +561,10 @@ int siglentSDG::appStartup()
    m_indiP_C1llev.add (pcf::IndiElement("value"));
    m_indiP_C1llev["value"].set(0);
 
-   createStandardIndiToggleSw( m_indiP_C1sync, "C1synchro", "C1 Sync Output", "C1 Sync Output");
-   if(registerIndiPropertyNew( m_indiP_C1sync, st_newCallBack_m_indiP_C1sync) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
 
-   REG_INDI_NEWPROP(m_indiP_C2outp, "C2outp", pcf::IndiProperty::Text);
-   m_indiP_C2outp.add (pcf::IndiElement("value"));
-   m_indiP_C2outp["value"].set("");
+   CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C1sync, "C1synchro");
+
+   CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C2outp, "C2outp");
 
    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C2freq, "C2freq", -1e15, 1e15, 1, "%g", "C2freq", "C2freq");
    m_indiP_C2freq["current"].set(0);
@@ -620,17 +612,10 @@ int siglentSDG::appStartup()
    m_indiP_C2llev.add (pcf::IndiElement("value"));
    m_indiP_C2llev["value"].set(0);
 
-   createStandardIndiToggleSw( m_indiP_C2sync, "C2synchro", "C2 Sync Output", "C2 Sync Output");
-   if(registerIndiPropertyNew( m_indiP_C2sync, st_newCallBack_m_indiP_C2sync) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
 
-   if(dev::telemeter<siglentSDG>::appStartup() < 0)
-   {
-      return log<software_error,-1>({__FILE__,__LINE__});
-   }
+   CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C2sync, "C2synchro");
+
+   TELEMETER_APP_STARTUP;
 
    return 0;
 }
@@ -969,7 +954,7 @@ int siglentSDG::onPowerOff()
    updateIfChanged(m_indiP_C1llev, "value", 0.0);
    if(m_waveform == "SINE"){updateIfChanged(m_indiP_C1phse, "value", 0.0);}
    if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C1wdth, "value", 0.0);}
-   updateIfChanged(m_indiP_C1outp, "value", std::string("Off"));
+   updateSwitchIfChanged(m_indiP_C1outp, "toggle", pcf::IndiElement::Off, INDI_IDLE);
    updateSwitchIfChanged(m_indiP_C1sync, "toggle", pcf::IndiElement::Off, INDI_IDLE);
 
 
@@ -998,7 +983,7 @@ int siglentSDG::onPowerOff()
    updateIfChanged(m_indiP_C2llev, "value", 0.0);
    if(m_waveform == "SINE"){updateIfChanged(m_indiP_C2phse, "value", 0.0);}
    if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C2wdth, "value", 0.0);}
-   updateIfChanged(m_indiP_C1outp, "value", std::string("Off"));
+   updateSwitchIfChanged(m_indiP_C2outp, "toggle", pcf::IndiElement::Off, INDI_IDLE);ç
    updateSwitchIfChanged(m_indiP_C2sync, "toggle", pcf::IndiElement::Off, INDI_IDLE);
 
    return 0;
@@ -1450,22 +1435,34 @@ int siglentSDG::queryOUTP( int channel )
       }
 
       std::string ro;
-      if(resp_output > 0) ro = "On";
-      else if(resp_output == 0 ) ro = "Off";
-      else ro = "UNK";
+      pcf::IndiElement ro_indi;
+      if(resp_output > 0)
+      {
+         ro = "On";
+         ro_indi = pcf::IndiElement::On;
+      } 
+      else if(resp_output == 0 )
+      {  
+         ro = "Off";
+         ro_indi = pcf::IndiElement::Off;
+      }
+      else
+      {
+         ro = "UNK";
+      }
 
       if(channel == 1)
       {
          m_C1outp = resp_output;
          recordParams();
-         updateIfChanged(m_indiP_C1outp, "value", ro);
+         updateSwitchIfChanged(m_indiP_C1outp, "toggle", ro_indi, INDI_IDLE);
       }
 
       else if(channel == 2)
       {
          m_C2outp = resp_output;
          recordParams();
-         updateIfChanged(m_indiP_C2outp, "value", ro);
+         updateSwitchIfChanged(m_indiP_C2outp, "toggle", ro_indi, INDI_IDLE);
       }
    }
    else
@@ -1713,20 +1710,12 @@ int siglentSDG::normalizeSetup()
 
 inline
 int siglentSDG::changeOutp( int channel,
-                            const std::string & newOutp
+                            bool newOutp
                           )
 {
    if(channel < 1 || channel > 2) return -1;
 
-   std::string no;
-
-   if(newOutp == "Off" || newOutp == "OFF" || newOutp == "off") no = "OFF";
-   else if(newOutp == "On" || newOutp == "ON" || newOutp == "on") no = "ON";
-   else
-   {
-      log<software_error>({__FILE__, __LINE__, "Invalid OUTP spec: " + newOutp});
-      return -1;
-   }
+   std::string no = newOutp ? "ON" : "OFF";
 
    std::string afterColon = "OUTP " + no;
    std::string command = makeCommand(channel, afterColon);
@@ -1763,16 +1752,7 @@ int siglentSDG::changeOutp( int channel,
 
    if(state() != stateCodes::READY && state() != stateCodes::OPERATING) return 0;
 
-   std::string newOutp;
-   try
-   {
-      newOutp = ipRecv["value"].get<std::string>();
-   }
-   catch(...)
-   {
-      log<software_error>({__FILE__, __LINE__, "Exception caught."});
-      return -1;
-   }
+   bool output = ipRecv["toggle"].getSwitchState() == pcf::IndiElement:On;
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -1780,7 +1760,7 @@ int siglentSDG::changeOutp( int channel,
    stateCodes::stateCodeT enterState = state();
    state(stateCodes::CONFIGURING);
 
-   int rv = changeOutp(channel, newOutp);
+   int rv = changeOutp(channel, output);
    if(rv < 0) log<software_error>({__FILE__, __LINE__});
 
    state(enterState);

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -513,15 +513,11 @@ int siglentSDG::appStartup()
 
    CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C1outp, "C1outp");
 
-   //REG_INDI_NEWPROP(m_indiP_C1freq, "C1freq", pcf::IndiProperty::Number);
    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1freq, "C1freq", -1e15, 1e15, 1, "%g", "C1freq", "C1freq");
-   //m_indiP_C1freq.add (pcf::IndiElement("value"));
    m_indiP_C1freq["current"].set(0);
    m_indiP_C1freq["target"].set(0);
 
-   //REG_INDI_NEWPROP(m_indiP_C1amp, "C1amp", pcf::IndiProperty::Number);
    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C1amp, "C1amp", -1e15, 1e15, 1, "%g", "C1amp", "C1amp");
-   //m_indiP_C1amp.add (pcf::IndiElement("value"));
    m_indiP_C1amp["current"].set(0);
    m_indiP_C1amp["target"].set(0);
 
@@ -534,16 +530,16 @@ int siglentSDG::appStartup()
       m_indiP_C1phse.add (pcf::IndiElement("value"));
       m_indiP_C1phse["value"].set(0);
    }
-
-   if(m_waveform == "PULSE"){
+   else if(m_waveform == "PULSE")
+   {
       REG_INDI_NEWPROP(m_indiP_C1wdth, "C1wdth", pcf::IndiProperty::Number);
       m_indiP_C1wdth.add (pcf::IndiElement("value"));
       m_indiP_C1wdth["value"].set(0);
    }
 
-   REG_INDI_NEWPROP(m_indiP_C1wvtp, "C1wvtp", pcf::IndiProperty::Text);
-   m_indiP_C1wvtp.add (pcf::IndiElement("value"));
-   m_indiP_C1wvtp["value"].set("");
+   CREATE_REG_INDI_NEW_TEXT(m_indiP_C1wvtp, "C1wvtp", "C1wvtp", "C1wvtp");
+   m_indiP_C1wvtp["current"].set("");
+   m_indiP_C1wvtp["target"].set("");
 
    REG_INDI_NEWPROP_NOCB(m_indiP_C1peri, "C1peri", pcf::IndiProperty::Number);
    m_indiP_C1peri.add (pcf::IndiElement("value"));
@@ -561,9 +557,9 @@ int siglentSDG::appStartup()
    m_indiP_C1llev.add (pcf::IndiElement("value"));
    m_indiP_C1llev["value"].set(0);
 
-
    CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C1sync, "C1synchro");
 
+   /* Channel 2 */
    CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C2outp, "C2outp");
 
    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_C2freq, "C2freq", -1e15, 1e15, 1, "%g", "C2freq", "C2freq");
@@ -578,23 +574,21 @@ int siglentSDG::appStartup()
    m_indiP_C2ofst.add (pcf::IndiElement("value"));
    m_indiP_C2ofst["value"].set(0);
 
-   if(m_waveform == "SINE")
-   {
+   if(m_waveform == "SINE"){
       REG_INDI_NEWPROP(m_indiP_C2phse, "C2phse", pcf::IndiProperty::Number);
       m_indiP_C2phse.add (pcf::IndiElement("value"));
       m_indiP_C2phse["value"].set(0);
    }
-
-   if(m_waveform == "PULSE")
+   else if(m_waveform == "PULSE")
    {
       REG_INDI_NEWPROP(m_indiP_C2wdth, "C2wdth", pcf::IndiProperty::Number);
       m_indiP_C2wdth.add (pcf::IndiElement("value"));
       m_indiP_C2wdth["value"].set(0);
    }
 
-   REG_INDI_NEWPROP(m_indiP_C2wvtp, "C2wvtp", pcf::IndiProperty::Text);
-   m_indiP_C2wvtp.add (pcf::IndiElement("value"));
-   m_indiP_C2wvtp["value"].set("");
+   CREATE_REG_INDI_NEW_TEXT(m_indiP_C2wvtp, "C2wvtp", "C2wvtp", "C2wvtp");
+   m_indiP_C2wvtp["current"].set("");
+   m_indiP_C2wvtp["target"].set("");
 
    REG_INDI_NEWPROP_NOCB(m_indiP_C2peri, "C2peri", pcf::IndiProperty::Number);
    m_indiP_C2peri.add (pcf::IndiElement("value"));
@@ -612,8 +606,8 @@ int siglentSDG::appStartup()
    m_indiP_C2llev.add (pcf::IndiElement("value"));
    m_indiP_C2llev["value"].set(0);
 
-
    CREATE_REG_INDI_NEW_TOGGLESWITCH(m_indiP_C2sync, "C2synchro");
+
 
    TELEMETER_APP_STARTUP;
 
@@ -938,22 +932,22 @@ int siglentSDG::onPowerOff()
    m_C1frequency_tgt = -1;
    m_C1vpp_tgt = -1;
 
-   updateIfChanged(m_indiP_C1wvtp, "value", m_C1wvtp);
-
-   updateIfChanged(m_indiP_C1freq, "current", 0.0);
-   updateIfChanged(m_indiP_C1freq, "target", 0.0);
-
-   updateIfChanged(m_indiP_C1peri, "value", 0.0);
-
-   updateIfChanged(m_indiP_C1amp, "current", 0.0);
-   updateIfChanged(m_indiP_C1amp, "target", 0.0);
-
+   updatesIfChanged<std::string>(m_indiP_C1wvtp, {"current", "target"}, {m_C1wvtp, m_C1wvtp});
+   updatesIfChanged<double>(m_indiP_C1freq, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C1peri, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C1amp, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C1ofst, {"current", "target"}, {0.0, 0.0});
    updateIfChanged(m_indiP_C1ampvrms, "value", 0.0);
-   updateIfChanged(m_indiP_C1ofst, "value", 0.0);
    updateIfChanged(m_indiP_C1hlev, "value", 0.0);
    updateIfChanged(m_indiP_C1llev, "value", 0.0);
-   if(m_waveform == "SINE"){updateIfChanged(m_indiP_C1phse, "value", 0.0);}
-   if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C1wdth, "value", 0.0);}
+   if(m_waveform == "SINE")
+   {
+      updatesIfChanged<double>(m_indiP_C1phse, {"current", "target"}, {0.0, 0.0});
+   }
+   else if(m_waveform == "PULSE")
+   {
+      updatesIfChanged<double>(m_indiP_C1wdth, {"current", "target"}, {0.0, 0.0});
+   }
    updateSwitchIfChanged(m_indiP_C1outp, "toggle", pcf::IndiElement::Off, INDI_IDLE);
    updateSwitchIfChanged(m_indiP_C1sync, "toggle", pcf::IndiElement::Off, INDI_IDLE);
 
@@ -967,23 +961,23 @@ int siglentSDG::onPowerOff()
    m_C2frequency_tgt = -1;
    m_C2vpp_tgt = -1;
 
-   updateIfChanged(m_indiP_C2wvtp, "value", m_C2wvtp);
-
-   updateIfChanged(m_indiP_C2freq, "current", 0.0);
-   updateIfChanged(m_indiP_C2freq, "target", 0.0);
-
-   updateIfChanged(m_indiP_C2peri, "value", 0.0);
-
-   updateIfChanged(m_indiP_C2amp, "current", 0.0);
-   updateIfChanged(m_indiP_C2amp, "target", 0.0);
-
+   updatesIfChanged<std::string>(m_indiP_C2wvtp,{"current", "target"}, {m_C2wvtp, m_C2wvtp});
+   updatesIfChanged<double>(m_indiP_C2freq, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C2peri, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C2amp, {"current", "target"}, {0.0, 0.0});
+   updatesIfChanged<double>(m_indiP_C2ofst, {"current", "target"}, {0.0, 0.0});
    updateIfChanged(m_indiP_C2ampvrms, "value", 0.0);
-   updateIfChanged(m_indiP_C2ofst, "value", 0.0);
    updateIfChanged(m_indiP_C2hlev, "value", 0.0);
    updateIfChanged(m_indiP_C2llev, "value", 0.0);
-   if(m_waveform == "SINE"){updateIfChanged(m_indiP_C2phse, "value", 0.0);}
-   if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C2wdth, "value", 0.0);}
-   updateSwitchIfChanged(m_indiP_C2outp, "toggle", pcf::IndiElement::Off, INDI_IDLE);ç
+   if(m_waveform == "SINE")
+   {
+      updatesIfChanged<double>(m_indiP_C2phse, {"current", "target"}, {0.0, 0.0});
+   }
+   else if(m_waveform == "PULSE")
+   {
+      updatesIfChanged<double>(m_indiP_C2wdth, {"current", "target"}, {0.0, 0.0});
+   }
+   updateSwitchIfChanged(m_indiP_C2outp, "toggle", pcf::IndiElement::Off, INDI_IDLE);
    updateSwitchIfChanged(m_indiP_C2sync, "toggle", pcf::IndiElement::Off, INDI_IDLE);
 
    return 0;
@@ -1309,18 +1303,16 @@ int siglentSDG::queryBSWV( int channel)
 
          recordParams();
 
-         updateIfChanged(m_indiP_C1wvtp, "value", resp_wvtp);
+         updateIfChanged(m_indiP_C1wvtp, "current", resp_wvtp);
          updateIfChanged(m_indiP_C1freq, "current", resp_freq);
-         updateIfChanged(m_indiP_C1peri, "value", resp_peri);
-
+         updateIfChanged(m_indiP_C1peri, "current", resp_peri);
          updateIfChanged(m_indiP_C1amp, "current", resp_amp);
-
+         updateIfChanged(m_indiP_C1ofst, "current", resp_ofst);
          updateIfChanged(m_indiP_C1ampvrms, "value", resp_ampvrms);
-         updateIfChanged(m_indiP_C1ofst, "value", resp_ofst);
          updateIfChanged(m_indiP_C1hlev, "value", resp_hlev);
          updateIfChanged(m_indiP_C1llev, "value", resp_llev);
-         if(m_waveform == "SINE"){updateIfChanged(m_indiP_C1phse, "value", resp_phse);}
-         if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C1wdth, "value", resp_wdth);}
+         if(m_waveform == "SINE"){updateIfChanged(m_indiP_C1phse, "current", resp_phse);}
+         else if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C1wdth, "current", resp_wdth);}
       }
       else if(channel == 2)
       {
@@ -1336,16 +1328,16 @@ int siglentSDG::queryBSWV( int channel)
 
          recordParams();
 
-         updateIfChanged(m_indiP_C2wvtp, "value", resp_wvtp);
+         updateIfChanged(m_indiP_C2wvtp, "current", resp_wvtp);
          updateIfChanged(m_indiP_C2freq, "current", resp_freq);
-         updateIfChanged(m_indiP_C2peri, "value", resp_peri);
+         updateIfChanged(m_indiP_C2peri, "current", resp_peri);
          updateIfChanged(m_indiP_C2amp, "current", resp_amp);
+         updateIfChanged(m_indiP_C2ofst, "current", resp_ofst);
          updateIfChanged(m_indiP_C2ampvrms, "value", resp_ampvrms);
-         updateIfChanged(m_indiP_C2ofst, "value", resp_ofst);
          updateIfChanged(m_indiP_C2hlev, "value", resp_hlev);
          updateIfChanged(m_indiP_C2llev, "value", resp_llev);
-         if(m_waveform == "SINE"){updateIfChanged(m_indiP_C2phse, "value", resp_phse);}
-         if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C2wdth, "value", resp_wdth);}
+         if(m_waveform == "SINE"){updateIfChanged(m_indiP_C2phse, "current", resp_phse);}
+         else if(m_waveform == "PULSE"){updateIfChanged(m_indiP_C2wdth, "current", resp_wdth);}
       }
    }
    else
@@ -1440,9 +1432,9 @@ int siglentSDG::queryOUTP( int channel )
       {
          ro = "On";
          ro_indi = pcf::IndiElement::On;
-      } 
+      }
       else if(resp_output == 0 )
-      {  
+      {
          ro = "Off";
          ro_indi = pcf::IndiElement::Off;
       }
@@ -1775,23 +1767,14 @@ int siglentSDG::changeFreq( int channel,
 {
    if(channel < 1 || channel > 2) return -1;
 
-   if(newFreq > m_maxFreq.back())
-   {
-      newFreq = m_maxFreq.back();
-   }
+   newFreq = std::clamp(newFreq, 0, m_maxFreq.back());
 
-   if(newFreq < 0)
-   {
-      newFreq = 0;
-   }
+   if(m_waveform == "SINE"){
+      // Limit amp for SINE waves
 
-   if(m_waveform != "PULSE"){
-      // Do not limit amp if a PULSE wave
+      double amp = (channel == 1) ? m_C1vpp_tgt : m_C2vpp_tgt;
 
-      double amp = m_C1vpp_tgt;
-      if(channel == 2) amp = m_C2vpp_tgt;
-
-      size_t i =0;
+      size_t i =0
       while( i < m_ampMax.size())
       {
          if(m_maxFreq[i] >= newFreq) break;
@@ -1875,12 +1858,15 @@ int siglentSDG::changeFreq( int channel,
       return -1;
    }
 
+   if (channel==1) updateIfChanged(m_indiP_C1freq, "target", newFreq);
+   else updateIfChanged(m_indiP_C2freq, "target", newFreq);
+
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
    stateCodes::stateCodeT enterState = state();
    state(stateCodes::CONFIGURING);
 
-   int rv = changeFreq(channel,newFreq);
+   int rv = changeFreq(channel, newFreq);
    if(rv < 0) log<software_error>({__FILE__, __LINE__});
 
    state(enterState);
@@ -2001,6 +1987,9 @@ int siglentSDG::changeAmp( int channel,
       return -1;
    }
 
+   if (channel==1) updateIfChanged(m_indiP_C1amp, "target", newAmp);
+   else updateIfChanged(m_indiP_C2amp, "target", newAmp);
+
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
 
@@ -2081,13 +2070,16 @@ int siglentSDG::changeOfst( int channel,
    double newOfst;
    try
    {
-      newOfst = ipRecv["value"].get<double>();
+      newOfst = ipRecv["target"].get<double>();
    }
    catch(...)
    {
       log<software_error>({__FILE__, __LINE__, "Exception caught."});
       return -1;
    }
+
+   if (channel==1) updateIfChanged(m_indiP_C1ofst, "target", newOfst);
+   else updateIfChanged(m_indiP_C2ofst, "target", newOfst);
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -2143,13 +2135,16 @@ int siglentSDG::changePhse( int channel,
    double newPhse;
    try
    {
-      newPhse = ipRecv["value"].get<double>();
+      newPhse = ipRecv["target"].get<double>();
    }
    catch(...)
    {
       log<software_error>({__FILE__, __LINE__, "Exception caught."});
       return -1;
    }
+
+   if (channel==1) updateIfChanged(m_indiP_C1phse, "target", newPhse);
+   else updateIfChanged(m_indiP_C2phse, "target", newPhse);
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -2205,13 +2200,16 @@ int siglentSDG::changeWdth( int channel,
    double newWdth;
    try
    {
-      newWdth = ipRecv["value"].get<double>();
+      newWdth = ipRecv["target"].get<double>();
    }
    catch(...)
    {
       log<software_error>({__FILE__, __LINE__, "Exception caught."});
       return -1;
    }
+
+   if (channel==1) updateIfChanged(m_indiP_C1wdth, "target", newWdth);
+   else updateIfChanged(m_indiP_C2wdth, "target", newWdth);
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -2263,13 +2261,17 @@ int siglentSDG::changeWvtp( int channel,
    std::string newWvtp;
    try
    {
-      newWvtp = ipRecv["value"].get<std::string>();
+      newWvtp = ipRecv["target"].get<std::string>();
    }
    catch(...)
    {
       log<software_error>({__FILE__, __LINE__, "Exception caught."});
       return -1;
    }
+
+
+   if (channel==1) updateIfChanged(m_indiP_C1wvtp, "target", newWvtp);
+   else updateIfChanged(m_indiP_C2wvtp, "target", newWvtp);
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
@@ -2287,8 +2289,7 @@ int siglentSDG::changeWvtp( int channel,
 
 inline
 int siglentSDG::changeSync( int channel,
-                            const bool newSync
-                          )
+                            const bool newSync)
 {
    if(channel < 1 || channel > 2) return -1;
 
@@ -2327,15 +2328,7 @@ int siglentSDG::changeSync( int channel,
 
    if(!ipRecv.find("toggle")) return 0;
 
-   if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
-   {
-      newSync = false;
-   }
-
-   if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
-   {
-      newSync = true;
-   }
+   newSync = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
 
    //Make sure we don't change things while other things are being updated.
    std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.

--- a/apps/siglentSDG/siglentSDG_parsers.hpp
+++ b/apps/siglentSDG/siglentSDG_parsers.hpp
@@ -35,7 +35,7 @@ int parseOUTP( int & channel, ///< [out] the channel indicated by this response.
 
    if(v[0][0] != 'C') return -3;
    if(v[0].size() < 2) return -4;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v.size() < 3) return -5;
 
@@ -93,7 +93,7 @@ int parseBSWV( int & channel, ///< [out] the channel indicated by this response.
 
    if(v[0][0] != 'C') return -3;
    if(v[0].size() < 2) return -4;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] != "WVTP") return -5;
    wvtp = v[3];
@@ -106,7 +106,7 @@ int parseBSWV( int & channel, ///< [out] the channel indicated by this response.
 
       if(v[4] != "OFST") return -8;
 
-      ofst = mx::ioutils::convertFromString<double>(v[5]);
+      ofst = mx::ioutils::stoT<double>(v[5]);
 
       return 0;
    }
@@ -114,36 +114,36 @@ int parseBSWV( int & channel, ///< [out] the channel indicated by this response.
    if(v.size() < 20) return -9;
 
    if(v[4] != "FRQ") return -10;
-   freq = mx::ioutils::convertFromString<double>(v[5]);
+   freq = mx::ioutils::stoT<double>(v[5]);
 
    if(v[6] != "PERI") return -11;
-   peri = mx::ioutils::convertFromString<double>(v[7]);
+   peri = mx::ioutils::stoT<double>(v[7]);
 
    if(v[8] != "AMP") return -12;
-   amp = mx::ioutils::convertFromString<double>(v[9]);
+   amp = mx::ioutils::stoT<double>(v[9]);
 
    if(v[10] != "AMPVRMS") return -13;
-   ampvrms = mx::ioutils::convertFromString<double>(v[11]);
+   ampvrms = mx::ioutils::stoT<double>(v[11]);
 
    if(v[12] != "OFST") return -14;
-   ofst = mx::ioutils::convertFromString<double>(v[13]);
+   ofst = mx::ioutils::stoT<double>(v[13]);
 
    if(v[14] != "HLEV") return -15;
-   hlev = mx::ioutils::convertFromString<double>(v[15]);
+   hlev = mx::ioutils::stoT<double>(v[15]);
 
    if(v[16] != "LLEV") return -16;
-   llev = mx::ioutils::convertFromString<double>(v[17]);
+   llev = mx::ioutils::stoT<double>(v[17]);
 
    if(wvtp == "SINE")
    {
       if(v[18] != "PHSE") return -17;
-      phse = mx::ioutils::convertFromString<double>(v[19]);
+      phse = mx::ioutils::stoT<double>(v[19]);
    }
 
    if(wvtp == "PULSE")
    {
       if(v[20] != "WIDTH") return -18;
-      wdth = mx::ioutils::convertFromString<double>(v[21]);
+      wdth = mx::ioutils::stoT<double>(v[21]);
    }
 
    return 0;
@@ -175,7 +175,7 @@ int parseMDWV( int & channel, ///< [out] the channel indicated by this response.
    if(v[1] != "MDWV") return -2;
 
    if(v[0][0] != 'C') return -3;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] != "STATE") return -4;
    state = v[3];
@@ -209,7 +209,7 @@ int parseSWWV( int & channel, ///< [out] the channel indicated by this response.
    if(v[1] != "SWWV") return -2;
 
    if(v[0][0] != 'C') return -3;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] != "STATE") return -4;
    state = v[3];
@@ -243,7 +243,7 @@ int parseBTWV( int & channel, ///< [out] the channel indicated by this response.
    if(v[1] != "BTWV") return -2;
 
    if(v[0][0] != 'C') return -3;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] != "STATE") return -4;
    state = v[3];
@@ -277,10 +277,10 @@ int parseARWV( int & channel, ///< [out] the channel indicated by this response.
    if(v[1] != "ARWV") return -2;
 
    if(v[0][0] != 'C') return -3;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] != "INDEX") return -4;
-   index = mx::ioutils::convertFromString<int>(v[3]);
+   index = mx::ioutils::stoT<int>(v[3]);
 
    return 0;
 }
@@ -312,7 +312,7 @@ int parseSYNC( int & channel, ///< [out] the channel indicated by this response.
    if(v[1] != "SYNC") return -2;
 
    if(v[0][0] != 'C') return -3;
-   channel = mx::ioutils::convertFromString<int>(v[0].substr(1, v[0].size()-1));
+   channel = mx::ioutils::stoT<int>(v[0].substr(1, v[0].size()-1));
 
    if(v[2] == "ON")
    {

--- a/apps/ttmModulator/ttmModulator.hpp
+++ b/apps/ttmModulator/ttmModulator.hpp
@@ -574,12 +574,12 @@ int ttmModulator::restTTM()
    if( sendNewProperty(m_indiP_C2volts, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    //3) Set phase to 0
-   if( sendNewProperty(m_indiP_C1phse, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
-   if( sendNewProperty(m_indiP_C2phse, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C1phse, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C2phse, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    //4) Set offset to 0
-   if( sendNewProperty(m_indiP_C1ofst, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
-   if( sendNewProperty(m_indiP_C2ofst, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C1ofst, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C2ofst, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    //5) Set outputs to off
    if( sendNewProperty(m_indiP_C1outp, "toggle", pcf::IndiElement::Off) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
@@ -626,9 +626,9 @@ int ttmModulator::setTTM()
       if( sendNewProperty(m_indiP_C2volts, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
       //3) Set phase to 0
-      if( sendNewProperty(m_indiP_C1phse, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+      if( sendNewProperty(m_indiP_C1phse, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
-      if( sendNewProperty(m_indiP_C2phse, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+      if( sendNewProperty(m_indiP_C2phse, "target", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
       //Now check if values have changed.
       if( waitValue(m_C1freq, 0.0) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
@@ -1213,7 +1213,7 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C1ofst)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C1ofst = ipRecv;
-       double nv = ipRecv["value"].get<double>();
+       double nv = ipRecv["current"].get<double>();
 
        m_C1ofst = nv;
 
@@ -1236,7 +1236,7 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C1phse)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C1phse = ipRecv;
-       double nv = ipRecv["value"].get<double>();
+       double nv = ipRecv["current"].get<double>();
 
        m_C1phse = nv;
 
@@ -1335,7 +1335,7 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C2ofst)(const pcf::IndiProperty &ipR
     {
        m_indiP_C2ofst = ipRecv;
 
-       double nv = ipRecv["value"].get<double>();
+       double nv = ipRecv["current"].get<double>();
 
        m_C2ofst = nv;
 
@@ -1357,7 +1357,7 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C2phse)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C2phse = ipRecv;
-       double nv = ipRecv["value"].get<double>();
+       double nv = ipRecv["current"].get<double>();
 
        m_C2phse = nv;
 

--- a/apps/ttmModulator/ttmModulator.hpp
+++ b/apps/ttmModulator/ttmModulator.hpp
@@ -57,13 +57,13 @@ protected:
    double m_modFreqRequested {-1}; ///< The requested modulation frequency, in Hz.
 
 
-   int m_C1outp {-1};     ///< Output state of fxn gen channel 1.
+   bool m_C1outp {false};     ///< Output state of fxn gen channel 1.
    double m_C1freq {-1};  ///< Frequency of fxn gen channel 1.
    double m_C1volts {-1}; ///< Voltage p2p of fxn gen channel 1.
    double m_C1ofst {-1};  ///< DC offset of fxn gen channel 1.
    double m_C1phse {-1};  ///< Phase of fxn gen channel 1.
 
-   int m_C2outp {-1};     ///< Output state of fxn gen channel 2
+   bool m_C2outp {false};     ///< Output state of fxn gen channel 2
    double m_C2freq {-1};  ///< Frequency of fxn gen channel 2.
    double m_C2volts {-1}; ///< Voltage p2p of fxn gen channel 2.
    double m_C2ofst {-1};  ///< DC offset of fxn gen channel 2.
@@ -434,7 +434,7 @@ int ttmModulator::calcState()
 {
    //Need TTM power state here.
 
-   if( m_C1outp < 1 || m_C2outp < 1 ) //At least one channel off
+   if( !m_C1outp || !m_C2outp ) //At least one channel off
    {
       //Need to also check fxn gen pwr state here
       m_modState = MODSTATE_REST;
@@ -594,8 +594,8 @@ int ttmModulator::restTTM()
    if( waitValue(m_C2phse, 0.0) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
    if( waitValue(m_C1ofst, 0.001, 1e-6) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
    if( waitValue(m_C2ofst, 0.001, 1e-6) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
-   if( waitValue(m_C1outp, 0) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
-   if( waitValue(m_C2outp, 0) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
+   if( waitValue(m_C1outp, false) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
+   if( waitValue(m_C2outp, false) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
 
    log<text_log>("The PyWFS TTM is rested.", logPrio::LOG_NOTICE);
 
@@ -664,8 +664,8 @@ int ttmModulator::setTTM()
    if( sendNewProperty(m_indiP_C1outp, "toggle", pcf::IndiElement::On) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
    if( sendNewProperty(m_indiP_C2outp, "toggle", pcf::IndiElement::On) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
-   if( waitValue(m_C1outp, 1) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
-   if( waitValue(m_C2outp, 1) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
+   if( waitValue(m_C1outp, true) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
+   if( waitValue(m_C2outp, true) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
 
    //3) Now we begin ramp . . .
    size_t N1 = m_setVoltage_1/m_setDVolts;
@@ -1137,20 +1137,7 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C1outp)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C1outp = ipRecv;
-       pcf::IndiElement outp = ipRecv["toggle"].getSwitchState();
-
-       if( outp == pcf::IndiElement::Off )
-       {
-          m_C1outp = 0;
-       }
-       else if (outp == pcf::IndiElement::On)
-       {
-          m_C1outp = 1;
-       }
-       else
-       {
-          m_C1outp = -1;
-       }
+       m_C1outp = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
 
        return 0;
     }
@@ -1258,20 +1245,8 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C2outp)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C2outp = ipRecv;
-       pcf::IndiElement outp = ipRecv["toggle"].getSwitchState();
 
-       if( outp == pcf::IndiElement::Off )
-       {
-          m_C2outp = 0;
-       }
-       else if (outp == pcf::IndiElement::On)
-       {
-          m_C2outp = 1;
-       }
-       else
-       {
-          m_C2outp = -1;
-       }
+       m_C2outp = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
 
        return 0;
     }

--- a/apps/ttmModulator/ttmModulator.hpp
+++ b/apps/ttmModulator/ttmModulator.hpp
@@ -582,8 +582,8 @@ int ttmModulator::restTTM()
    if( sendNewProperty(m_indiP_C2ofst, "value", 0.0) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    //5) Set outputs to off
-   if( sendNewProperty(m_indiP_C1outp, "value", "Off") < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
-   if( sendNewProperty(m_indiP_C2outp, "value", "Off") < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C1outp, "toggle", pcf::IndiElement::Off) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C2outp, "toggle", pcf::IndiElement::Off) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    //Now check if values have changed.
    if( waitValue(m_C1freq, 0.0) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
@@ -661,8 +661,8 @@ int ttmModulator::setTTM()
    log<text_log>("Setting the PyWFS TTM.", logPrio::LOG_INFO);
 
    //2) Set outputs to on
-   if( sendNewProperty(m_indiP_C1outp, "value", "On") < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
-   if( sendNewProperty(m_indiP_C2outp, "value", "On") < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C1outp, "toggle", pcf::IndiElement::On) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
+   if( sendNewProperty(m_indiP_C2outp, "toggle", pcf::IndiElement::On) < 0 ) return log<software_error,-1>({__FILE__,__LINE__});
 
    if( waitValue(m_C1outp, 1) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
    if( waitValue(m_C2outp, 1) < 0) return log<software_error,-1>({__FILE__,__LINE__, "fxngen timeout"});
@@ -1137,13 +1137,13 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C1outp)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C1outp = ipRecv;
-       std::string outp = ipRecv["value"].getValue();
+       pcf::IndiElement outp = ipRecv["toggle"].getSwitchState();
 
-       if( outp == "Off" )
+       if( outp == pcf::IndiElement::Off )
        {
           m_C1outp = 0;
        }
-       else if (outp == "On")
+       else if (outp == pcf::IndiElement::On)
        {
           m_C1outp = 1;
        }
@@ -1258,13 +1258,13 @@ INDI_SETCALLBACK_DEFN(ttmModulator, m_indiP_C2outp)(const pcf::IndiProperty &ipR
     try
     {
        m_indiP_C2outp = ipRecv;
-       std::string outp = ipRecv["value"].getValue();
+       pcf::IndiElement outp = ipRecv["toggle"].getSwitchState();
 
-       if( outp == "Off" )
+       if( outp == pcf::IndiElement::Off )
        {
           m_C2outp = 0;
        }
-       else if (outp == "On")
+       else if (outp == pcf::IndiElement::On)
        {
           m_C2outp = 1;
        }

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -66,9 +66,15 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     double m_pos{ 0 };    ///< Current position in mm
     double m_tgtPos{ 0 }; ///< Target position in mm.
 
-    bool m_wason = true; ///< Whether the stage was in state power on before power off
+   bool m_wason = true; ///< Whether the stage was in state power on before power off
 
-    int m_homingState{ 0 }; ///< The homing state, tracks the stages of homing.
+   int m_homingState{0}; ///< The homing state, tracks the stages of homing.
+
+   time_t m_lastHomed {0}; ///< Time stamp of the last time the stage was homed
+
+public:
+   /// Default c'tor.
+   zaberCtrl();
 
     time_t m_lastHomed{ 0 }; ///< Time stamp of the last time the stage was homed
 
@@ -148,9 +154,12 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     pcf::IndiProperty m_indiP_temp;
     pcf::IndiProperty m_indiP_lastHomed;
 
-  public:
-    INDI_NEWCALLBACK_DECL( zaberCtrl, m_indiP_pos );
-    INDI_NEWCALLBACK_DECL( zaberCtrl, m_indiP_rawPos );
+   //INDI properties for user interaction:
+   pcf::IndiProperty m_indiP_pos;
+   pcf::IndiProperty m_indiP_rawPos;
+   pcf::IndiProperty m_indiP_maxPos;
+   pcf::IndiProperty m_indiP_temp;
+   pcf::IndiProperty m_indiP_lastHomed;
 
     // INDI properties for interacting with Low-Level
     pcf::IndiProperty m_indiP_stageState;
@@ -168,7 +177,23 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageTemp );
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageLastHomed );
 
-    /** \name Telemeter Interface
+   //INDI properties for interacting with Low-Level
+   pcf::IndiProperty m_indiP_stageState;
+   pcf::IndiProperty m_indiP_stageMaxRawPos;
+   pcf::IndiProperty m_indiP_stageRawPos;
+   pcf::IndiProperty m_indiP_stageTgtPos;
+   pcf::IndiProperty m_indiP_stageTemp;
+   pcf::IndiProperty m_indiP_stageLastHomed;
+
+public:
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageState);
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageMaxRawPos);
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageRawPos);
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageTgtPos);
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageTemp);
+   INDI_SETCALLBACK_DECL(zaberCtrl, m_indiP_stageLastHomed);
+
+   /** \name Telemeter Interface
      *
      * @{
      */
@@ -299,9 +324,17 @@ int zaberCtrl::appStartup()
     indi::addNumberElement( m_indiP_temp, "current", -50, 100, 0, "%0.1f" );
     registerIndiPropertyReadOnly( m_indiP_temp );
 
-    createROIndiNumber( m_indiP_lastHomed, "last_homed", "Time of last home [sec]" );
-    indi::addNumberElement<time_t>( m_indiP_lastHomed, "time_sec", 0, std::numeric_limits<time_t>::max(), 1, "%d" );
-    registerIndiPropertyReadOnly( m_indiP_lastHomed );
+   createROIndiNumber( m_indiP_lastHomed, "last_homed", "Time of last home [sec]");
+   indi::addNumberElement<time_t>( m_indiP_lastHomed, "time_sec", 0,std::numeric_limits<time_t>::max(), 1, "%d");
+   registerIndiPropertyReadOnly(m_indiP_lastHomed);
+
+   //Register for the low level status reports
+   REG_INDI_SETPROP(m_indiP_stageState, m_lowLevelName, "curr_state");
+   REG_INDI_SETPROP(m_indiP_stageMaxRawPos, m_lowLevelName, std::string("max_pos"));
+   REG_INDI_SETPROP(m_indiP_stageRawPos, m_lowLevelName, std::string("curr_pos"));
+   REG_INDI_SETPROP(m_indiP_stageTgtPos, m_lowLevelName, std::string("tgt_pos"));
+   REG_INDI_SETPROP(m_indiP_stageTemp, m_lowLevelName, std::string("temp"));
+   REG_INDI_SETPROP(m_indiP_stageLastHomed, m_lowLevelName, std::string("last_homed"));
 
     // Register for the low level status reports
     REG_INDI_SETPROP( m_indiP_stageState, m_lowLevelName, "curr_state" );
@@ -336,15 +369,26 @@ int zaberCtrl::appLogic()
         state( stateCodes::NOTCONNECTED );
     }
 
-    if( state() == stateCodes::POWEROFF )
-    {
-        if( m_wason )
-        {
-            // Here do poweroff update
-            if( stdMotionStage<zaberCtrl>::onPowerOff() < 0 )
-            {
-                log<software_error>( { __FILE__, __LINE__ } );
-            }
+   if(state() == stateCodes::POWEROFF)
+   {
+      if(m_wason)
+      {
+         //Here do poweroff update
+         if( stdMotionStage<zaberCtrl>::onPowerOff() < 0)
+         {
+            log<software_error>({__FILE__,__LINE__});
+         }
+
+         m_wason = false;
+      }
+      else 
+      {
+         //Here do poweroff update
+         if( stdMotionStage<zaberCtrl>::whilePowerOff() < 0)
+         {
+            log<software_error>({__FILE__,__LINE__});
+         }
+      }
 
             m_wason = false;
         }
@@ -365,12 +409,37 @@ int zaberCtrl::appLogic()
             log<software_error>( { __FILE__, __LINE__ } );
         }
 
-        return 0;
-    }
+   if(state() == stateCodes::NOTCONNECTED)
+   {
+      recordStage();
 
-    if( state() == stateCodes::NOTCONNECTED )
-    {
-        recordStage();
+      //record telem if it's been longer than 10 sec:
+      if(telemeter<zaberCtrl>::appLogic() < 0)
+      {
+         log<software_error>({__FILE__, __LINE__});
+      }
+
+      return 0;
+   }
+
+   if(state() == stateCodes::POWERON)
+   {
+      m_wason = true;
+      recordStage();
+      return 0;
+   }
+
+   if(state() == stateCodes::NOTHOMED)
+   {
+      if(m_powerOnHome) 
+      {
+         startHoming();
+         sleep(1); //give it time to start 
+      }
+
+      return 0;
+
+   }
 
         // record telem if it's been longer than 10 sec:
         if( telemeter<zaberCtrl>::appLogic() < 0 )
@@ -882,6 +951,24 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageLastHomed )( const pcf::IndiPrope
     m_lastHomed = ipRecv[m_stageName].get<double>();
 
     updateIfChanged( m_indiP_lastHomed, "time_sec", m_lastHomed );
+
+    return 0;
+}
+
+INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageLastHomed )(const pcf::IndiProperty &ipRecv)
+{
+    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_stageLastHomed, ipRecv);
+
+    if( ipRecv.find(m_stageName) != true ) //Just not our stage.
+    {
+        return 0;
+    }
+
+    std::lock_guard<std::mutex> guard(m_indiMutex);
+
+    m_lastHomed = ipRecv[m_stageName].get<double>();
+
+    updateIfChanged(m_indiP_lastHomed, "time_sec", m_lastHomed);
 
     return 0;
 }

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -372,45 +372,46 @@ int zaberLowLevel::appStartup()
     }
 
     REG_INDI_NEWPROP_NOCB( m_indiP_curr_state, "curr_state", pcf::IndiProperty::Text );
-    
+
     REG_INDI_NEWPROP_NOCB( m_indiP_max_pos, "max_pos", pcf::IndiProperty::Text );
-    
+
     REG_INDI_NEWPROP_NOCB( m_indiP_parked, "parked", pcf::IndiProperty::Number );
-    
+
     REG_INDI_NEWPROP_NOCB( m_indiP_lastHomed, "last_homed", pcf::IndiProperty::Number );
-    
+
     REG_INDI_NEWPROP_NOCB( m_indiP_curr_pos, "curr_pos", pcf::IndiProperty::Number );
 
     REG_INDI_NEWPROP_NOCB( m_indiP_temp, "temp", pcf::IndiProperty::Number );
-    
+
     REG_INDI_NEWPROP_NOCB( m_indiP_warn, "warning", pcf::IndiProperty::Switch );
     m_indiP_warn.setRule( pcf::IndiProperty::AnyOfMany );
-    
+
     REG_INDI_NEWPROP( m_indiP_tgt_pos, "tgt_pos", pcf::IndiProperty::Number );
 
-    /*--> Make a switch */
-    REG_INDI_NEWPROP( m_indiP_req_home, "req_home", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP( m_indiP_req_home, "req_home", pcf::IndiProperty::Switch );
+    m_indiP_req_home.setRule( pcf::IndiProperty::AtMostOne );
 
-    /*--> Make a switch */
-    REG_INDI_NEWPROP( m_indiP_req_halt, "req_halt", pcf::IndiProperty::Number );
+    CREATE_REG_INDI_NEW_REQUESTSWITCH( m_indiP_req_home_all, "home_all" );
 
-    /*--> Make a switch */
-    REG_INDI_NEWPROP( m_indiP_req_ehalt, "req_ehalt", pcf::IndiProperty::Number );
-    
+    REG_INDI_NEWPROP( m_indiP_req_halt, "req_halt", pcf::IndiProperty::Switch );
+    m_indiP_req_halt.setRule( pcf::IndiProperty::AtMostOne );
+
+    REG_INDI_NEWPROP( m_indiP_req_ehalt, "req_ehalt", pcf::IndiProperty::Switch );
+    m_indiP_req_ehalt.setRule( pcf::IndiProperty::AtMostOne );
 
     for( size_t n = 0; n < m_stages.size(); ++n )
     {
         m_indiP_curr_state.add( pcf::IndiElement( m_stages[n].name() ) );
-        
+
         m_indiP_max_pos.add( pcf::IndiElement( m_stages[n].name() ) );
         m_indiP_max_pos[m_stages[n].name()] = -1;
-        
+
         m_indiP_parked.add( pcf::IndiElement( m_stages[n].name() ) );
-        
+
         m_indiP_lastHomed.add( pcf::IndiElement( m_stages[n].name() ) );
-        
+
         m_indiP_curr_pos.add( pcf::IndiElement( m_stages[n].name() ) );
-        
+
         m_indiP_temp.add( pcf::IndiElement( m_stages[n].name() ) );
 
         m_indiP_warn.add( pcf::IndiElement( m_stages[n].name() ) );
@@ -419,12 +420,15 @@ int zaberLowLevel::appStartup()
         m_indiP_tgt_pos.add( pcf::IndiElement( m_stages[n].name() ) );
 
         m_indiP_req_home.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_home[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
         m_indiP_req_halt.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_halt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
         m_indiP_req_ehalt.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_ehalt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
-        //Now load last state from disk
+        // Now load last state from disk
         std::ifstream posIn;
         posIn.open( std::format( "{}/{}/{}", m_sysPath, m_configName, m_stages[n].name() ) );
 
@@ -889,26 +893,8 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_home )( const pcf::IndiPropert
         {
             if( found )
             {
-                if( m_stages[n].deviceAddress() < 1 )
-                {
-                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
-                                                      m_stages[n].serial() + " not found in system." } );
-                }
-                std::lock_guard<std::mutex> guard( m_indiMutex );
-
-                if( m_stages[n].homing() )
-                {
-                    continue;
-                }
-
-                if( m_stages[n].home( m_port ) < 0 )
-                {
-                    return log<software_error, -1>( { "error from home for " + m_stages[n].name() } );
-                }
-
-                updateIfChanged( m_indiP_tgt_pos, m_stages[n].name(), 0 );
-                updateIfChanged( m_indiP_parked, m_stages[n].name(), m_stages[n].parked() );
-                updateIfChanged( m_indiP_curr_state, m_stages[n].name(), std::string( "HOMING" ) );
+                log<software_error>( { "more than one stage specified in req_home, rejecting request" } );
+                return -1;
             }
 
             if( m_stages[n].deviceAddress() < 1 )
@@ -1011,18 +997,7 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_halt )( const pcf::IndiPropert
         {
             if( found )
             {
-                if( m_stages[n].deviceAddress() < 1 )
-                {
-                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
-                                                      m_stages[n].serial() + " not found in system." } );
-                }
-
-                std::lock_guard<std::mutex> guard( m_indiMutex );
-
-                if( m_stages[n].stop( m_port ) < 0 )
-                {
-                    return log<software_error, -1>( { "error from stop for " + m_stages[n].name() } );
-                }
+                return log<software_error, -1>( "more than one stage specified in req_halt, rejecting request" );
             }
 
             if( m_stages[n].deviceAddress() < 1 )
@@ -1074,8 +1049,11 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_ehalt )( const pcf::IndiProper
             {
                 if( m_stages[n].deviceAddress() < 1 )
                 {
-                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
-                                                      m_stages[n].serial() + " not found in system." } );
+                    log<software_error>( std::format( "stage {} with s/n {} "
+                                                      "not present",
+                                                      m_stages[n].name(),
+                                                      m_stages[n].serial() ) );
+                    continue;
                 }
 
                 std::lock_guard<std::mutex> guard( m_indiMutex );

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -372,46 +372,45 @@ int zaberLowLevel::appStartup()
     }
 
     REG_INDI_NEWPROP_NOCB( m_indiP_curr_state, "curr_state", pcf::IndiProperty::Text );
-
+    
     REG_INDI_NEWPROP_NOCB( m_indiP_max_pos, "max_pos", pcf::IndiProperty::Text );
-
+    
     REG_INDI_NEWPROP_NOCB( m_indiP_parked, "parked", pcf::IndiProperty::Number );
-
+    
     REG_INDI_NEWPROP_NOCB( m_indiP_lastHomed, "last_homed", pcf::IndiProperty::Number );
-
+    
     REG_INDI_NEWPROP_NOCB( m_indiP_curr_pos, "curr_pos", pcf::IndiProperty::Number );
 
     REG_INDI_NEWPROP_NOCB( m_indiP_temp, "temp", pcf::IndiProperty::Number );
-
+    
     REG_INDI_NEWPROP_NOCB( m_indiP_warn, "warning", pcf::IndiProperty::Switch );
     m_indiP_warn.setRule( pcf::IndiProperty::AnyOfMany );
-
+    
     REG_INDI_NEWPROP( m_indiP_tgt_pos, "tgt_pos", pcf::IndiProperty::Number );
 
-    REG_INDI_NEWPROP( m_indiP_req_home, "req_home", pcf::IndiProperty::Switch );
-    m_indiP_req_home.setRule( pcf::IndiProperty::AtMostOne );
+    /*--> Make a switch */
+    REG_INDI_NEWPROP( m_indiP_req_home, "req_home", pcf::IndiProperty::Number );
 
-    CREATE_REG_INDI_NEW_REQUESTSWITCH( m_indiP_req_home_all, "home_all" );
+    /*--> Make a switch */
+    REG_INDI_NEWPROP( m_indiP_req_halt, "req_halt", pcf::IndiProperty::Number );
 
-    REG_INDI_NEWPROP( m_indiP_req_halt, "req_halt", pcf::IndiProperty::Switch );
-    m_indiP_req_halt.setRule( pcf::IndiProperty::AtMostOne );
-
-    REG_INDI_NEWPROP( m_indiP_req_ehalt, "req_ehalt", pcf::IndiProperty::Switch );
-    m_indiP_req_ehalt.setRule( pcf::IndiProperty::AtMostOne );
+    /*--> Make a switch */
+    REG_INDI_NEWPROP( m_indiP_req_ehalt, "req_ehalt", pcf::IndiProperty::Number );
+    
 
     for( size_t n = 0; n < m_stages.size(); ++n )
     {
         m_indiP_curr_state.add( pcf::IndiElement( m_stages[n].name() ) );
-
+        
         m_indiP_max_pos.add( pcf::IndiElement( m_stages[n].name() ) );
         m_indiP_max_pos[m_stages[n].name()] = -1;
-
+        
         m_indiP_parked.add( pcf::IndiElement( m_stages[n].name() ) );
-
+        
         m_indiP_lastHomed.add( pcf::IndiElement( m_stages[n].name() ) );
-
+        
         m_indiP_curr_pos.add( pcf::IndiElement( m_stages[n].name() ) );
-
+        
         m_indiP_temp.add( pcf::IndiElement( m_stages[n].name() ) );
 
         m_indiP_warn.add( pcf::IndiElement( m_stages[n].name() ) );
@@ -420,15 +419,12 @@ int zaberLowLevel::appStartup()
         m_indiP_tgt_pos.add( pcf::IndiElement( m_stages[n].name() ) );
 
         m_indiP_req_home.add( pcf::IndiElement( m_stages[n].name() ) );
-        m_indiP_req_home[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
         m_indiP_req_halt.add( pcf::IndiElement( m_stages[n].name() ) );
-        m_indiP_req_halt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
         m_indiP_req_ehalt.add( pcf::IndiElement( m_stages[n].name() ) );
-        m_indiP_req_ehalt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
 
-        // Now load last state from disk
+        //Now load last state from disk
         std::ifstream posIn;
         posIn.open( std::format( "{}/{}/{}", m_sysPath, m_configName, m_stages[n].name() ) );
 
@@ -669,7 +665,7 @@ int zaberLowLevel::appLogic()
                                 return 0; // means we're powering off
                             }
 
-                            log<software_error>();
+                            log<software_error>( { __FILE__, __LINE__ } );
                             state( stateCodes::ERROR );
                             return 0;
                         }
@@ -893,8 +889,26 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_home )( const pcf::IndiPropert
         {
             if( found )
             {
-                log<software_error>( { "more than one stage specified in req_home, rejecting request" } );
-                return -1;
+                if( m_stages[n].deviceAddress() < 1 )
+                {
+                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
+                                                      m_stages[n].serial() + " not found in system." } );
+                }
+                std::lock_guard<std::mutex> guard( m_indiMutex );
+
+                if( m_stages[n].homing() )
+                {
+                    continue;
+                }
+
+                if( m_stages[n].home( m_port ) < 0 )
+                {
+                    return log<software_error, -1>( { "error from home for " + m_stages[n].name() } );
+                }
+
+                updateIfChanged( m_indiP_tgt_pos, m_stages[n].name(), 0 );
+                updateIfChanged( m_indiP_parked, m_stages[n].name(), m_stages[n].parked() );
+                updateIfChanged( m_indiP_curr_state, m_stages[n].name(), std::string( "HOMING" ) );
             }
 
             if( m_stages[n].deviceAddress() < 1 )
@@ -997,7 +1011,18 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_halt )( const pcf::IndiPropert
         {
             if( found )
             {
-                return log<software_error, -1>( "more than one stage specified in req_halt, rejecting request" );
+                if( m_stages[n].deviceAddress() < 1 )
+                {
+                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
+                                                      m_stages[n].serial() + " not found in system." } );
+                }
+
+                std::lock_guard<std::mutex> guard( m_indiMutex );
+
+                if( m_stages[n].stop( m_port ) < 0 )
+                {
+                    return log<software_error, -1>( { "error from stop for " + m_stages[n].name() } );
+                }
             }
 
             if( m_stages[n].deviceAddress() < 1 )
@@ -1049,11 +1074,8 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_req_ehalt )( const pcf::IndiProper
             {
                 if( m_stages[n].deviceAddress() < 1 )
                 {
-                    log<software_error>( std::format( "stage {} with s/n {} "
-                                                      "not present",
-                                                      m_stages[n].name(),
-                                                      m_stages[n].serial() ) );
-                    continue;
+                    return log<software_error, -1>( { "stage " + m_stages[n].name() + " with with s/n " +
+                                                      m_stages[n].serial() + " not found in system." } );
                 }
 
                 std::lock_guard<std::mutex> guard( m_indiMutex );

--- a/apps/zaberLowLevel/zaberStage.hpp
+++ b/apps/zaberLowLevel/zaberStage.hpp
@@ -43,7 +43,7 @@ class zaberStage
 
     bool m_homing{ false };
 
-    timespec m_lastHomed{ 0, 0 }; ///< Time stamp of the last time the stage was homed
+    time_t m_lastHomed {0}; ///< Time stamp of the last time the stage was homed
 
     bool m_parked{ false };
 
@@ -180,7 +180,7 @@ class zaberStage
      */
     bool homing();
 
-    /// Get the time of last homing
+    /// Get the time of last homing 
     /**
      * \returns the current value of m_lastHomed
      */
@@ -367,9 +367,9 @@ class zaberStage
     /// Clear all state so that when the system is powered back on we get the correct new state.
     int onPowerOff();
 
-    int writeStateFile( std::ofstream &fout /**< [in] an open ofstream to write to */ );
+    int writeStateFile( std::ofstream & fout /**< [in] an open ofstream to write to */);
 
-    int readStateFile( std::ifstream &fin /**< [in] an open ofstream to write to */ );
+    int readStateFile( std::ifstream & fin /**< [in] an open ofstream to write to */);
 };
 
 template <class parentT>
@@ -445,11 +445,11 @@ bool zaberStage<parentT>::homing()
 template <class parentT>
 time_t zaberStage<parentT>::lastHomed()
 {
-    return m_lastHomed.tv_sec;
+    return m_lastHomed;
 }
 
 template <class parentT>
-int zaberStage<parentT>::parked()
+bool zaberStage<parentT>::parked()
 {
     return m_parked;
 }
@@ -647,12 +647,9 @@ int zaberStage<parentT>::getResponse( std::string &response, const za_reply &rep
 
         if( m_deviceStatus == 'I' && m_homing )
         {
-            m_warnWR    = false; // Clear preemptively
-            m_homing    = false;
-            if(clock_gettime(CLOCK_ISIO, &m_lastHomed) < 0)
-            {
-                MagAOXAppT::log<software_error>( {errno, 0, "clock_gettime for last homed"});
-            }
+            m_warnWR = false; // Clear preemptively
+            m_homing = false;
+            m_lastHomed = time(nullptr);
         }
 
         if( rep.warning_flags[0] == '-' )
@@ -1605,83 +1602,84 @@ int zaberStage<parentT>::onPowerOff()
 }
 
 template <class parentT>
-int zaberStage<parentT>::writeStateFile( std::ofstream &fout )
+int zaberStage<parentT>::writeStateFile( std::ofstream & fout )
 {
-    fout << m_rawPos << '\n';
+   fout << m_rawPos << '\n';
 
-    if( !fout )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error writing raw position" } );
-    }
+   if(!fout)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error writing raw position"} );
+   }
 
-    fout << m_parked << '\n';
+   fout << m_parked << '\n';
 
-    if( !fout )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error writing parked state" } );
-    }
+   if(!fout)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error writing parked state"} );
+   }
 
-    fout << m_maxPos << '\n';
+   fout << m_maxPos << '\n';
 
-    if( !fout )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error writing max position" } );
-    }
+   if(!fout)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error writing max position"} );
+   }
 
-    fout << m_lastHomed.tv_sec << '\n';
+   fout << m_lastHomed << '\n';
 
-    if( !fout )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error writing last home time" } );
-    }
+   if(!fout)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error writing last home time"} );
+   }
 
-    return 0;
+   return 0;
 }
 
 template <class parentT>
-int zaberStage<parentT>::readStateFile( std::ifstream &fin )
+int zaberStage<parentT>::readStateFile( std::ifstream & fin )
 {
-    long   rawPos;
-    bool   parked;
-    long   maxPos;
-    time_t lastHomed;
+   long rawPos;
+   bool parked;
+   long maxPos;
+   time_t lastHomed;
 
-    fin >> rawPos;
+   fin >> rawPos;
 
-    if( !fin )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error reading raw position" } );
-    }
+   if(!fin)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error reading raw position"} );
+   }
 
-    fin >> parked;
+   fin >> parked;
 
-    if( !fin )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error reading parked state" } );
-    }
+   if(!fin)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error reading parked state"} );
+   }
 
-    fin >> maxPos;
+   fin >> maxPos;
 
-    if( !fin )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error reading max position" } );
-    }
+   if(!fin)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error reading max position"} );
+   }
 
-    fin >> lastHomed;
+   
+   fin >> lastHomed;
 
-    if( !fin )
-    {
-        return MagAOXAppT::log<software_error, -1>( { "error reading last home time" } );
-    }
+   if(!fin)
+   {
+      return MagAOXAppT::log<software_error, -1>( { "error reading last home time"} );
+   }
 
-    m_rawPos    = rawPos;
-    m_tgtPos    = rawPos;
-    m_parked    = parked;
-    m_maxPos    = maxPos;
-    m_lastHomed.tv_sec = lastHomed;
-    m_lastHomed.tv_nsec = 0;
+   m_rawPos = rawPos;
+   m_tgtPos = rawPos;
+   m_parked = parked;
+   m_maxPos = maxPos;
+   m_lastHomed = lastHomed;
 
-    return 0;
+   return 0;
+
 }
 
 } // namespace app

--- a/libMagAOX/logger/tests/generateTemplatedCatch2Tests.py
+++ b/libMagAOX/logger/tests/generateTemplatedCatch2Tests.py
@@ -688,6 +688,16 @@ def main():
         if ".hpp" not in type:
             continue
 
+        # workaround for software_log issues with source_location
+        if "software" in type:
+            print("software")
+            continue
+
+        # workaround for telsee deprecated fields
+        if "telsee" in type:
+            print("telsee")
+            continue
+
         typePath = os.path.join(typesFolderPath, type)
 
         # make dictionary with info for template

--- a/libMagAOX/logger/types/software_log.hpp
+++ b/libMagAOX/logger/types/software_log.hpp
@@ -171,10 +171,9 @@ struct software_log : public flatbuffer_log
         }
 
         /// C'tor for errno only -- code explanation can be looked up later.
-        messageT( const int32_t errnoCode, /**< [in] The errno code at the time of the log entry. Only errno should be
-                                                    passed here, so strerror can be used later.*/
-                  const std::source_location &loc /**< [in] [opt] source location */
-                  = std::source_location::current() )
+        messageT( const int32_t errnoCode, /**< [in] The errno code at the time of the log entry. Only errno should be passed here, so strerror can be used later.*/
+                  const std::source_location &loc = std::source_location::current() /**< [in] [opt] source location */
+                   )
         {
             auto _file = builder.CreateString( loc.file_name() );
 
@@ -236,9 +235,22 @@ struct software_log : public flatbuffer_log
             builder.Finish( gs );
         }
 
+        /// C'tor with no codes, just the explanation.
+        messageT( const std::string          &explanation, /**< [in] explanatory text about the software event */
+                  const std::source_location &loc    = std::source_location::current()      /**< [in] [opt] source location */
+                   )
+        {
+            auto _file = builder.CreateString( loc.file_name() );
+            auto _expl = builder.CreateString( explanation );
+
+            auto gs = CreateSoftware_log_fb( builder, _file, loc.line(), 0, 0, _expl );
+
+            builder.Finish( gs );
+        }
+
         /// C'tor for a trace log, only the file and line.
-        messageT( const std::source_location &loc /**< [in] [opt] source location */
-                  = std::source_location::current() )
+        messageT( const std::source_location &loc = std::source_location::current() /**< [in] [opt] source location */
+                   )
         {
             auto _file = builder.CreateString( loc.file_name() );
 

--- a/utils/tests/logsurgeon_test.cpp
+++ b/utils/tests/logsurgeon_test.cpp
@@ -1,0 +1,25 @@
+/** \file template_test.cpp
+  * \brief Catch2 tests for the template app.
+  *
+  * History:
+  */
+#include "../../tests/catch2/catch.hpp"
+
+#include "../logsurgeon/logsurgeon.hpp"
+
+namespace template_test
+{
+
+SCENARIO( "xxxx", "[template]" )
+{
+   GIVEN("xxxxx")
+   {
+      WHEN("xxxx")
+      {
+         int rv = 0;
+
+         REQUIRE(rv == 0);
+      }
+   }
+}
+} //namespace template_test


### PR DESCRIPTION
Fixes #135 

the following attributes have now moved to target/current
* C1wvtp / C2wvtp
* C1freq / C2freq
* C1peri / C2peri
* C1amp / C2amp
* C1ofst / C2ofst
* C1wdth / C2wdth
* C1phse / C2phse

the following attributes are now switches instead of text fields
* C1outp / C2outp
* C1sync / C2sync

Both picamCtrl and ttmModulator have been updated to use the new dialect

Code has been compiled but is untested as of right now.