### PR TITLE
harden GUI INDI reconnect threading and subscriber lifetime

### DIFF
--- a/INDI/libcommon/IndiConnection.cpp
+++ b/INDI/libcommon/IndiConnection.cpp
@@ -92,10 +92,12 @@ IndiConnection::~IndiConnection()
         //do nothing
     }
 
-    if(m_fstreamOutput && m_fstreamOutput != m_fstreamSTDOUT)
+    MutexLock::AutoLock autoOut( &m_mutOutput );
+    if(m_fdOutput >= 0 && m_fdOutput != STDOUT_FILENO)
     {
-        fclose(m_fstreamOutput);
+        ::close(m_fdOutput);
     }
+    m_fdOutput = -1;
 
 }
 
@@ -119,9 +121,8 @@ void IndiConnection::construct( const string &szName,
   // These are the two descriptors we will use to talk to the outside world.
   m_fdInput = STDIN_FILENO;
 
-  //We start with STDOUT.
-  m_fstreamSTDOUT = fdopen(STDOUT_FILENO, "w+");
-  setOutputFd(STDOUT_FILENO);
+  // We start with STDOUT.
+  m_fdOutput = STDOUT_FILENO;
 
   // setup the signal handler.
   //::signal( SIGHUP, IndiConnection::handleSignal );
@@ -380,13 +381,31 @@ void IndiConnection::sendXml( const string &szXml ) const
 {
   MutexLock::AutoLock autoOut( &m_mutOutput );
 
-  if(!m_fstreamOutput)
+  if(m_fdOutput < 0)
   {
     return;
   }
 
-  ::fprintf( m_fstreamOutput, "%s", szXml.c_str() );
-  fflush(m_fstreamOutput);
+  const char * buf = szXml.c_str();
+  size_t remaining = szXml.size();
+
+  while(remaining > 0)
+  {
+    ssize_t nwr = ::write(m_fdOutput, buf, remaining);
+    if(nwr > 0)
+    {
+      buf += nwr;
+      remaining -= static_cast<size_t>(nwr);
+      continue;
+    }
+
+    if(nwr < 0 && errno == EINTR)
+    {
+      continue;
+    }
+
+    break;
+  }
 
 }
 
@@ -427,22 +446,19 @@ void IndiConnection::setInputFd( const int &iFd )
 
 void IndiConnection::setOutputFd( const int &iFd )
 {
+    MutexLock::AutoLock autoOut( &m_mutOutput );
+
+    if(iFd == m_fdOutput)
+    {
+        return;
+    }
+
+    if(m_fdOutput >= 0 && m_fdOutput != STDOUT_FILENO)
+    {
+        ::close(m_fdOutput);
+    }
+
     m_fdOutput = iFd;
-
-    //Close if it's open as long as it isn't STDOUT
-    if(m_fstreamOutput && m_fstreamOutput != m_fstreamSTDOUT)
-    {
-        fclose(m_fstreamOutput);
-    }
-
-    if(iFd == STDOUT_FILENO)
-    {
-        m_fstreamOutput = m_fstreamSTDOUT;
-    }
-    else
-    {
-        m_fstreamOutput = fdopen(m_fdOutput, "w+");
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/INDI/libcommon/IndiConnection.hpp
+++ b/INDI/libcommon/IndiConnection.hpp
@@ -159,11 +159,6 @@ class IndiConnection : public pcf::Thread
     /// The file descriptor to write to.
     int m_fdOutput;
 
-    /// Stream for safer output
-    FILE * m_fstreamOutput {NULL};
-
-    FILE * m_fstreamSTDOUT {NULL};
-
     /// If the processing of INDI messages is put in a separate thread,
     /// this is the thread id of it.
     pthread_t m_idProcessThread;

--- a/agent_context.md
+++ b/agent_context.md
@@ -1,0 +1,71 @@
+Follow these code style and documentation rules exactly.
+
+1) File-Level Documentation
+  - Each header/source should have a top Doxygen file block:
+  - \file
+  - \brief
+  - \author (if project uses it)
+
+2) Include Guards and Includes
+  - Match existing project include-guard naming convention.
+  - Keep include ordering consistent with project style.
+  - Do not introduce new include style unless project already uses it.
+
+3) Function Declaration Documentation
+  - Every function declaration must have a brief `///` summary.
+  - Add a short `/** ... */` details block only when needed.
+  - Document every parameter inline at declaration site using:
+    - `type name /**< [in] description */`
+  - Apply to normal methods, constructors, slots, and signals.
+  - Keep return-value docs where project uses them.
+
+4) Member Variable Documentation
+  - Document non-trivial class members with `///`.
+  - Describe role/ownership/state, not just type.
+
+5) Naming and Structure
+  - Use project member naming convention (e.g. `m_` prefix).
+  - Keep declaration ordering/grouping stable:
+  - public/protected/private
+  - slots/signals grouped consistently.
+  - Leave a blank line between declarations for readability.
+
+6) Header vs Source Placement
+  - Keep non-trivial definitions out of headers.
+  - Move implementations to `.cpp` unless intentionally inline.
+
+7) Editing Discipline
+  - Preserve existing behavior unless explicitly requested.
+  - When renaming members/APIs, update all dependent call sites.
+  - Keep changes minimal and scoped.
+
+8) Formatting and Verification
+  - Run `clang-format` on touched files.
+  - Ensure docs and naming are consistent after formatting.
+  - Report any places where project style is ambiguous before making assumptions.
+
+9) Doxygen Named Section Ordering
+  - For classes that expose configuration via member data + accessors, keep named sections split into:
+  - `... - Data` for protected/private member state
+  - `...` (without `- Data`) for public access functions
+  - Place the `... - Data` section before the corresponding public accessor section.
+
+10) Header Declaration Parameter Docs
+  - In headers, prefer inline parameter documentation on declarations (`type name /**< ... */`) rather than separate `\param` lists, unless there is a specific reason to deviate.
+
+11) PR Prompt Attribution
+  - At the top of PR descriptions, include an explicit attribution line when work was performed with Codex.
+  - Preferred format:
+    - `This work was performed by GPT-5.3-Codex in response to the prompt: "...".`
+  - Include the primary user prompt verbatim (or a faithful condensed version if it is extremely long).
+
+12) Branch Naming (MagAOX)
+  - Feature branches must be namespaced by the active username.
+  - Format: `<username>/<feature-name>`
+  - Example: `jrmales/gui-segfault-fixes`
+  - For other users, substitute their username in place of `jrmales`.
+
+When you finish:
+- Summarize what changed.
+- List affected files.
+- Note any follow-up items or potential edge cases.

--- a/agent_context.md
+++ b/agent_context.md
@@ -65,6 +65,20 @@ Follow these code style and documentation rules exactly.
   - Example: `jrmales/gui-segfault-fixes`
   - For other users, substitute their username in place of `jrmales`.
 
+13) Class Declarations vs Definitions
+  - Do not include non-trivial function definitions inside class declarations.
+  - Put function definitions below the class declaration (or in `.cpp`), preserving behavior.
+
+14) Scoped Block Comments
+  - For any `{}` block used only to control lock/mutex lifetime, annotate the opening brace as:
+    - `{ //mutex scope`
+
+15) Changed File Documentation Pass
+  - When a file is touched, update documentation quality across the full changed file, not only in modified lines.
+
+16) Keep This File Current
+  - Add new standing style/documentation instructions to `agent_context.md` as they are introduced.
+
 When you finish:
 - Summarize what changed.
 - List affected files.

--- a/gui/lib/multiIndiManager.hpp
+++ b/gui/lib/multiIndiManager.hpp
@@ -1,3 +1,6 @@
+/** \file multiIndiManager.hpp
+ * \brief Manager for a shared INDI publisher with reconnect handling.
+ */
 #ifndef multiIndiManager_hpp
 #define multiIndiManager_hpp
 
@@ -13,338 +16,328 @@
 
 #include "multiIndiPublisher.hpp"
 
-inline void _dispatchOnDisconnect( multiIndiSubscriber * sub )
+/// Dispatches disconnect callbacks on the Qt event loop when the subscriber is a QObject.
+/** This avoids direct cross-thread QObject callback execution during disconnect cleanup.
+ */
+inline void _dispatchOnDisconnect( multiIndiSubscriber *sub )
 {
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      QTimer::singleShot(0, obj, [sub]() { sub->onDisconnect(); });
-      return;
-   }
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        QTimer::singleShot( 0, obj, [sub]() { sub->onDisconnect(); } );
+        return;
+    }
 
-   sub->onDisconnect();
+    sub->onDisconnect();
 }
 
 /// Class to manage an INDI publisher and multiple INDI subscribers
 /** Primary purpose of this class is to detect lack/loss of connection and
-  * reconnect when able, then re-initialize the subscriptions.
-  *
-  *
-  */
+ * reconnect when able, then re-initialize the subscriptions.
+ *
+ *
+ */
 class multiIndiManager : public multiIndiSubscriber
 {
 
-protected:
-   std::string m_clientName;  ///< Name used for the INDI client
-   std::string m_hostAddress; ///< Address of the indiserver host to connect to
-   int m_hostPort {0};        ///< Port on the host for indiserver
+  protected:
+    std::string m_clientName;    ///< Name used for the INDI client.
+    std::string m_hostAddress;   ///< Address of the INDI server host to connect to.
+    int         m_hostPort{ 0 }; ///< Port of the INDI server host to connect to.
 
-   //std::vector<multiIndiSubscriber *> m_subscribers; ///< Pointers to the subscribers themselves
+    multiIndiPublisher *m_publisher{ nullptr }; ///< Managed publisher/client instance.
+    std::mutex          m_mutex;                ///< Guards publisher pointer and subscriber snapshots.
 
-   multiIndiPublisher * m_publisher {nullptr}; ///< The publisher, which is the INDI client which manages the distrubtion of properties to subscribers.
-   std::mutex m_mutex;
+    std::thread m_monThread; ///< Connection monitor/reconnect thread.
 
-   std::thread m_monThread;
+    std::atomic_bool m_shutdown{ false }; ///< Signals monitor thread shutdown.
 
-   std::atomic_bool m_shutdown {false};
+  public:
+    /// Constructs an unconfigured manager.
+    multiIndiManager();
 
-public:
-   /// Default c'tor
-   /*
-    */
-   multiIndiManager();
+    /// Constructs a manager with connection settings.
+    multiIndiManager( const std::string &clientName,  ///< [in] INDI client name.
+                      const std::string &hostAddress, ///< [in] INDI server host address.
+                      const int          hostPort     ///< [in] INDI server host port.
+    );
 
-   /// Constructor which sets up and initiates the connection
-   /*
-    */
-   multiIndiManager( const std::string & clientName,  ///< [in]
-                     const std::string & hostAddress, ///< [in]
-                     const int hostPort               ///< [in]
-                   );
+    /// Destroys the manager and stops the monitor thread.
+    ~multiIndiManager();
 
-   /// Destructor
-   /* Disconnects and cleans up the client.
-    */
-   ~multiIndiManager();
+    /// Gets the INDI client name.
+    /** \returns The current INDI client name. */
+    std::string clientName();
 
-   /// Get the
-   /**
-     * \returns the current value of
+    /// Sets the INDI client name.
+    /** After setting this, call `activate(true)` to reconnect with the new name.
      */
-   std::string clientName();
+    void clientName( const std::string &cn /**< [in] New INDI client name. */ );
 
-   /// Set the
-   /** After setting this, you will need to call activate(true) to reset the client.
+    /// Gets the INDI server host address.
+    /** \returns The current host address. */
+    std::string hostAddress();
+
+    /// Sets the INDI server host address.
+    /** After setting this, call `activate(true)` to reconnect with the new host.
      */
-   void clientName( const std::string & cn /**< [in] the new*/);
+    void hostName( const std::string &hn /**< [in] New host address. */ );
 
-   /// Get the
-   /**
-     * \returns the current value of
+    /// Gets the INDI server port.
+    /** \returns The current host port. */
+    int hostPort();
+
+    /// Sets the INDI server port.
+    /** After setting this, call `activate(true)` to reconnect with the new port.
      */
-   std::string hostAddress();
+    void hostPort( int hp /**< [in] New host port. */ );
 
-   /// Set the
-   /** After setting this, you will need to call activate(true) to reset the client.
+    /// Add a subscriber.
+    /** If connected, this immediately calls the subscribers subscribe member function.
      */
-   void hostName( const std::string & hn /**< [in] the new*/);
+    virtual int addSubscriber( multiIndiSubscriber *sub /**< [in] Subscriber to add. */ );
 
-   /// Get the
-   /**
-     * \returns the current value of
-     */
-   int hostPort();
+    /// Removes a subscriber.
+    virtual void unsubscribe( multiIndiSubscriber *sub /**< [in] Subscriber to remove. */ );
 
-   /// Set the
-   /** After setting this, you will need to call activate(true) to reset the client.
-     */
-   void hostPort( int hp  /**< [in] the new*/);
+    /// Sends an INDI newProperty message through the managed publisher.
+    virtual void sendNewProperty( const pcf::IndiProperty &ipSend /**< [in] Property update request. */ );
 
-   /// Add a subscriber.
-   /** If connected, this immediately calls the subscribers subscribe member function.
-     */
-   virtual int addSubscriber( multiIndiSubscriber * sub /**< [in] the subscriber to add*/);
-   virtual void unsubscribe( multiIndiSubscriber * sub );
+    /// Sends an INDI getProperties message through the managed publisher.
+    virtual void sendGetProperties( const pcf::IndiProperty &ipSend /**< [in] Property query request. */ );
 
-   virtual void sendNewProperty( const pcf::IndiProperty &ipSend)
-   {
-      std::lock_guard<std::mutex> lock(m_mutex);
-      if(m_publisher) m_publisher->sendNewProperty(ipSend);
-   }
+    /// Starts or restarts the connection monitor.
+    void activate( bool force = false /**< [in] True forces reconnect by restarting the monitor thread. */ );
 
-   virtual void sendGetProperties(const pcf::IndiProperty &ipSend)
-   {
-      std::lock_guard<std::mutex> lock(m_mutex);
-      if(m_publisher) m_publisher->sendGetProperties(ipSend);
-   }
-
-   ///
-   /*
-    */
-   void activate(bool force = false /**< [in] if true, then this will force a reconnection */);
-
-public: //todo: make a protected static member
-
-   void connectClient();
+  public: // todo: make a protected static member
+    /// Monitor thread entry point that manages connect/disconnect/reconnect.
+    void connectClient();
 };
 
-inline
-multiIndiManager::multiIndiManager()
+inline multiIndiManager::multiIndiManager()
 {
 }
 
-inline
-multiIndiManager::multiIndiManager( const std::string & clientName,
-                                    const std::string & hostAddress,
-                                    const int hostPort
-                                  ) : m_clientName {clientName}, m_hostAddress{hostAddress}, m_hostPort{hostPort}
+inline multiIndiManager::multiIndiManager( const std::string &clientName,
+                                           const std::string &hostAddress,
+                                           const int          hostPort )
+    : m_clientName{ clientName }, m_hostAddress{ hostAddress }, m_hostPort{ hostPort }
 {
 }
 
-inline
-multiIndiManager::~multiIndiManager()
+inline multiIndiManager::~multiIndiManager()
 {
-   m_shutdown.store(true, std::memory_order_relaxed);
+    m_shutdown.store( true, std::memory_order_relaxed );
 
-   if(m_monThread.joinable())
-   {
-      try
-      {
-         m_monThread.join(); //this will throw if it was already joined
-      }
-      catch(...)
-      {
-      }
-   }
+    if( m_monThread.joinable() )
+    {
+        try
+        {
+            m_monThread.join(); // this will throw if it was already joined
+        }
+        catch( ... )
+        {
+        }
+    }
 }
 
-inline
-void _connectStart( multiIndiManager * mim )
+inline void _connectStart( multiIndiManager *mim )
 {
-   mim->connectClient();
+    mim->connectClient();
 }
 
-inline
-void multiIndiManager::activate(bool force)
+inline void multiIndiManager::sendNewProperty( const pcf::IndiProperty &ipSend )
 {
-   if(force)
-   {
-      m_shutdown.store(true, std::memory_order_relaxed);
-
-      if(m_monThread.joinable())
-      {
-         try
-         {
-            m_monThread.join(); //this will throw if it was already joined
-         }
-         catch(...)
-         {
-          }
-      }
-      m_shutdown.store(false, std::memory_order_relaxed);
-   }
-
-   if(m_monThread.joinable()) return; //Already running
-
-   try
-   {
-      m_monThread  = std::thread( _connectStart, this);
-   }
-   catch( const std::exception & e )
-   {
-      std::cerr << "Exception while activating INDI connection thread: " << e.what() << "\n";
-   }
-   catch( ... )
-   {
-      std::cerr << "Unknown exception while activating INDI connection thread.\n";
-   }
+    std::lock_guard<std::mutex> lock( m_mutex );
+    if( m_publisher )
+        m_publisher->sendNewProperty( ipSend );
 }
 
-
-
-inline
-int multiIndiManager::addSubscriber( multiIndiSubscriber * sub )
+inline void multiIndiManager::sendGetProperties( const pcf::IndiProperty &ipSend )
 {
-   std::lock_guard<std::mutex> lock(m_mutex);
-   subscribers.insert(sub);
-
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      QObject::connect(obj, &QObject::destroyed, [this, sub]() { this->unsubscribe(sub); });
-   }
-
-   if(m_publisher != nullptr)
-   {
-      m_publisher->addSubscriber(sub);
-   }
-
-   return 0;
+    std::lock_guard<std::mutex> lock( m_mutex );
+    if( m_publisher )
+        m_publisher->sendGetProperties( ipSend );
 }
 
-inline
-void multiIndiManager::unsubscribe( multiIndiSubscriber * sub )
+inline void multiIndiManager::activate( bool force )
 {
-   std::lock_guard<std::mutex> lock(m_mutex);
-   subscribers.erase(sub);
-   if(m_publisher != nullptr)
-   {
-      m_publisher->unsubscribe(sub);
-   }
-}
+    if( force )
+    {
+        m_shutdown.store( true, std::memory_order_relaxed );
 
-inline
-void multiIndiManager::connectClient()
-{
-   while( !m_shutdown.load(std::memory_order_relaxed) )
-   {
-      multiIndiPublisher * pub {nullptr};
-      std::vector<multiIndiSubscriber *> subs;
-      bool doDisconnect {false};
-      bool doConnect {false};
-
-      {
-         std::lock_guard<std::mutex> lock(m_mutex);
-         if(m_publisher != nullptr) //Check to see if we're still connected
-         {
-            if(m_publisher->getQuitProcess() || m_publisher->disconnect() || m_shutdown.load(std::memory_order_relaxed))
+        if( m_monThread.joinable() )
+        {
+            try
             {
-               pub = m_publisher;
-               m_publisher = nullptr;
-               subs.reserve(subscribers.size());
-               for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
-               doDisconnect = true;
+                m_monThread.join(); // this will throw if it was already joined
             }
-         }
-         else
-         {
-            doConnect = true;
-         }
-      }
-
-      if(doDisconnect)
-      {
-         pub->quitProcess();
-         pub->deactivate();
-
-         for(auto * sub : subs)
-         {
-            _dispatchOnDisconnect(sub);
-            pub->unsubscribe(sub);
-         }
-
-         delete pub;
-      }
-
-      if(doConnect) //try to connect
-      {
-         multiIndiPublisher * candidate {nullptr};
-         try
-         {
-            candidate = new multiIndiPublisher(m_clientName, m_hostAddress, m_hostPort);
-         }
-         catch(...)
-         {
-            sleep(1);
-            continue;
-         }
-
-         candidate->activate();
-
-         sleep(5);
-
-         //Check connection
-         if(candidate->getQuitProcess() || m_shutdown.load(std::memory_order_relaxed)) //not connected
-         {
-            candidate->deactivate();
-            delete candidate;
-
-         }
-         else //connected
-         {
+            catch( ... )
             {
-               std::lock_guard<std::mutex> lock(m_mutex);
-               m_publisher = candidate;
-               subs.reserve(subscribers.size());
-               for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+            }
+        }
+        m_shutdown.store( false, std::memory_order_relaxed );
+    }
+
+    if( m_monThread.joinable() )
+        return; // Already running
+
+    try
+    {
+        m_monThread = std::thread( _connectStart, this );
+    }
+    catch( const std::exception &e )
+    {
+        std::cerr << "Exception while activating INDI connection thread: " << e.what() << "\n";
+    }
+    catch( ... )
+    {
+        std::cerr << "Unknown exception while activating INDI connection thread.\n";
+    }
+}
+
+inline int multiIndiManager::addSubscriber( multiIndiSubscriber *sub )
+{
+    std::lock_guard<std::mutex> lock( m_mutex );
+    subscribers.insert( sub );
+
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        QObject::connect( obj, &QObject::destroyed, [this, sub]() { this->unsubscribe( sub ); } );
+    }
+
+    if( m_publisher != nullptr )
+    {
+        m_publisher->addSubscriber( sub );
+    }
+
+    return 0;
+}
+
+inline void multiIndiManager::unsubscribe( multiIndiSubscriber *sub )
+{
+    std::lock_guard<std::mutex> lock( m_mutex );
+    subscribers.erase( sub );
+    if( m_publisher != nullptr )
+    {
+        m_publisher->unsubscribe( sub );
+    }
+}
+
+inline void multiIndiManager::connectClient()
+{
+    while( !m_shutdown.load( std::memory_order_relaxed ) )
+    {
+        multiIndiPublisher                *pub{ nullptr };
+        std::vector<multiIndiSubscriber *> subs;
+        bool                               doDisconnect{ false };
+        bool                               doConnect{ false };
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_mutex );
+            if( m_publisher != nullptr ) // Check to see if we're still connected
+            {
+                if( m_publisher->getQuitProcess() || m_publisher->disconnect() ||
+                    m_shutdown.load( std::memory_order_relaxed ) )
+                {
+                    pub         = m_publisher;
+                    m_publisher = nullptr;
+                    subs.reserve( subscribers.size() );
+                    for( auto it = subscribers.begin(); it != subscribers.end(); ++it )
+                        subs.push_back( *it );
+                    doDisconnect = true;
+                }
+            }
+            else
+            {
+                doConnect = true;
+            }
+        }
+
+        if( doDisconnect )
+        {
+            pub->quitProcess();
+            pub->deactivate();
+
+            for( auto *sub : subs )
+            {
+                _dispatchOnDisconnect( sub );
+                pub->unsubscribe( sub );
             }
 
-            for(auto * sub : subs)
+            delete pub;
+        }
+
+        if( doConnect ) // try to connect
+        {
+            multiIndiPublisher *candidate{ nullptr };
+            try
             {
-               candidate->addSubscriber(sub);
+                candidate = new multiIndiPublisher( m_clientName, m_hostAddress, m_hostPort );
             }
-            candidate->onConnect();
-         }
-      }
+            catch( ... )
+            {
+                sleep( 1 );
+                continue;
+            }
 
-      sleep(1);
-   }
+            candidate->activate();
 
-   multiIndiPublisher * pub {nullptr};
-   std::vector<multiIndiSubscriber *> subs;
-   {
-      std::lock_guard<std::mutex> lock(m_mutex);
-      if(m_publisher != nullptr) //Before exiting, disconnect.
-      {
-         pub = m_publisher;
-         m_publisher = nullptr;
-         subs.reserve(subscribers.size());
-         for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
-      }
-   }
+            sleep( 5 );
 
-   if(pub != nullptr)
-   {
-      pub->quitProcess();
-      pub->deactivate();
+            // Check connection
+            if( candidate->getQuitProcess() || m_shutdown.load( std::memory_order_relaxed ) ) // not connected
+            {
+                candidate->deactivate();
+                delete candidate;
+            }
+            else // connected
+            {
+                { // mutex scope
+                    std::lock_guard<std::mutex> lock( m_mutex );
+                    m_publisher = candidate;
+                    subs.reserve( subscribers.size() );
+                    for( auto it = subscribers.begin(); it != subscribers.end(); ++it )
+                        subs.push_back( *it );
+                }
 
-      for(auto * sub : subs)
-      {
-         _dispatchOnDisconnect(sub);
-         pub->unsubscribe(sub);
-      }
+                for( auto *sub : subs )
+                {
+                    candidate->addSubscriber( sub );
+                }
+                candidate->onConnect();
+            }
+        }
 
-      delete pub;
-   }
+        sleep( 1 );
+    }
+
+    multiIndiPublisher                *pub{ nullptr };
+    std::vector<multiIndiSubscriber *> subs;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_mutex );
+        if( m_publisher != nullptr ) // Before exiting, disconnect.
+        {
+            pub         = m_publisher;
+            m_publisher = nullptr;
+            subs.reserve( subscribers.size() );
+            for( auto it = subscribers.begin(); it != subscribers.end(); ++it )
+                subs.push_back( *it );
+        }
+    }
+
+    if( pub != nullptr )
+    {
+        pub->quitProcess();
+        pub->deactivate();
+
+        for( auto *sub : subs )
+        {
+            _dispatchOnDisconnect( sub );
+            pub->unsubscribe( sub );
+        }
+
+        delete pub;
+    }
 }
 
-
-#endif  //multiIndiManager_hpp
+#endif // multiIndiManager_hpp

--- a/gui/lib/multiIndiManager.hpp
+++ b/gui/lib/multiIndiManager.hpp
@@ -3,10 +3,26 @@
 
 #include <thread>
 #include <mutex>
+#include <atomic>
+#include <vector>
+
+#include <QObject>
+#include <QTimer>
 
 #include <unistd.h>
 
 #include "multiIndiPublisher.hpp"
+
+inline void _dispatchOnDisconnect( multiIndiSubscriber * sub )
+{
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      QTimer::singleShot(0, obj, [sub]() { sub->onDisconnect(); });
+      return;
+   }
+
+   sub->onDisconnect();
+}
 
 /// Class to manage an INDI publisher and multiple INDI subscribers
 /** Primary purpose of this class is to detect lack/loss of connection and
@@ -25,10 +41,11 @@ protected:
    //std::vector<multiIndiSubscriber *> m_subscribers; ///< Pointers to the subscribers themselves
 
    multiIndiPublisher * m_publisher {nullptr}; ///< The publisher, which is the INDI client which manages the distrubtion of properties to subscribers.
+   std::mutex m_mutex;
 
    std::thread m_monThread;
 
-   bool m_shutdown {false};
+   std::atomic_bool m_shutdown {false};
 
 public:
    /// Default c'tor
@@ -86,6 +103,19 @@ public:
    /** If connected, this immediately calls the subscribers subscribe member function.
      */
    virtual int addSubscriber( multiIndiSubscriber * sub /**< [in] the subscriber to add*/);
+   virtual void unsubscribe( multiIndiSubscriber * sub );
+
+   virtual void sendNewProperty( const pcf::IndiProperty &ipSend)
+   {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      if(m_publisher) m_publisher->sendNewProperty(ipSend);
+   }
+
+   virtual void sendGetProperties(const pcf::IndiProperty &ipSend)
+   {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      if(m_publisher) m_publisher->sendGetProperties(ipSend);
+   }
 
    ///
    /*
@@ -113,7 +143,7 @@ multiIndiManager::multiIndiManager( const std::string & clientName,
 inline
 multiIndiManager::~multiIndiManager()
 {
-   m_shutdown = true;
+   m_shutdown.store(true, std::memory_order_relaxed);
 
    if(m_monThread.joinable())
    {
@@ -138,7 +168,7 @@ void multiIndiManager::activate(bool force)
 {
    if(force)
    {
-      m_shutdown = true;
+      m_shutdown.store(true, std::memory_order_relaxed);
 
       if(m_monThread.joinable())
       {
@@ -150,7 +180,7 @@ void multiIndiManager::activate(bool force)
          {
           }
       }
-      m_shutdown = false;
+      m_shutdown.store(false, std::memory_order_relaxed);
    }
 
    if(m_monThread.joinable()) return; //Already running
@@ -174,8 +204,15 @@ void multiIndiManager::activate(bool force)
 inline
 int multiIndiManager::addSubscriber( multiIndiSubscriber * sub )
 {
+   std::lock_guard<std::mutex> lock(m_mutex);
    subscribers.insert(sub);
-   if(m_publisher)
+
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      QObject::connect(obj, &QObject::destroyed, [this, sub]() { this->unsubscribe(sub); });
+   }
+
+   if(m_publisher != nullptr)
    {
       m_publisher->addSubscriber(sub);
    }
@@ -184,32 +221,65 @@ int multiIndiManager::addSubscriber( multiIndiSubscriber * sub )
 }
 
 inline
+void multiIndiManager::unsubscribe( multiIndiSubscriber * sub )
+{
+   std::lock_guard<std::mutex> lock(m_mutex);
+   subscribers.erase(sub);
+   if(m_publisher != nullptr)
+   {
+      m_publisher->unsubscribe(sub);
+   }
+}
+
+inline
 void multiIndiManager::connectClient()
 {
-   while( !m_shutdown )
+   while( !m_shutdown.load(std::memory_order_relaxed) )
    {
-      if(m_publisher != nullptr) //Check to see if we're still connected
+      multiIndiPublisher * pub {nullptr};
+      std::vector<multiIndiSubscriber *> subs;
+      bool doDisconnect {false};
+      bool doConnect {false};
+
       {
-         if(m_publisher->getQuitProcess() || m_publisher->disconnect() || m_shutdown)
+         std::lock_guard<std::mutex> lock(m_mutex);
+         if(m_publisher != nullptr) //Check to see if we're still connected
          {
-            m_publisher->quitProcess();
-            m_publisher->deactivate();
-
-            for(auto it = subscribers.begin(); it != subscribers.end(); ++it)
+            if(m_publisher->getQuitProcess() || m_publisher->disconnect() || m_shutdown.load(std::memory_order_relaxed))
             {
-               (*it)->onDisconnect();
-               m_publisher->unsubscribe(*it);
+               pub = m_publisher;
+               m_publisher = nullptr;
+               subs.reserve(subscribers.size());
+               for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+               doDisconnect = true;
             }
-
-            delete m_publisher;
-            m_publisher = nullptr;
-        }
+         }
+         else
+         {
+            doConnect = true;
+         }
       }
-      else //try to connect
+
+      if(doDisconnect)
       {
+         pub->quitProcess();
+         pub->deactivate();
+
+         for(auto * sub : subs)
+         {
+            _dispatchOnDisconnect(sub);
+            pub->unsubscribe(sub);
+         }
+
+         delete pub;
+      }
+
+      if(doConnect) //try to connect
+      {
+         multiIndiPublisher * candidate {nullptr};
          try
          {
-            m_publisher = new multiIndiPublisher(m_clientName, m_hostAddress, m_hostPort);
+            candidate = new multiIndiPublisher(m_clientName, m_hostAddress, m_hostPort);
          }
          catch(...)
          {
@@ -217,44 +287,62 @@ void multiIndiManager::connectClient()
             continue;
          }
 
-         m_publisher->activate();
+         candidate->activate();
 
          sleep(5);
 
          //Check connection
-         if(m_publisher->getQuitProcess()) //not connected
+         if(candidate->getQuitProcess() || m_shutdown.load(std::memory_order_relaxed)) //not connected
          {
-            m_publisher->deactivate();
-            delete m_publisher;
-            m_publisher = nullptr;
+            candidate->deactivate();
+            delete candidate;
 
          }
          else //connected
          {
-            for(auto it = subscribers.begin(); it != subscribers.end(); ++it)
             {
-               m_publisher->addSubscriber(*it);
+               std::lock_guard<std::mutex> lock(m_mutex);
+               m_publisher = candidate;
+               subs.reserve(subscribers.size());
+               for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
             }
-            m_publisher->onConnect();
+
+            for(auto * sub : subs)
+            {
+               candidate->addSubscriber(sub);
+            }
+            candidate->onConnect();
          }
       }
 
       sleep(1);
    }
 
-   if(m_publisher != nullptr) //Before exiting, disconnect.
+   multiIndiPublisher * pub {nullptr};
+   std::vector<multiIndiSubscriber *> subs;
    {
-      m_publisher->quitProcess();
-      m_publisher->deactivate();
-
-      for(auto it = subscribers.begin(); it != subscribers.end(); ++it)
+      std::lock_guard<std::mutex> lock(m_mutex);
+      if(m_publisher != nullptr) //Before exiting, disconnect.
       {
-         (*it)->onDisconnect();
-         m_publisher->unsubscribe(*it);
+         pub = m_publisher;
+         m_publisher = nullptr;
+         subs.reserve(subscribers.size());
+         for(auto it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+      }
+   }
+
+   if(pub != nullptr)
+   {
+      pub->quitProcess();
+      pub->deactivate();
+
+      for(auto * sub : subs)
+      {
+         _dispatchOnDisconnect(sub);
+         pub->unsubscribe(sub);
       }
 
-      delete m_publisher;
-      m_publisher = nullptr;
+      delete pub;
    }
 }
 

--- a/gui/lib/multiIndiPublisher.hpp
+++ b/gui/lib/multiIndiPublisher.hpp
@@ -187,8 +187,17 @@ inline int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber *sub, 
         }
     }
 
-    // note: we have to send this every time b/c otherwise late subscribers won't get an update on subscribe
-    sendGetProperties( ipSub );
+    // Request current value for late subscribers. For QObject-based subscribers,
+    // queue via their event loop instead of sending inline from connection thread.
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        pcf::IndiProperty ipReq = ipSub;
+        QTimer::singleShot( 0, obj, [sub, ipReq]() { sub->sendGetProperties( ipReq ); } );
+    }
+    else
+    {
+        sendGetProperties( ipSub );
+    }
 
     return 0;
 }

--- a/gui/lib/multiIndiPublisher.hpp
+++ b/gui/lib/multiIndiPublisher.hpp
@@ -1,10 +1,13 @@
+/** \file multiIndiPublisher.hpp
+ * \brief Shared INDI client publisher for multiple subscribers.
+ */
 #ifndef multiIndiPublisher_hpp
 #define multiIndiPublisher_hpp
 
-#include <unordered_map>
-#include <set>
-#include <vector>
 #include <mutex>
+#include <set>
+#include <unordered_map>
+#include <vector>
 
 #include <QObject>
 #include <QTimer>
@@ -15,255 +18,274 @@
 
 /// Define this before including this file if you wish to specify a version of the client.
 #ifndef MULTI_INDI_CLIENT_VERSION
-#define MULTI_INDI_CLIENT_VERSION "none"
+    #define MULTI_INDI_CLIENT_VERSION "none"
 #endif
 
-#define MULTI_INDI_PROTO_VERSION  "1.7"
+#define MULTI_INDI_PROTO_VERSION "1.7"
 
-inline void _dispatchDefProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+/// Dispatches a defProperty callback, queued through Qt for QObject subscribers.
+inline void _dispatchDefProperty( multiIndiSubscriber *sub, const pcf::IndiProperty &ipRecv )
 {
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      pcf::IndiProperty ipCopy = ipRecv;
-      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleDefProperty(ipCopy); });
-      return;
-   }
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        pcf::IndiProperty ipCopy = ipRecv;
+        QTimer::singleShot( 0, obj, [sub, ipCopy]() { sub->handleDefProperty( ipCopy ); } );
+        return;
+    }
 
-   sub->handleDefProperty(ipRecv);
+    sub->handleDefProperty( ipRecv );
 }
 
-inline void _dispatchDelProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+/// Dispatches a delProperty callback, queued through Qt for QObject subscribers.
+inline void _dispatchDelProperty( multiIndiSubscriber *sub, const pcf::IndiProperty &ipRecv )
 {
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      pcf::IndiProperty ipCopy = ipRecv;
-      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleDelProperty(ipCopy); });
-      return;
-   }
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        pcf::IndiProperty ipCopy = ipRecv;
+        QTimer::singleShot( 0, obj, [sub, ipCopy]() { sub->handleDelProperty( ipCopy ); } );
+        return;
+    }
 
-   sub->handleDelProperty(ipRecv);
+    sub->handleDelProperty( ipRecv );
 }
 
-inline void _dispatchSetProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+/// Dispatches a setProperty callback, queued through Qt for QObject subscribers.
+inline void _dispatchSetProperty( multiIndiSubscriber *sub, const pcf::IndiProperty &ipRecv )
 {
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      pcf::IndiProperty ipCopy = ipRecv;
-      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleSetProperty(ipCopy); });
-      return;
-   }
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        pcf::IndiProperty ipCopy = ipRecv;
+        QTimer::singleShot( 0, obj, [sub, ipCopy]() { sub->handleSetProperty( ipCopy ); } );
+        return;
+    }
 
-   sub->handleSetProperty(ipRecv);
+    sub->handleSetProperty( ipRecv );
 }
 
-inline void _dispatchOnConnect( multiIndiSubscriber * sub )
+/// Dispatches an onConnect callback, queued through Qt for QObject subscribers.
+inline void _dispatchOnConnect( multiIndiSubscriber *sub )
 {
-   if(auto * obj = dynamic_cast<QObject *>(sub))
-   {
-      QTimer::singleShot(0, obj, [sub]() { sub->onConnect(); });
-      return;
-   }
+    if( auto *obj = dynamic_cast<QObject *>( sub ) )
+    {
+        QTimer::singleShot( 0, obj, [sub]() { sub->onConnect(); } );
+        return;
+    }
 
-   sub->onConnect();
+    sub->onConnect();
 }
 
 /// An INDI client which serves as a publisher for many subscribers.
 /** This allows many widgets to use a single INDI client connection from within
-  * one overall application (e.g. a GUI window).
-  *
-  * Subscribers, instances of classes derived from multiIndiSubscriber, register
-  * callbacks to be notified when a specific property is changed.
-  *
-  */
+ * one overall application (e.g. a GUI window).
+ */
 class multiIndiPublisher : public pcf::IndiClient, public multiIndiSubscriber
 {
 
-protected:
+  protected:
+    std::string          m_hostAddress; ///< Host address configured for the publisher connection.
+    std::string          m_hostPort;    ///< Host port configured for the publisher connection.
+    std::recursive_mutex m_subMutex;    ///< Guards subscriber structures during publish/subscribe updates.
 
-   std::string m_hostAddress;
-   std::string m_hostPort;
-   std::recursive_mutex m_subMutex;
+  public:
+    /// Constructor, which establishes the INDI client connection.
+    multiIndiPublisher( const std::string &clientName,  ///< [in] INDI client name.
+                        const std::string &hostAddress, ///< [in] INDI server host address.
+                        const int          hostPort     ///< [in] INDI server host port.
+    );
 
-public:
+    /// Destructor.
+    ~multiIndiPublisher() noexcept;
 
-   /// Constructor, which establishes the INDI client connection.
-   multiIndiPublisher( const std::string & clientName,
-                       const std::string & hostAddress,
-                       const int hostPort
-                     );
+    /// Adds a subscriber to receive publisher events.
+    virtual int addSubscriber( multiIndiSubscriber *sub /**< [in] Subscriber to add. */ );
 
-   ~multiIndiPublisher() noexcept {};
+    /// Unsubscribes a subscriber from all events.
+    virtual void unsubscribe( multiIndiSubscriber *sub /**< [in] Subscriber to remove. */ );
 
-   virtual int addSubscriber( multiIndiSubscriber * sub )
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      return multiIndiSubscriber::addSubscriber(sub);
-   }
+    /// Unsubscribes a subscriber from one specific property.
+    virtual void unsubscribe( multiIndiSubscriber *sub,     /**< [in] Subscriber to remove. */
+                              const std::string   &device,  /**< [in] Device name. */
+                              const std::string   &propName /**< [in] Property name. */
+    );
 
-   virtual void unsubscribe( multiIndiSubscriber * sub )
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      multiIndiSubscriber::unsubscribe(sub);
-   }
-
-   virtual void unsubscribe( multiIndiSubscriber * sub,
-                             const std::string & device,
-                             const std::string & propName
-                           )
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      multiIndiSubscriber::unsubscribe(sub, device, propName);
-   }
-
-
-   /// Subscribes the given instance of multiIndiSubscriber for notifications on the given property.
-   /**
-     * \returns 0 on success.
-     * \returns -1 on error.
+    /// Subscribes a subscriber for notifications on the given property.
+    /** \returns 0 on success, -1 on error.
      */
-   virtual int addSubscriberProperty( multiIndiSubscriber * sub, ///< [in] pointer to the subscriber
-                                      pcf::IndiProperty & ipSub  ///< [in] the property being subscribed to.
-                                    );
+    virtual int addSubscriberProperty( multiIndiSubscriber *sub,  /**< [in] Subscriber pointer. */
+                                       pcf::IndiProperty   &ipSub /**< [in] Property being subscribed to. */
+    );
 
-   virtual int addSubscriberProperty( multiIndiSubscriber * sub, ///< [in] pointer to the subscriber
-                                      const std::string & device,  ///< [in] the property being subscribed to.
-                                      const std::string & propName
-                                    )
-   {
-      pcf::IndiProperty ipSub;
-      ipSub.setDevice(device);
-      ipSub.setName(propName);
-
-      return addSubscriberProperty(sub, ipSub);
-   }
-
-   virtual void handleDefProperty( const pcf::IndiProperty &ipRecv );
-
-   virtual void handleDelProperty( const pcf::IndiProperty &ipRecv );
-
-   /// Responds to SET PROPERTY
-   /** This is the implementation of the pcf::IndiClient interface function.
-     * Calls the handleSetProperty callback for any subscribers registered on the property.
+    /// Subscribes a subscriber for notifications using device/property names.
+    /** \returns 0 on success, -1 on error.
      */
-   virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the INDI property which has changed */);
+    virtual int addSubscriberProperty( multiIndiSubscriber *sub,     /**< [in] Subscriber pointer. */
+                                       const std::string   &device,  /**< [in] Device name. */
+                                       const std::string   &propName /**< [in] Property name. */
+    );
 
-   /// Implementation of the pcf::IndiClient interface, called by activate to actually beging the INDI event loop.
-   /**
-     */
-   void execute();
+    /// Handles defProperty messages from the INDI client.
+    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Received INDI property. */ );
 
-   /// Called once the parent is connected.
-   virtual void onConnect()
-   {
-      std::vector<multiIndiSubscriber *> subs;
-      {
-         std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-         subs.reserve(subscribers.size());
-         for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
-      }
+    /// Handles delProperty messages from the INDI client.
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] Received INDI property. */ );
 
-      for(auto * sub : subs)
-      {
-         _dispatchOnConnect(sub);
-      }
-   }
+    /// Handles setProperty messages from the INDI client.
+    virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Received INDI property. */ );
 
-   virtual void sendNewProperty( const pcf::IndiProperty &ipSend)
-   {
-      pcf::IndiClient::sendNewProperty(ipSend);
-   }
+    /// Implementation of the IndiClient execution loop.
+    void execute();
 
-   virtual void sendGetProperties(const pcf::IndiProperty &ipSend)
-   {
-       pcf::IndiClient::sendGetProperties(ipSend);
-   }
+    /// Called once the parent is connected.
+    virtual void onConnect();
+
+    /// Sends a newProperty request.
+    virtual void sendNewProperty( const pcf::IndiProperty &ipSend /**< [in] Property update request. */ );
+
+    /// Sends a getProperties request.
+    virtual void sendGetProperties( const pcf::IndiProperty &ipSend /**< [in] Property query request. */ );
 };
 
-inline
-multiIndiPublisher::multiIndiPublisher( const std::string & clientName,
-                                        const std::string & hostAddress,
-                                        const int hostPort
-                                      ) : pcf::IndiClient( clientName, MULTI_INDI_CLIENT_VERSION, MULTI_INDI_PROTO_VERSION, hostAddress, hostPort)
+inline multiIndiPublisher::multiIndiPublisher( const std::string &clientName,
+                                               const std::string &hostAddress,
+                                               const int          hostPort )
+    : pcf::IndiClient( clientName, MULTI_INDI_CLIENT_VERSION, MULTI_INDI_PROTO_VERSION, hostAddress, hostPort )
 {
-   //pcf::IndiProperty ipSend;
-   //sendGetProperties( ipSend );
+    // pcf::IndiProperty ipSend;
+    // sendGetProperties( ipSend );
 }
 
-
-inline
-int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber * sub,
-                                               pcf::IndiProperty & ipSub
-                                             )
+inline multiIndiPublisher::~multiIndiPublisher() noexcept
 {
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      if(multiIndiSubscriber::addSubscriberProperty(sub, ipSub) != 0)
-      {
-         return -1;
-      }
-   }
-
-   //note: we have to send this every time b/c otherwise late subscribers won't get an update on subscribe
-   sendGetProperties(ipSub);
-
-   return 0;
 }
 
-inline
-void multiIndiPublisher::handleDefProperty( const pcf::IndiProperty &ipRecv )
+inline int multiIndiPublisher::addSubscriber( multiIndiSubscriber *sub )
 {
-   std::vector<multiIndiSubscriber *> subs;
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      subs.reserve(subscribers.size());
-      for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
-   }
-
-   for(auto * sub : subs)
-   {
-      _dispatchDefProperty(sub, ipRecv);
-   }
+    std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+    return multiIndiSubscriber::addSubscriber( sub );
 }
 
-inline
-void multiIndiPublisher::handleDelProperty( const pcf::IndiProperty &ipRecv )
+inline void multiIndiPublisher::unsubscribe( multiIndiSubscriber *sub )
 {
-   std::vector<multiIndiSubscriber *> subs;
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      subs.reserve(subscribers.size());
-      for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
-   }
-
-   for(auto * sub : subs)
-   {
-      _dispatchDelProperty(sub, ipRecv);
-   }
+    std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+    multiIndiSubscriber::unsubscribe( sub );
 }
 
-inline
-void multiIndiPublisher::handleSetProperty( const pcf::IndiProperty &ipRecv )
+inline void
+multiIndiPublisher::unsubscribe( multiIndiSubscriber *sub, const std::string &device, const std::string &propName )
 {
-   std::vector<multiIndiSubscriber *> subs;
-   {
-      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
-      std::pair< propMapIteratorT, propMapIteratorT> range = subscribedProperties.equal_range(ipRecv.createUniqueKey());
-
-      if(range.first == subscribedProperties.end()) return;
-
-      for(propMapIteratorT it = range.first; it != range.second; ++it) subs.push_back(it->second);
-   }
-
-   for(auto * sub : subs)
-   {
-      _dispatchSetProperty(sub, ipRecv);
-   }
+    std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+    multiIndiSubscriber::unsubscribe( sub, device, propName );
 }
 
-inline
-void multiIndiPublisher::execute()
+inline int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber *sub, pcf::IndiProperty &ipSub )
 {
-   processIndiRequests(false);
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+        if( multiIndiSubscriber::addSubscriberProperty( sub, ipSub ) != 0 )
+        {
+            return -1;
+        }
+    }
+
+    // note: we have to send this every time b/c otherwise late subscribers won't get an update on subscribe
+    sendGetProperties( ipSub );
+
+    return 0;
 }
 
-#endif //multiIndiPublisher_hpp
+inline int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber *sub,
+                                                      const std::string   &device,
+                                                      const std::string   &propName )
+{
+    pcf::IndiProperty ipSub;
+    ipSub.setDevice( device );
+    ipSub.setName( propName );
+
+    return addSubscriberProperty( sub, ipSub );
+}
+
+inline void multiIndiPublisher::handleDefProperty( const pcf::IndiProperty &ipRecv )
+{
+    std::vector<multiIndiSubscriber *> subs;
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+        subs.reserve( subscribers.size() );
+        for( subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it )
+            subs.push_back( *it );
+    }
+
+    for( auto *sub : subs )
+    {
+        _dispatchDefProperty( sub, ipRecv );
+    }
+}
+
+inline void multiIndiPublisher::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    std::vector<multiIndiSubscriber *> subs;
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+        subs.reserve( subscribers.size() );
+        for( subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it )
+            subs.push_back( *it );
+    }
+
+    for( auto *sub : subs )
+    {
+        _dispatchDelProperty( sub, ipRecv );
+    }
+}
+
+inline void multiIndiPublisher::handleSetProperty( const pcf::IndiProperty &ipRecv )
+{
+    std::vector<multiIndiSubscriber *> subs;
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex>         lock( m_subMutex );
+        std::pair<propMapIteratorT, propMapIteratorT> range =
+            subscribedProperties.equal_range( ipRecv.createUniqueKey() );
+
+        if( range.first == subscribedProperties.end() )
+            return;
+
+        for( propMapIteratorT it = range.first; it != range.second; ++it )
+            subs.push_back( it->second );
+    }
+
+    for( auto *sub : subs )
+    {
+        _dispatchSetProperty( sub, ipRecv );
+    }
+}
+
+inline void multiIndiPublisher::execute()
+{
+    processIndiRequests( false );
+}
+
+inline void multiIndiPublisher::onConnect()
+{
+    std::vector<multiIndiSubscriber *> subs;
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> lock( m_subMutex );
+        subs.reserve( subscribers.size() );
+        for( subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it )
+            subs.push_back( *it );
+    }
+
+    for( auto *sub : subs )
+    {
+        _dispatchOnConnect( sub );
+    }
+}
+
+inline void multiIndiPublisher::sendNewProperty( const pcf::IndiProperty &ipSend )
+{
+    pcf::IndiClient::sendNewProperty( ipSend );
+}
+
+inline void multiIndiPublisher::sendGetProperties( const pcf::IndiProperty &ipSend )
+{
+    pcf::IndiClient::sendGetProperties( ipSend );
+}
+
+#endif // multiIndiPublisher_hpp

--- a/gui/lib/multiIndiPublisher.hpp
+++ b/gui/lib/multiIndiPublisher.hpp
@@ -3,6 +3,11 @@
 
 #include <unordered_map>
 #include <set>
+#include <vector>
+#include <mutex>
+
+#include <QObject>
+#include <QTimer>
 
 #include "../../INDI/libcommon/IndiClient.hpp"
 
@@ -14,6 +19,53 @@
 #endif
 
 #define MULTI_INDI_PROTO_VERSION  "1.7"
+
+inline void _dispatchDefProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+{
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      pcf::IndiProperty ipCopy = ipRecv;
+      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleDefProperty(ipCopy); });
+      return;
+   }
+
+   sub->handleDefProperty(ipRecv);
+}
+
+inline void _dispatchDelProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+{
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      pcf::IndiProperty ipCopy = ipRecv;
+      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleDelProperty(ipCopy); });
+      return;
+   }
+
+   sub->handleDelProperty(ipRecv);
+}
+
+inline void _dispatchSetProperty( multiIndiSubscriber * sub, const pcf::IndiProperty & ipRecv )
+{
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      pcf::IndiProperty ipCopy = ipRecv;
+      QTimer::singleShot(0, obj, [sub, ipCopy]() { sub->handleSetProperty(ipCopy); });
+      return;
+   }
+
+   sub->handleSetProperty(ipRecv);
+}
+
+inline void _dispatchOnConnect( multiIndiSubscriber * sub )
+{
+   if(auto * obj = dynamic_cast<QObject *>(sub))
+   {
+      QTimer::singleShot(0, obj, [sub]() { sub->onConnect(); });
+      return;
+   }
+
+   sub->onConnect();
+}
 
 /// An INDI client which serves as a publisher for many subscribers.
 /** This allows many widgets to use a single INDI client connection from within
@@ -30,6 +82,7 @@ protected:
 
    std::string m_hostAddress;
    std::string m_hostPort;
+   std::recursive_mutex m_subMutex;
 
 public:
 
@@ -40,6 +93,27 @@ public:
                      );
 
    ~multiIndiPublisher() noexcept {};
+
+   virtual int addSubscriber( multiIndiSubscriber * sub )
+   {
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      return multiIndiSubscriber::addSubscriber(sub);
+   }
+
+   virtual void unsubscribe( multiIndiSubscriber * sub )
+   {
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      multiIndiSubscriber::unsubscribe(sub);
+   }
+
+   virtual void unsubscribe( multiIndiSubscriber * sub,
+                             const std::string & device,
+                             const std::string & propName
+                           )
+   {
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      multiIndiSubscriber::unsubscribe(sub, device, propName);
+   }
 
 
    /// Subscribes the given instance of multiIndiSubscriber for notifications on the given property.
@@ -81,7 +155,17 @@ public:
    /// Called once the parent is connected.
    virtual void onConnect()
    {
-      multiIndiSubscriber::onConnect();
+      std::vector<multiIndiSubscriber *> subs;
+      {
+         std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+         subs.reserve(subscribers.size());
+         for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+      }
+
+      for(auto * sub : subs)
+      {
+         _dispatchOnConnect(sub);
+      }
    }
 
    virtual void sendNewProperty( const pcf::IndiProperty &ipSend)
@@ -111,9 +195,12 @@ int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber * sub,
                                                pcf::IndiProperty & ipSub
                                              )
 {
-   if(multiIndiSubscriber::addSubscriberProperty(sub, ipSub) != 0)
    {
-      return -1;
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      if(multiIndiSubscriber::addSubscriberProperty(sub, ipSub) != 0)
+      {
+         return -1;
+      }
    }
 
    //note: we have to send this every time b/c otherwise late subscribers won't get an update on subscribe
@@ -125,31 +212,51 @@ int multiIndiPublisher::addSubscriberProperty( multiIndiSubscriber * sub,
 inline
 void multiIndiPublisher::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it)
+   std::vector<multiIndiSubscriber *> subs;
    {
-      (*it)->handleDefProperty(ipRecv);
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      subs.reserve(subscribers.size());
+      for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+   }
+
+   for(auto * sub : subs)
+   {
+      _dispatchDefProperty(sub, ipRecv);
    }
 }
 
 inline
 void multiIndiPublisher::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
-   for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it)
+   std::vector<multiIndiSubscriber *> subs;
    {
-      (*it)->handleDelProperty(ipRecv);
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      subs.reserve(subscribers.size());
+      for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it) subs.push_back(*it);
+   }
+
+   for(auto * sub : subs)
+   {
+      _dispatchDelProperty(sub, ipRecv);
    }
 }
 
 inline
 void multiIndiPublisher::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-   std::pair< propMapIteratorT, propMapIteratorT> range = subscribedProperties.equal_range(ipRecv.createUniqueKey());
-
-   if(range.first == subscribedProperties.end()) return;
-
-   for(propMapIteratorT it = range.first; it != range.second; ++it)
+   std::vector<multiIndiSubscriber *> subs;
    {
-      it->second->handleSetProperty(ipRecv);
+      std::lock_guard<std::recursive_mutex> lock(m_subMutex);
+      std::pair< propMapIteratorT, propMapIteratorT> range = subscribedProperties.equal_range(ipRecv.createUniqueKey());
+
+      if(range.first == subscribedProperties.end()) return;
+
+      for(propMapIteratorT it = range.first; it != range.second; ++it) subs.push_back(it->second);
+   }
+
+   for(auto * sub : subs)
+   {
+      _dispatchSetProperty(sub, ipRecv);
    }
 }
 

--- a/gui/lib/multiIndiSubscriber.hpp
+++ b/gui/lib/multiIndiSubscriber.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 
+#include <atomic>
 #include <unordered_map>
 #include <set>
 
@@ -39,7 +40,7 @@ protected:
 
    subSetT subscribers;
 
-   bool m_disconnect {false};
+   std::atomic_bool m_disconnect {false};
 
 public:
 
@@ -97,14 +98,12 @@ public:
 
    void setDisconnect()
    {
-      m_disconnect = true;
+      m_disconnect.store(true, std::memory_order_relaxed);
    }
 
    bool disconnect()
    {
-      bool disc = m_disconnect;
-      m_disconnect = false;
-      return disc;
+      return m_disconnect.exchange(false, std::memory_order_relaxed);
    }
 
    /// Callback for a `defProperty` message notifying us that the propery has changed.

--- a/gui/lib/multiIndiSubscriber.hpp
+++ b/gui/lib/multiIndiSubscriber.hpp
@@ -1,307 +1,286 @@
+/** \file multiIndiSubscriber.hpp
+ * \brief Subscriber interface and routing for shared INDI publishers.
+ */
 #ifndef multiIndiSubscriber_hpp
 #define multiIndiSubscriber_hpp
 
-#include <iostream>
-
 #include <atomic>
-#include <unordered_map>
+#include <iostream>
 #include <set>
+#include <unordered_map>
 
 #include "../../INDI/libcommon/IndiProperty.hpp"
 
 /// Class implementing the functions of a subscriber to a multiIndiPublisher.
-/** Derived classes will implement handleSetProperty, which is the callback
-  * for the publisher to use when a property changes.
-  */
+/** Derived classes implement property callbacks used by a publisher.
+ */
 class multiIndiSubscriber
 {
 
-public:
+  public:
+    /// Subscriber pointers are stored in a map keyed by `device.name` unique key.
+    typedef std::unordered_multimap<std::string, multiIndiSubscriber *> propMapT;
 
-   /// Subscriber pointers are stored in a map, keyed by the property `device.name` unique key.
-   typedef std::unordered_multimap< std::string, multiIndiSubscriber *> propMapT;
+    /// Forward iterator for the unordered_multimap of subscribers.
+    typedef propMapT::iterator propMapIteratorT;
 
-   /// The forward iterator for the unordered_multimap of subscribers
-   typedef propMapT::iterator propMapIteratorT;
+    /// Subscriber pointers are also stored in a set, to allow iteration.
+    typedef std::set<multiIndiSubscriber *> subSetT;
 
-   /// Subscriber pointers are also stored in a set, to allow iteration over them
-   typedef std::set<multiIndiSubscriber*> subSetT;
+    /// Iterator for the set of subscriber pointers.
+    typedef subSetT::iterator subSetIteratorT;
 
-   /// The iterator for the set of subscriber pointers
-   typedef subSetT::iterator subSetIteratorT;
+  protected:
+    multiIndiSubscriber *m_parent{ nullptr }; ///< Parent subscriber/publisher this instance is attached to.
 
-protected:
+    propMapT subscribedProperties; ///< Property-specific child subscriptions.
 
-   /// The parent subscriber to which the instance is subscribed.
-   multiIndiSubscriber * m_parent {nullptr};
+    subSetT subscribers; ///< Child subscribers registered under this instance.
 
-   /// Child subscribers for which this instance is the parent
-   propMapT subscribedProperties;
+    std::atomic_bool m_disconnect{ false }; ///< One-shot disconnect flag consumed by disconnect().
 
-   subSetT subscribers;
+  public:
+    /// Constructs an unbound subscriber.
+    multiIndiSubscriber();
 
-   std::atomic_bool m_disconnect {false};
-
-public:
-
-   multiIndiSubscriber();
-
-   /// Destructor
-   /** Unsubscribes from the publisher.
+    /// Destructor.
+    /** Unsubscribes from parent publisher if currently attached.
      */
-   virtual ~multiIndiSubscriber() noexcept;
+    virtual ~multiIndiSubscriber() noexcept;
 
-   virtual void subscribe() {}
+    /// Hook invoked when the subscriber is attached to a parent.
+    virtual void subscribe();
 
-   /// Subscribes the given instance of multiIndiSubscriber to this instance
-   /**
-     * \returns 0 on success.
-     * \returns -1 on error.
+    /// Subscribes the given instance of multiIndiSubscriber to this instance.
+    /** \returns 0 on success, -1 on error.
      */
-   virtual int addSubscriber( multiIndiSubscriber * sub /**< [in] pointer to the subscriber */ );
+    virtual int addSubscriber( multiIndiSubscriber *sub /**< [in] Pointer to the subscriber. */ );
 
-   /// Subscribes the given instance of multiIndiSubscriber for notifications on the given property.
-   /**
-     * \returns 0 on success.
-     * \returns -1 on error.
+    /// Subscribes a child to a specific property.
+    /** \returns 0 on success, -1 on error.
      */
-   virtual int addSubscriberProperty( multiIndiSubscriber * sub, ///< [in] pointer to the subscriber
-                                      pcf::IndiProperty & ipSub  ///< [in] the property being subscribed to.
-                                    );
+    virtual int addSubscriberProperty( multiIndiSubscriber *sub,  /**< [in] Pointer to the subscriber. */
+                                       pcf::IndiProperty   &ipSub /**< [in] Property being subscribed to. */
+    );
 
-   virtual int addSubscriberProperty( multiIndiSubscriber * sub,   ///< [in] pointer to the subscriber
-                                      const std::string & device,  ///< [in] name of the device being subscribed to.
-                                      const std::string & propName ///< [in] name of the property being subscribed to
-                                    );
-
-   /// Remove all subscriptions for this subscriber.
-   /** This is mainly called by the multiIndiSubscriber destructor.
+    /// Subscribes a child to a property by device and property name.
+    /** \returns 0 on success, -1 on error.
      */
-   virtual void unsubscribe( multiIndiSubscriber * sub /**< [in] the subscriber being un-subscribed*/);
+    virtual int addSubscriberProperty( multiIndiSubscriber *sub,     /**< [in] Pointer to the subscriber. */
+                                       const std::string   &device,  /**< [in] Device name being subscribed to. */
+                                       const std::string   &propName /**< [in] Property name being subscribed to. */
+    );
 
-   virtual void unsubscribe( multiIndiSubscriber * sub,   ///< [in] the subscriber being un-subscribed
-                             const std::string & device,  ///< [in] name of the device being un-subscribed from.
-                             const std::string & propName ///< [in] name of the property being un-subscribed from
-                           );
-
-   /// Called by the parent once the parent is connected.
-   /** If this is reimplemented, you should call multiIndiSubscriber::onConnect() to ensure children are notified.
-     *
+    /// Removes all subscriptions for a child subscriber.
+    /** Mainly called by the multiIndiSubscriber destructor.
      */
-   virtual void onConnect();
+    virtual void unsubscribe( multiIndiSubscriber *sub /**< [in] Subscriber being unsubscribed. */ );
 
-   /// Called by the parent once the parent is disconnected.
-   /** If this is reimplemented, you should call multiIndiSubscriber::onDisconnect() to ensure children are notified.
-     *
+    /// Removes a single property subscription for a child subscriber.
+    virtual void unsubscribe( multiIndiSubscriber *sub,     /**< [in] Subscriber being unsubscribed. */
+                              const std::string   &device,  /**< [in] Device name being unsubscribed from. */
+                              const std::string   &propName /**< [in] Property name being unsubscribed from. */
+    );
+
+    /// Called by the parent once connected.
+    /** If reimplemented, call `multiIndiSubscriber::onConnect()` to notify children.
      */
-   virtual void onDisconnect();
+    virtual void onConnect();
 
-   void setDisconnect()
-   {
-      m_disconnect.store(true, std::memory_order_relaxed);
-   }
-
-   bool disconnect()
-   {
-      return m_disconnect.exchange(false, std::memory_order_relaxed);
-   }
-
-   /// Callback for a `defProperty` message notifying us that the propery has changed.
-   /** This is called by the publisher which is subscribed to.
-     *
-     * Derived classes shall implement this.
+    /// Called by the parent once disconnected.
+    /** If reimplemented, call `multiIndiSubscriber::onDisconnect()` to notify children.
      */
-   virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been defined*/);
+    virtual void onDisconnect();
 
-   /// Callback for a `delProperty` message notifying us that the propery has changed.
-   /** This is called by the publisher which is subscribed to.
-     *
-     * Derived classes shall implement this.
+    /// Sets the disconnect flag consumed by `disconnect()`.
+    void setDisconnect();
+
+    /// Consumes and returns the current disconnect flag.
+    /** \returns True if a disconnect was requested since last call.
      */
-   virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/);
+    bool disconnect();
 
-   /// Callback for a `setProperty` message notifying us that the propery has changed.
-   /** This is called by the publisher which is subscribed to.
-     *
-     * Derived classes shall implement this.
-     */
-   virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Callback for a `defProperty` message.
+    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has been defined. */ );
 
-   /// Send an `newProperty` request to a remote device.
-   /** This is a request to update a property that the remote device owns.
-     */
-   virtual void sendNewProperty( const pcf::IndiProperty &ipSend /**< [in] the property to send a change request for*/);
+    /// Callback for a `delProperty` message.
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has been deleted. */ );
 
-   /// Send an `getProperties` request to a remote device.
-   /** This is a request to get the value of a property or all properties.
-    */
-   virtual void sendGetProperties(const pcf::IndiProperty &ipSend /**< [in] the property to send a change request for*/);
+    /// Callback for a `setProperty` message.
+    virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has changed. */ );
+
+    /// Sends a `newProperty` request to a remote device.
+    virtual void sendNewProperty( const pcf::IndiProperty &ipSend /**< [in] Property change request. */ );
+
+    /// Sends a `getProperties` request to a remote device.
+    virtual void sendGetProperties( const pcf::IndiProperty &ipSend /**< [in] Property query request. */ );
 };
 
-inline
-multiIndiSubscriber::multiIndiSubscriber()
+inline multiIndiSubscriber::multiIndiSubscriber()
 {
 }
 
-inline
-multiIndiSubscriber::~multiIndiSubscriber() noexcept
+inline multiIndiSubscriber::~multiIndiSubscriber() noexcept
 {
-   if(m_parent)
-   {
-      m_parent->unsubscribe(this);
-   }
+    if( m_parent )
+    {
+        m_parent->unsubscribe( this );
+    }
 }
 
-inline
-int multiIndiSubscriber::addSubscriber( multiIndiSubscriber * sub )
+inline void multiIndiSubscriber::subscribe()
 {
-   subscribers.insert(sub);
-   sub->m_parent = this;
-   sub->subscribe();
-   return 0;
 }
 
-inline
-int multiIndiSubscriber::addSubscriberProperty( multiIndiSubscriber * sub,
-                                                pcf::IndiProperty & ipSub
-                                              )
+inline int multiIndiSubscriber::addSubscriber( multiIndiSubscriber *sub )
 {
-   subscribedProperties.insert(std::pair<std::string,multiIndiSubscriber*>(ipSub.createUniqueKey(), sub));
-
-   subscribers.insert(sub);
-   sub->m_parent = this;
-
-   return 0;
+    subscribers.insert( sub );
+    sub->m_parent = this;
+    sub->subscribe();
+    return 0;
 }
 
-inline
-int multiIndiSubscriber::addSubscriberProperty( multiIndiSubscriber * sub,
-                                                const std::string & device,
-                                                const std::string & propName
-                                              )
+inline int multiIndiSubscriber::addSubscriberProperty( multiIndiSubscriber *sub, pcf::IndiProperty &ipSub )
 {
-   pcf::IndiProperty ipSub;
-   ipSub.setDevice(device);
-   ipSub.setName(propName);
+    subscribedProperties.insert( std::pair<std::string, multiIndiSubscriber *>( ipSub.createUniqueKey(), sub ) );
 
-   return addSubscriberProperty(sub, ipSub);
+    subscribers.insert( sub );
+    sub->m_parent = this;
+
+    return 0;
 }
 
-inline
-void multiIndiSubscriber::unsubscribe( multiIndiSubscriber * sub )
+inline int multiIndiSubscriber::addSubscriberProperty( multiIndiSubscriber *sub,
+                                                       const std::string   &device,
+                                                       const std::string   &propName )
 {
-   //Since this is a forward iterator, we can't just for-loop through this because the erase invalidates, and we can't decrement!
-   auto it = subscribedProperties.begin();
-   while(it != subscribedProperties.end() )
-   {
-      if(it->second == sub)
-      {
-         subscribedProperties.erase(it);
-         it=subscribedProperties.begin();
-      }
-      else  ++it;
-   }
+    pcf::IndiProperty ipSub;
+    ipSub.setDevice( device );
+    ipSub.setName( propName );
 
-   subscribers.erase(sub);
-   sub->m_parent = nullptr;
+    return addSubscriberProperty( sub, ipSub );
 }
 
-inline
-void multiIndiSubscriber::unsubscribe( multiIndiSubscriber * sub,
-                                       const std::string & device,
-                                       const std::string & propName
-                                     )
+inline void multiIndiSubscriber::unsubscribe( multiIndiSubscriber *sub )
 {
-   pcf::IndiProperty ipSub;
-   ipSub.setDevice(device);
-   ipSub.setName(propName);
+    // Since this is a forward iterator, erase invalidates and we cannot decrement.
+    auto it = subscribedProperties.begin();
+    while( it != subscribedProperties.end() )
+    {
+        if( it->second == sub )
+        {
+            subscribedProperties.erase( it );
+            it = subscribedProperties.begin();
+        }
+        else
+        {
+            ++it;
+        }
+    }
 
-   std::string key = ipSub.createUniqueKey();
-   //Since this is a forward iterator, we can't just for-loop through this because the erase invalidates, and we can't decrement!
-   auto it = subscribedProperties.begin();
-   while(it != subscribedProperties.end() )
-   {
-      if(it->first == key && it->second == sub)
-      {
-         subscribedProperties.erase(it);
-         it=subscribedProperties.begin();
-      }
-      else  ++it;
-   }
-
-   //Now check if we've unsubscribed from all properties
-   bool have = false;
-   for(auto it = subscribedProperties.begin(); it != subscribedProperties.end(); ++it)
-   {
-      if(it->second == sub)
-      {
-         have = true;
-         break;
-      }
-   }
-
-   if(!have)
-   {
-      subscribers.erase(sub);
-      sub->m_parent = nullptr;
-   }
+    subscribers.erase( sub );
+    sub->m_parent = nullptr;
 }
 
-inline
-void multiIndiSubscriber::onConnect()
+inline void
+multiIndiSubscriber::unsubscribe( multiIndiSubscriber *sub, const std::string &device, const std::string &propName )
 {
-   for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it)
-   {
-      (*it)->onConnect();
-   }
+    pcf::IndiProperty ipSub;
+    ipSub.setDevice( device );
+    ipSub.setName( propName );
+
+    std::string key = ipSub.createUniqueKey();
+    // Since this is a forward iterator, erase invalidates and we cannot decrement.
+    auto it = subscribedProperties.begin();
+    while( it != subscribedProperties.end() )
+    {
+        if( it->first == key && it->second == sub )
+        {
+            subscribedProperties.erase( it );
+            it = subscribedProperties.begin();
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    bool have = false;
+    for( auto it2 = subscribedProperties.begin(); it2 != subscribedProperties.end(); ++it2 )
+    {
+        if( it2->second == sub )
+        {
+            have = true;
+            break;
+        }
+    }
+
+    if( !have )
+    {
+        subscribers.erase( sub );
+        sub->m_parent = nullptr;
+    }
 }
 
-inline
-void multiIndiSubscriber::onDisconnect()
+inline void multiIndiSubscriber::onConnect()
 {
-   for(subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it)
-   {
-      (*it)->onDisconnect();
-   }
+    for( subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it )
+    {
+        ( *it )->onConnect();
+    }
 }
 
-inline
-void multiIndiSubscriber::handleDefProperty( const pcf::IndiProperty & ipRecv)
+inline void multiIndiSubscriber::onDisconnect()
 {
-   static_cast<void>(ipRecv);
+    for( subSetIteratorT it = subscribers.begin(); it != subscribers.end(); ++it )
+    {
+        ( *it )->onDisconnect();
+    }
 }
 
-inline
-void multiIndiSubscriber::handleDelProperty( const pcf::IndiProperty & ipRecv)
+inline void multiIndiSubscriber::setDisconnect()
 {
-   static_cast<void>(ipRecv);
+    m_disconnect.store( true, std::memory_order_relaxed );
 }
 
-inline
-void multiIndiSubscriber::handleSetProperty( const pcf::IndiProperty & ipRecv)
+inline bool multiIndiSubscriber::disconnect()
 {
-   static_cast<void>(ipRecv);
+    return m_disconnect.exchange( false, std::memory_order_relaxed );
 }
 
-inline
-void multiIndiSubscriber::sendNewProperty( const pcf::IndiProperty &ipSend )
+inline void multiIndiSubscriber::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   if(m_parent == nullptr)
-   {
-      return;
-   }
-   m_parent->sendNewProperty(ipSend);
+    static_cast<void>( ipRecv );
 }
 
-inline
-void multiIndiSubscriber::sendGetProperties(const pcf::IndiProperty &ipSend)
+inline void multiIndiSubscriber::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
-    if (m_parent == nullptr)
+    static_cast<void>( ipRecv );
+}
+
+inline void multiIndiSubscriber::handleSetProperty( const pcf::IndiProperty &ipRecv )
+{
+    static_cast<void>( ipRecv );
+}
+
+inline void multiIndiSubscriber::sendNewProperty( const pcf::IndiProperty &ipSend )
+{
+    if( m_parent == nullptr )
     {
         return;
     }
 
-    m_parent->sendGetProperties(ipSend);
+    m_parent->sendNewProperty( ipSend );
 }
 
-#endif //multiIndiSubscriber_hpp
+inline void multiIndiSubscriber::sendGetProperties( const pcf::IndiProperty &ipSend )
+{
+    if( m_parent == nullptr )
+    {
+        return;
+    }
+
+    m_parent->sendGetProperties( ipSend );
+}
+
+#endif // multiIndiSubscriber_hpp

--- a/gui/rtimv/plugins/indiDictionary/indiDictionary.cpp
+++ b/gui/rtimv/plugins/indiDictionary/indiDictionary.cpp
@@ -11,6 +11,7 @@ protected:
 
 public:
     std::set<std::string> m_subscribed;
+    std::mutex m_subscribedMutex;
 
 protected:
     dictionaryT *m_dict{nullptr};
@@ -41,8 +42,11 @@ public:
 
         std::string key = ipRecv.createUniqueKey();
 
-        if (m_subscribed.count(key) == 0)
-            return;
+        {
+            std::lock_guard<std::mutex> guard(m_subscribedMutex);
+            if (m_subscribed.count(key) == 0)
+                return;
+        }
 
         auto elIt = ipRecv.getElements().begin();
 
@@ -66,12 +70,23 @@ public:
                 val = ipRecv[elIt->second.getName()].get();
             }
 
-            (*m_dict)[elKey].setBlob(val.c_str(), val.size() + 1);
+            auto dit = m_dict->find(elKey);
+            if(dit == m_dict->end())
+            {
+                ++elIt;
+                continue;
+            }
+
+            dit->second.setBlob(val.c_str(), val.size() + 1);
 
             if(elKey == "tcsi.teldata.pa")
             {
                 m_northAngle = ipRecv[elIt->second.getName()].get<float>();
-                (*m_dict)["rtimv.north.angle"].setBlob(&m_northAngle, sizeof(float));
+                auto nit = m_dict->find("rtimv.north.angle");
+                if(nit != m_dict->end())
+                {
+                    nit->second.setBlob(&m_northAngle, sizeof(float));
+                }
             }
 
             ++elIt;
@@ -111,7 +126,12 @@ indiDictionary::indiDictionary() : rtimvDictionaryInterface()
 
 indiDictionary::~indiDictionary()
 {
+   m_connTimer.stop();
+   QObject::disconnect(&m_connTimer, SIGNAL(timeout()), this, SLOT(checkConnection()));
+
+   std::lock_guard<std::mutex> lock(m_clientMutex);
    if(m_client) delete m_client;
+   m_client = nullptr;
 }
 
 int indiDictionary::attachDictionary( dictionaryT * dict,
@@ -142,6 +162,7 @@ int indiDictionary::attachDictionary( dictionaryT * dict,
       if(m_dict)
       {
         (*m_dict)["tcsi.teldata.pa"].setBlob(nullptr, 0);
+        (*m_dict)["rtimv.north.angle"].setBlob(nullptr, 0);
       }
    }
 
@@ -193,8 +214,14 @@ void indiDictionary::checkConnection()
 
       std::string key = dev + "." + prop;
 
-      auto res = m_client->m_subscribed.insert(key);
-      if(res.second == true) //If we have inserted it, we snoop it
+      bool shouldSnoop = false;
+      {
+         std::lock_guard<std::mutex> guard(m_client->m_subscribedMutex);
+         auto res = m_client->m_subscribed.insert(key);
+         shouldSnoop = res.second;
+      }
+
+      if(shouldSnoop == true) //If we have inserted it, we snoop it
       {
          pcf::IndiProperty ipSend;
          ipSend.setDevice(dev);

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -1,3 +1,6 @@
+/** \file dmCtrl.hpp
+ * \brief Deformable mirror control widget for INDI-backed operations.
+ */
 
 #ifndef dmCtrl_hpp
 #define dmCtrl_hpp
@@ -14,529 +17,566 @@ namespace xqt
 
 class dmCtrl : public xWidget
 {
-   Q_OBJECT
+    Q_OBJECT
 
-protected:
+  protected:
+    std::string m_appState; ///< Current FSM state for the DM controller app.
 
-   std::string m_appState;
+    std::string m_dmName;    ///< INDI device name for the target DM application.
+    std::string m_shmimName; ///< Shared-memory stream name reported by the DM app.
 
-   std::string m_dmName;
-   std::string m_shmimName;
+    std::string              m_flatShmim;        ///< Shared-memory stream backing the selected flat.
+    bool                     m_flatSet{ false }; ///< True when a flat is currently applied.
+    std::string              m_flatName;         ///< Name of the selected flat option.
+    std::vector<std::string> m_flatOptions;      ///< Available flat options from INDI.
 
-   std::string m_flatShmim;
-   bool m_flatSet {false};
-   std::string m_flatName;
-   std::vector<std::string> m_flatOptions;
+    std::string              m_testShmim;        ///< Shared-memory stream backing the selected test pattern.
+    bool                     m_testSet{ false }; ///< True when a test pattern is currently applied.
+    std::string              m_testName;         ///< Name of the selected test option.
+    std::vector<std::string> m_testOptions;      ///< Available test options from INDI.
 
-   std::string m_testShmim;
-   bool m_testSet {false};
-   std::string m_testName;
-   std::vector<std::string> m_testOptions;
+    std::mutex m_stateMutex; ///< Guards cached state copied into the GUI thread.
 
-   std::mutex m_stateMutex;
+  public:
+    /// Constructs the DM control widget.
+    explicit dmCtrl( std::string    &dmName,                    /**< [in] INDI device name for the DM controller. */
+                     QWidget        *Parent = 0,                /**< [in] Optional parent widget. */
+                     Qt::WindowFlags f      = Qt::WindowFlags() /**< [in] Qt window flags. */
+    );
 
+    /// Destroys the widget and detaches from parent subscriber if attached.
+    ~dmCtrl();
 
-public:
-   explicit dmCtrl( std::string & dmName,
-                    QWidget * Parent = 0,
-                    Qt::WindowFlags f = Qt::WindowFlags()
-                  );
+    /// Subscribes this widget to required INDI properties.
+    void subscribe();
 
-   ~dmCtrl();
+    /// Handles parent connection events from subscriber framework.
+    virtual void onConnect();
 
-   void subscribe();
+    /// Handles parent disconnection events from subscriber framework.
+    virtual void onDisconnect();
 
-   virtual void onConnect();
-   virtual void onDisconnect();
+    /// Handles defProperty notifications.
+    void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has changed. */ );
 
-   void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handles setProperty notifications.
+    void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has changed. */ );
 
-   void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+  public slots:
+    /// Applies connected-state widget enablement and display updates.
+    void onConnectGUI();
 
+    /// Applies disconnected-state widget enablement and display updates.
+    void onDisconnectGUI();
 
-public slots:
-   void onConnectGUI();
-   void onDisconnectGUI();
-   void updateGUI();
+    /// Refreshes GUI controls from cached state.
+    void updateGUI();
 
-   void on_buttonInit_pressed();
-   void on_buttonZeroAll_pressed();
-   void on_buttonZero_pressed();
-   void on_buttonRelease_pressed();
+    /// Sends initDM request.
+    void on_buttonInit_pressed();
 
-   void on_comboSelectFlat_activated(int);
-   void on_buttonSetFlat_pressed();
-   void on_buttonZeroFlat_pressed();
+    /// Sends zeroAll request.
+    void on_buttonZeroAll_pressed();
 
-   void on_comboSelectTest_activated(int);
-   void on_buttonSetTest_pressed();
-   void on_buttonZeroTest_pressed();
+    /// Sends zeroDM request.
+    void on_buttonZero_pressed();
 
-signals:
+    /// Sends releaseDM request.
+    void on_buttonRelease_pressed();
 
-   void doOnConnect();
-   void doOnDisconnect();
-   void doUpdateGUI();
+    /// Updates selected flat and sends flat selection request.
+    void on_comboSelectFlat_activated( int index /**< [in] Combo-box index of selected flat. */ );
 
-private:
+    /// Sends request to apply currently selected flat.
+    void on_buttonSetFlat_pressed();
 
-   Ui::dmCtrl ui;
+    /// Sends request to clear applied flat.
+    void on_buttonZeroFlat_pressed();
+
+    /// Updates selected test and sends test selection request.
+    void on_comboSelectTest_activated( int index /**< [in] Combo-box index of selected test pattern. */ );
+
+    /// Sends request to apply currently selected test.
+    void on_buttonSetTest_pressed();
+
+    /// Sends request to clear applied test.
+    void on_buttonZeroTest_pressed();
+
+  signals:
+    /// Queues connected-state GUI updates onto the widget thread.
+    void doOnConnect();
+
+    /// Queues disconnected-state GUI updates onto the widget thread.
+    void doOnDisconnect();
+
+    /// Queues state refresh updates onto the widget thread.
+    void doUpdateGUI();
+
+  private:
+    Ui::dmCtrl ui; ///< Generated Qt UI object.
 };
 
-dmCtrl::dmCtrl( std::string & dmName,
-                QWidget * Parent,
-                Qt::WindowFlags f) : xWidget(Parent, f), m_dmName{dmName}
+dmCtrl::dmCtrl( std::string &dmName, QWidget *Parent, Qt::WindowFlags f ) : xWidget( Parent, f ), m_dmName{ dmName }
 {
-   ui.setupUi(this);
-   //ui.labelDMName->setText(m_dmName.c_str());
+    ui.setupUi( this );
+    // ui.labelDMName->setText(m_dmName.c_str());
 
-   setWindowTitle(QString(m_dmName.c_str()));
+    setWindowTitle( QString( m_dmName.c_str() ) );
 
-   ui.fsmState->NOTHOMED("RIP");
-   ui.fsmState->HOMING("INITIALIZING");
-   ui.fsmState->READY("NOT SET");
-   ui.fsmState->OPERATING("SET");
-   ui.fsmState->device(m_dmName);
+    ui.fsmState->NOTHOMED( "RIP" );
+    ui.fsmState->HOMING( "INITIALIZING" );
+    ui.fsmState->READY( "NOT SET" );
+    ui.fsmState->OPERATING( "SET" );
+    ui.fsmState->device( m_dmName );
 
-   setXwFont(ui.buttonInit);
-   setXwFont(ui.buttonZeroAll);
-   setXwFont(ui.buttonZero);
-   setXwFont(ui.buttonInit);
-   setXwFont(ui.buttonRelease);
-   setXwFont(ui.buttonSetFlat);
-   setXwFont(ui.buttonZeroFlat);
-   setXwFont(ui.buttonSetTest);
-   setXwFont(ui.buttonZeroTest);
-   setXwFont(ui.comboSelectFlat);
-   setXwFont(ui.comboSelectTest);
+    setXwFont( ui.buttonInit );
+    setXwFont( ui.buttonZeroAll );
+    setXwFont( ui.buttonZero );
+    setXwFont( ui.buttonInit );
+    setXwFont( ui.buttonRelease );
+    setXwFont( ui.buttonSetFlat );
+    setXwFont( ui.buttonZeroFlat );
+    setXwFont( ui.buttonSetTest );
+    setXwFont( ui.buttonZeroTest );
+    setXwFont( ui.comboSelectFlat );
+    setXwFont( ui.comboSelectTest );
 
-   //setXwFont(ui.fsmState);
+    // setXwFont(ui.fsmState);
 
-   setXwFont(ui.labelShmimName);
-   setXwFont(ui.labelShmimName_value);
-   setXwFont(ui.labelFlatShmim);
-   setXwFont(ui.labelFlatShmim_value);
-   setXwFont(ui.labelTestShmim);
-   setXwFont(ui.labelTestShmim_value);
+    setXwFont( ui.labelShmimName );
+    setXwFont( ui.labelShmimName_value );
+    setXwFont( ui.labelFlatShmim );
+    setXwFont( ui.labelFlatShmim_value );
+    setXwFont( ui.labelTestShmim );
+    setXwFont( ui.labelTestShmim_value );
 
-   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
+    connect( this, SIGNAL( doOnConnect() ), this, SLOT( onConnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doOnDisconnect() ), this, SLOT( onDisconnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ), Qt::QueuedConnection );
 
-   onDisconnectGUI();
+    onDisconnectGUI();
 }
 
 dmCtrl::~dmCtrl()
 {
-   if(m_parent) m_parent->unsubscribe(this);
+    if( m_parent )
+        m_parent->unsubscribe( this );
 }
 
 void dmCtrl::subscribe()
 {
-   if(!m_parent) return;
+    if( !m_parent )
+        return;
 
-   m_parent->addSubscriberProperty(this, m_dmName, "fsm");
-   m_parent->addSubscriberProperty(this, m_dmName, "sm_shmimName");
-   m_parent->addSubscriberProperty(this, m_dmName, "flat");
-   m_parent->addSubscriberProperty(this, m_dmName, "flat_shmim");
-   m_parent->addSubscriberProperty(this, m_dmName, "flat_set");
-   m_parent->addSubscriberProperty(this, m_dmName, "test");
-   m_parent->addSubscriberProperty(this, m_dmName, "test_shmim");
-   m_parent->addSubscriberProperty(this, m_dmName, "test_set");
-   m_parent->addSubscriber(ui.fsmState);
+    m_parent->addSubscriberProperty( this, m_dmName, "fsm" );
+    m_parent->addSubscriberProperty( this, m_dmName, "sm_shmimName" );
+    m_parent->addSubscriberProperty( this, m_dmName, "flat" );
+    m_parent->addSubscriberProperty( this, m_dmName, "flat_shmim" );
+    m_parent->addSubscriberProperty( this, m_dmName, "flat_set" );
+    m_parent->addSubscriberProperty( this, m_dmName, "test" );
+    m_parent->addSubscriberProperty( this, m_dmName, "test_shmim" );
+    m_parent->addSubscriberProperty( this, m_dmName, "test_set" );
+    m_parent->addSubscriber( ui.fsmState );
 
-   return;
+    return;
 }
 
 void dmCtrl::onConnect()
 {
-   emit doOnConnect();
+    emit doOnConnect();
 }
 
 void dmCtrl::onConnectGUI()
 {
-   //ui.labelDMName->setEnabled(true);
-   ui.fsmState->setEnabled(true);
-   ui.labelShmimName->setEnabled(true);
-   ui.labelShmimName_value->setEnabled(true);
-   ui.labelFlatShmim->setEnabled(true);
-   ui.labelFlatShmim_value->setEnabled(true);
-   ui.labelTestShmim->setEnabled(true);
-   ui.labelTestShmim_value->setEnabled(true);
+    // ui.labelDMName->setEnabled(true);
+    ui.fsmState->setEnabled( true );
+    ui.labelShmimName->setEnabled( true );
+    ui.labelShmimName_value->setEnabled( true );
+    ui.labelFlatShmim->setEnabled( true );
+    ui.labelFlatShmim_value->setEnabled( true );
+    ui.labelTestShmim->setEnabled( true );
+    ui.labelTestShmim_value->setEnabled( true );
 
-   ui.buttonZeroAll->setEnabled(true);
+    ui.buttonZeroAll->setEnabled( true );
 
-   ui.comboSelectFlat->setEnabled(true);
-   ui.comboSelectTest->setEnabled(true);
+    ui.comboSelectFlat->setEnabled( true );
+    ui.comboSelectTest->setEnabled( true );
 
-   ui.fsmState->onConnect();
+    ui.fsmState->onConnect();
 
-   setWindowTitle(QString(m_dmName.c_str()));
+    setWindowTitle( QString( m_dmName.c_str() ) );
 }
 
 void dmCtrl::onDisconnect()
 {
-   emit doOnDisconnect();
+    emit doOnDisconnect();
 }
 
 void dmCtrl::onDisconnectGUI()
 {
-   //ui.labelDMName->setEnabled(false);
-   ui.fsmState->setEnabled(false);
-   ui.labelShmimName->setEnabled(false);
-   ui.labelShmimName_value->setEnabled(false);
-   ui.labelFlatShmim->setEnabled(false);
-   ui.labelFlatShmim_value->setEnabled(false);
-   ui.labelTestShmim->setEnabled(false);
-   ui.labelTestShmim_value->setEnabled(false);
+    // ui.labelDMName->setEnabled(false);
+    ui.fsmState->setEnabled( false );
+    ui.labelShmimName->setEnabled( false );
+    ui.labelShmimName_value->setEnabled( false );
+    ui.labelFlatShmim->setEnabled( false );
+    ui.labelFlatShmim_value->setEnabled( false );
+    ui.labelTestShmim->setEnabled( false );
+    ui.labelTestShmim_value->setEnabled( false );
 
-   ui.buttonInit->setEnabled(false);
-   ui.buttonZero->setEnabled(false);
-   ui.buttonZeroAll->setEnabled(false);
-   ui.buttonRelease->setEnabled(false);
+    ui.buttonInit->setEnabled( false );
+    ui.buttonZero->setEnabled( false );
+    ui.buttonZeroAll->setEnabled( false );
+    ui.buttonRelease->setEnabled( false );
 
-   ui.buttonSetFlat->setEnabled(false);
-   ui.buttonZeroFlat->setEnabled(false);
+    ui.buttonSetFlat->setEnabled( false );
+    ui.buttonZeroFlat->setEnabled( false );
 
-   ui.buttonSetTest->setEnabled(false);
-   ui.buttonZeroTest->setEnabled(false);
+    ui.buttonSetTest->setEnabled( false );
+    ui.buttonZeroTest->setEnabled( false );
 
-   ui.comboSelectFlat->setEnabled(false);
-   ui.comboSelectTest->setEnabled(false);
+    ui.comboSelectFlat->setEnabled( false );
+    ui.comboSelectTest->setEnabled( false );
 
-   setWindowTitle(QString(m_dmName.c_str()) + QString(" (disconnected)"));
+    setWindowTitle( QString( m_dmName.c_str() ) + QString( " (disconnected)" ) );
 
-   ui.fsmState->onDisconnect();
+    ui.fsmState->onDisconnect();
 }
 
-void dmCtrl::handleDefProperty( const pcf::IndiProperty & ipRecv)
+void dmCtrl::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   return handleSetProperty(ipRecv);
+    return handleSetProperty( ipRecv );
 }
 
-void dmCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)
+void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-   std::lock_guard<std::mutex> lock(m_stateMutex);
+    std::lock_guard<std::mutex> lock( m_stateMutex );
 
-   if(ipRecv.getDevice() != m_dmName)
-   {
-      return;
-   }
-   else if(ipRecv.getName() == "fsm")
-   {
-      if(ipRecv.find("state"))
-      {
-         m_appState = ipRecv["state"].get<std::string>();
-      }
-   }
-   else if(ipRecv.getName() == "sm_shmimName")
-   {
-      if(ipRecv.find("name"))
-      {
-         m_shmimName = ipRecv["name"].get<std::string>();
-      }
-   }
-   else if(ipRecv.getName() == "flat")
-   {
-      m_flatOptions.clear();
-      m_flatName = "";
-      for(auto it=ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it)
-      {
-         m_flatOptions.push_back(it->first);
-         if(ipRecv[it->first] == pcf::IndiElement::On) m_flatName = it->first;
-      }
-   }
-   else if(ipRecv.getName() == "flat_shmim")
-   {
-      if(ipRecv.find("channel"))
-      {
-         m_flatShmim = ipRecv["channel"].get<std::string>();
-      }
-   }
-   else if(ipRecv.getName() == "flat_set")
-   {
-      if(ipRecv.find("toggle"))
-      {
-         if(ipRecv["toggle"] == pcf::IndiElement::On) m_flatSet = true;
-         else m_flatSet = false;
-      }
-   }
-   else if(ipRecv.getName() == "test")
-   {
-      m_testOptions.clear();
-      m_testName = "";
-      for(auto it=ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it)
-      {
-         m_testOptions.push_back(it->first);
-         if(ipRecv[it->first] == pcf::IndiElement::On) m_testName = it->first;
+    if( ipRecv.getDevice() != m_dmName )
+    {
+        return;
+    }
+    else if( ipRecv.getName() == "fsm" )
+    {
+        if( ipRecv.find( "state" ) )
+        {
+            m_appState = ipRecv["state"].get<std::string>();
+        }
+    }
+    else if( ipRecv.getName() == "sm_shmimName" )
+    {
+        if( ipRecv.find( "name" ) )
+        {
+            m_shmimName = ipRecv["name"].get<std::string>();
+        }
+    }
+    else if( ipRecv.getName() == "flat" )
+    {
+        m_flatOptions.clear();
+        m_flatName = "";
+        for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
+        {
+            m_flatOptions.push_back( it->first );
+            if( ipRecv[it->first] == pcf::IndiElement::On )
+                m_flatName = it->first;
+        }
+    }
+    else if( ipRecv.getName() == "flat_shmim" )
+    {
+        if( ipRecv.find( "channel" ) )
+        {
+            m_flatShmim = ipRecv["channel"].get<std::string>();
+        }
+    }
+    else if( ipRecv.getName() == "flat_set" )
+    {
+        if( ipRecv.find( "toggle" ) )
+        {
+            if( ipRecv["toggle"] == pcf::IndiElement::On )
+                m_flatSet = true;
+            else
+                m_flatSet = false;
+        }
+    }
+    else if( ipRecv.getName() == "test" )
+    {
+        m_testOptions.clear();
+        m_testName = "";
+        for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
+        {
+            m_testOptions.push_back( it->first );
+            if( ipRecv[it->first] == pcf::IndiElement::On )
+                m_testName = it->first;
+        }
+    }
+    else if( ipRecv.getName() == "test_shmim" )
+    {
+        if( ipRecv.find( "channel" ) )
+        {
+            m_testShmim = ipRecv["channel"].get<std::string>();
+        }
+    }
+    else if( ipRecv.getName() == "test_set" )
+    {
+        if( ipRecv.find( "toggle" ) )
+        {
+            if( ipRecv["toggle"] == pcf::IndiElement::On )
+                m_testSet = true;
+            else
+                m_testSet = false;
+        }
+    }
 
-      }
-   }
-   else if(ipRecv.getName() == "test_shmim")
-   {
-      if(ipRecv.find("channel"))
-      {
-         m_testShmim = ipRecv["channel"].get<std::string>();
-      }
-   }
-   else if(ipRecv.getName() == "test_set")
-   {
-      if(ipRecv.find("toggle"))
-      {
-         if(ipRecv["toggle"] == pcf::IndiElement::On) m_testSet = true;
-         else m_testSet = false;
-      }
-   }
-
-   emit doUpdateGUI();
-
+    emit doUpdateGUI();
 }
 
 void dmCtrl::updateGUI()
 {
-   std::string appState;
-   std::string shmimName;
-   std::string flatShmim;
-   std::string testShmim;
-   bool flatSet {false};
-   bool testSet {false};
-   std::string flatName;
-   std::string testName;
-   std::vector<std::string> flatOptions;
-   std::vector<std::string> testOptions;
+    std::string              appState;
+    std::string              shmimName;
+    std::string              flatShmim;
+    std::string              testShmim;
+    bool                     flatSet{ false };
+    bool                     testSet{ false };
+    std::string              flatName;
+    std::string              testName;
+    std::vector<std::string> flatOptions;
+    std::vector<std::string> testOptions;
 
-   {
-      std::lock_guard<std::mutex> lock(m_stateMutex);
-      appState = m_appState;
-      shmimName = m_shmimName;
-      flatShmim = m_flatShmim;
-      testShmim = m_testShmim;
-      flatSet = m_flatSet;
-      testSet = m_testSet;
-      flatName = m_flatName;
-      testName = m_testName;
-      flatOptions = m_flatOptions;
-      testOptions = m_testOptions;
-   }
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        appState    = m_appState;
+        shmimName   = m_shmimName;
+        flatShmim   = m_flatShmim;
+        testShmim   = m_testShmim;
+        flatSet     = m_flatSet;
+        testSet     = m_testSet;
+        flatName    = m_flatName;
+        testName    = m_testName;
+        flatOptions = m_flatOptions;
+        testOptions = m_testOptions;
+    }
 
-   ui.labelShmimName_value->setText(shmimName.c_str());
-   ui.labelFlatShmim_value->setText(flatShmim.c_str());
-   ui.labelTestShmim_value->setText(testShmim.c_str());
+    ui.labelShmimName_value->setText( shmimName.c_str() );
+    ui.labelFlatShmim_value->setText( flatShmim.c_str() );
+    ui.labelTestShmim_value->setText( testShmim.c_str() );
 
-   ui.comboSelectFlat->clear();
-   for(const auto & opt : flatOptions) ui.comboSelectFlat->addItem(opt.c_str());
-   if(!flatName.empty()) ui.comboSelectFlat->setCurrentText(flatName.c_str());
+    ui.comboSelectFlat->clear();
+    for( const auto &opt : flatOptions )
+        ui.comboSelectFlat->addItem( opt.c_str() );
+    if( !flatName.empty() )
+        ui.comboSelectFlat->setCurrentText( flatName.c_str() );
 
-   ui.comboSelectTest->clear();
-   for(const auto & opt : testOptions) ui.comboSelectTest->addItem(opt.c_str());
-   if(!testName.empty()) ui.comboSelectTest->setCurrentText(testName.c_str());
+    ui.comboSelectTest->clear();
+    for( const auto &opt : testOptions )
+        ui.comboSelectTest->addItem( opt.c_str() );
+    if( !testName.empty() )
+        ui.comboSelectTest->setCurrentText( testName.c_str() );
 
-//    ui.buttonSetFlat->setEnabled(true);
-//    ui.buttonZeroFlat->setEnabled(true);
-//
-//    ui.buttonSetTest->setEnabled(true);
-//    ui.buttonZeroTest->setEnabled(true);
-//
-   if( appState != "NOTHOMED" && appState != "READY" && appState != "OPERATING" )
-   {
-      //Disable & zero all
+    //    ui.buttonSetFlat->setEnabled(true);
+    //    ui.buttonZeroFlat->setEnabled(true);
+    //
+    //    ui.buttonSetTest->setEnabled(true);
+    //    ui.buttonZeroTest->setEnabled(true);
+    //
+    if( appState != "NOTHOMED" && appState != "READY" && appState != "OPERATING" )
+    {
+        // Disable & zero all
 
-      ui.buttonInit->setEnabled(false);
-      ui.buttonZero->setEnabled(false);
-      ui.buttonRelease->setEnabled(false);
+        ui.buttonInit->setEnabled( false );
+        ui.buttonZero->setEnabled( false );
+        ui.buttonRelease->setEnabled( false );
 
-      ui.buttonSetFlat->setEnabled(false);
-      ui.buttonZeroFlat->setEnabled(false);
+        ui.buttonSetFlat->setEnabled( false );
+        ui.buttonZeroFlat->setEnabled( false );
 
-      ui.buttonSetTest->setEnabled(false);
-      ui.buttonZeroTest->setEnabled(false);
+        ui.buttonSetTest->setEnabled( false );
+        ui.buttonZeroTest->setEnabled( false );
 
-      return;
-   }
+        return;
+    }
 
-   if( appState == "NOTHOMED" )
-   {
+    if( appState == "NOTHOMED" )
+    {
 
-      ui.buttonInit->setEnabled(true);
-      ui.buttonZero->setEnabled(false);
-      ui.buttonRelease->setEnabled(false);
+        ui.buttonInit->setEnabled( true );
+        ui.buttonZero->setEnabled( false );
+        ui.buttonRelease->setEnabled( false );
 
-      ui.buttonSetFlat->setEnabled(false);
-      ui.buttonZeroFlat->setEnabled(false);
+        ui.buttonSetFlat->setEnabled( false );
+        ui.buttonZeroFlat->setEnabled( false );
 
-      ui.buttonSetTest->setEnabled(false);
-      ui.buttonZeroTest->setEnabled(false);
+        ui.buttonSetTest->setEnabled( false );
+        ui.buttonZeroTest->setEnabled( false );
 
-      return;
-   }
+        return;
+    }
 
-   ui.buttonInit->setEnabled(false);
-   ui.buttonZero->setEnabled(true);
-   ui.buttonRelease->setEnabled(true);
+    ui.buttonInit->setEnabled( false );
+    ui.buttonZero->setEnabled( true );
+    ui.buttonRelease->setEnabled( true );
 
+    if( flatSet == false )
+    {
+        ui.buttonSetFlat->setEnabled( true );
+        ui.buttonZeroFlat->setEnabled( false );
+    }
+    else
+    {
+        ui.buttonSetFlat->setEnabled( false );
+        ui.buttonZeroFlat->setEnabled( true );
+    }
 
-   if(flatSet == false)
-   {
-      ui.buttonSetFlat->setEnabled(true);
-      ui.buttonZeroFlat->setEnabled(false);
-   }
-   else
-   {
-      ui.buttonSetFlat->setEnabled(false);
-      ui.buttonZeroFlat->setEnabled(true);
-   }
+    if( testSet == false )
+    {
+        ui.buttonSetTest->setEnabled( true );
+        ui.buttonZeroTest->setEnabled( false );
+    }
+    else
+    {
+        ui.buttonSetTest->setEnabled( false );
+        ui.buttonZeroTest->setEnabled( true );
+    }
 
-   if(testSet == false)
-   {
-      ui.buttonSetTest->setEnabled(true);
-      ui.buttonZeroTest->setEnabled(false);
-   }
-   else
-   {
-      ui.buttonSetTest->setEnabled(false);
-      ui.buttonZeroTest->setEnabled(true);
-   }
-
-} //updateGUI()
+} // updateGUI()
 
 void dmCtrl::on_buttonInit_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("initDM");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "initDM" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonZeroAll_pressed()
 {
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ip( pcf::IndiProperty::Switch );
 
-   ip.setDevice(m_dmName);
-   ip.setName("zeroAll");
-   ip.add(pcf::IndiElement("request"));
+    ip.setDevice( m_dmName );
+    ip.setName( "zeroAll" );
+    ip.add( pcf::IndiElement( "request" ) );
 
-   ip["request"].setSwitchState(pcf::IndiElement::On);
+    ip["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void dmCtrl::on_buttonZero_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("zeroDM");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "zeroDM" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonRelease_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("releaseDM");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "releaseDM" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
-
-
-void dmCtrl::on_comboSelectFlat_activated(int index)
+void dmCtrl::on_comboSelectFlat_activated( int index )
 {
-   std::string choice = ui.comboSelectFlat->itemText(index).toStdString();
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("flat");
+    std::string       choice = ui.comboSelectFlat->itemText( index ).toStdString();
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "flat" );
 
-   for(int i=0; i < ui.comboSelectFlat->count(); ++i)
-   {
-      std::string eln = ui.comboSelectFlat->itemText(i).toStdString();
-      std::cerr << eln << "\n";
-      ipFreq.add(pcf::IndiElement(eln));
-      if(eln == choice) ipFreq[eln] = pcf::IndiElement::On;
-      else ipFreq[eln] = pcf::IndiElement::Off;
-   }
-   sendNewProperty(ipFreq);
+    for( int i = 0; i < ui.comboSelectFlat->count(); ++i )
+    {
+        std::string eln = ui.comboSelectFlat->itemText( i ).toStdString();
+        std::cerr << eln << "\n";
+        ipFreq.add( pcf::IndiElement( eln ) );
+        if( eln == choice )
+            ipFreq[eln] = pcf::IndiElement::On;
+        else
+            ipFreq[eln] = pcf::IndiElement::Off;
+    }
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonSetFlat_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("flat_set");
-   ipFreq.add(pcf::IndiElement("toggle"));
-   ipFreq["toggle"] = pcf::IndiElement::On;
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "flat_set" );
+    ipFreq.add( pcf::IndiElement( "toggle" ) );
+    ipFreq["toggle"] = pcf::IndiElement::On;
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonZeroFlat_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("flat_set");
-   ipFreq.add(pcf::IndiElement("toggle"));
-   ipFreq["toggle"] = pcf::IndiElement::Off;
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "flat_set" );
+    ipFreq.add( pcf::IndiElement( "toggle" ) );
+    ipFreq["toggle"] = pcf::IndiElement::Off;
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
-
-
-void dmCtrl::on_comboSelectTest_activated(int index)
+void dmCtrl::on_comboSelectTest_activated( int index )
 {
-   std::string choice = ui.comboSelectTest->itemText(index).toStdString();
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("test");
+    std::string       choice = ui.comboSelectTest->itemText( index ).toStdString();
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "test" );
 
-   for(int i=0; i < ui.comboSelectTest->count(); ++i)
-   {
-      std::string eln = ui.comboSelectTest->itemText(i).toStdString();
-      ipFreq.add(pcf::IndiElement(eln));
-      if(eln == choice) ipFreq[eln] = pcf::IndiElement::On;
-      else ipFreq[eln] = pcf::IndiElement::Off;
-   }
-   sendNewProperty(ipFreq);
+    for( int i = 0; i < ui.comboSelectTest->count(); ++i )
+    {
+        std::string eln = ui.comboSelectTest->itemText( i ).toStdString();
+        ipFreq.add( pcf::IndiElement( eln ) );
+        if( eln == choice )
+            ipFreq[eln] = pcf::IndiElement::On;
+        else
+            ipFreq[eln] = pcf::IndiElement::Off;
+    }
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonSetTest_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("test_set");
-   ipFreq.add(pcf::IndiElement("toggle"));
-   ipFreq["toggle"] = pcf::IndiElement::On;
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "test_set" );
+    ipFreq.add( pcf::IndiElement( "toggle" ) );
+    ipFreq["toggle"] = pcf::IndiElement::On;
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void dmCtrl::on_buttonZeroTest_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_dmName);
-   ipFreq.setName("test_set");
-   ipFreq.add(pcf::IndiElement("toggle"));
-   ipFreq["toggle"] = pcf::IndiElement::Off;
+    ipFreq.setDevice( m_dmName );
+    ipFreq.setName( "test_set" );
+    ipFreq.add( pcf::IndiElement( "toggle" ) );
+    ipFreq["toggle"] = pcf::IndiElement::Off;
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
-} //namespace xqt
+} // namespace xqt
 
 #include "moc_dmCtrl.cpp"
 

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -2,6 +2,9 @@
 #ifndef dmCtrl_hpp
 #define dmCtrl_hpp
 
+#include <mutex>
+#include <vector>
+
 #include "ui_dmCtrl.h"
 
 #include "../xWidgets/xWidget.hpp"
@@ -23,10 +26,14 @@ protected:
    std::string m_flatShmim;
    bool m_flatSet {false};
    std::string m_flatName;
+   std::vector<std::string> m_flatOptions;
 
    std::string m_testShmim;
    bool m_testSet {false};
    std::string m_testName;
+   std::vector<std::string> m_testOptions;
+
+   std::mutex m_stateMutex;
 
 
 public:
@@ -48,6 +55,8 @@ public:
 
 
 public slots:
+   void onConnectGUI();
+   void onDisconnectGUI();
    void updateGUI();
 
    void on_buttonInit_pressed();
@@ -65,6 +74,8 @@ public slots:
 
 signals:
 
+   void doOnConnect();
+   void doOnDisconnect();
    void doUpdateGUI();
 
 private:
@@ -108,9 +119,11 @@ dmCtrl::dmCtrl( std::string & dmName,
    setXwFont(ui.labelTestShmim);
    setXwFont(ui.labelTestShmim_value);
 
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()));
+   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
 
-   onDisconnect();
+   onDisconnectGUI();
 }
 
 dmCtrl::~dmCtrl()
@@ -137,6 +150,11 @@ void dmCtrl::subscribe()
 
 void dmCtrl::onConnect()
 {
+   emit doOnConnect();
+}
+
+void dmCtrl::onConnectGUI()
+{
    //ui.labelDMName->setEnabled(true);
    ui.fsmState->setEnabled(true);
    ui.labelShmimName->setEnabled(true);
@@ -157,6 +175,11 @@ void dmCtrl::onConnect()
 }
 
 void dmCtrl::onDisconnect()
+{
+   emit doOnDisconnect();
+}
+
+void dmCtrl::onDisconnectGUI()
 {
    //ui.labelDMName->setEnabled(false);
    ui.fsmState->setEnabled(false);
@@ -184,8 +207,6 @@ void dmCtrl::onDisconnect()
    setWindowTitle(QString(m_dmName.c_str()) + QString(" (disconnected)"));
 
    ui.fsmState->onDisconnect();
-
-   multiIndiSubscriber::onDisconnect();
 }
 
 void dmCtrl::handleDefProperty( const pcf::IndiProperty & ipRecv)
@@ -195,6 +216,8 @@ void dmCtrl::handleDefProperty( const pcf::IndiProperty & ipRecv)
 
 void dmCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)
 {
+   std::lock_guard<std::mutex> lock(m_stateMutex);
+
    if(ipRecv.getDevice() != m_dmName)
    {
       return;
@@ -215,16 +238,12 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)
    }
    else if(ipRecv.getName() == "flat")
    {
-      ui.comboSelectFlat->clear();
-
+      m_flatOptions.clear();
+      m_flatName = "";
       for(auto it=ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it)
       {
-         if(ui.comboSelectFlat->findText(it->first.c_str(), Qt::MatchExactly | Qt::MatchCaseSensitive) == -1)
-         {
-            ui.comboSelectFlat->addItem(it->first.c_str());
-         }
-
-         if(ipRecv[it->first] == pcf::IndiElement::On) ui.comboSelectFlat->setCurrentText(it->first.c_str());
+         m_flatOptions.push_back(it->first);
+         if(ipRecv[it->first] == pcf::IndiElement::On) m_flatName = it->first;
       }
    }
    else if(ipRecv.getName() == "flat_shmim")
@@ -244,16 +263,12 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)
    }
    else if(ipRecv.getName() == "test")
    {
-      ui.comboSelectTest->clear();
-
+      m_testOptions.clear();
+      m_testName = "";
       for(auto it=ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it)
       {
-         if(ui.comboSelectTest->findText(it->first.c_str(), Qt::MatchExactly | Qt::MatchCaseSensitive) == -1)
-         {
-            ui.comboSelectTest->addItem(it->first.c_str());
-         }
-
-         if(ipRecv[it->first] == pcf::IndiElement::On) ui.comboSelectTest->setCurrentText(it->first.c_str());
+         m_testOptions.push_back(it->first);
+         if(ipRecv[it->first] == pcf::IndiElement::On) m_testName = it->first;
 
       }
    }
@@ -279,9 +294,42 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)
 
 void dmCtrl::updateGUI()
 {
-   ui.labelShmimName_value->setText(m_shmimName.c_str());
-   ui.labelFlatShmim_value->setText(m_flatShmim.c_str());
-   ui.labelTestShmim_value->setText(m_testShmim.c_str());
+   std::string appState;
+   std::string shmimName;
+   std::string flatShmim;
+   std::string testShmim;
+   bool flatSet {false};
+   bool testSet {false};
+   std::string flatName;
+   std::string testName;
+   std::vector<std::string> flatOptions;
+   std::vector<std::string> testOptions;
+
+   {
+      std::lock_guard<std::mutex> lock(m_stateMutex);
+      appState = m_appState;
+      shmimName = m_shmimName;
+      flatShmim = m_flatShmim;
+      testShmim = m_testShmim;
+      flatSet = m_flatSet;
+      testSet = m_testSet;
+      flatName = m_flatName;
+      testName = m_testName;
+      flatOptions = m_flatOptions;
+      testOptions = m_testOptions;
+   }
+
+   ui.labelShmimName_value->setText(shmimName.c_str());
+   ui.labelFlatShmim_value->setText(flatShmim.c_str());
+   ui.labelTestShmim_value->setText(testShmim.c_str());
+
+   ui.comboSelectFlat->clear();
+   for(const auto & opt : flatOptions) ui.comboSelectFlat->addItem(opt.c_str());
+   if(!flatName.empty()) ui.comboSelectFlat->setCurrentText(flatName.c_str());
+
+   ui.comboSelectTest->clear();
+   for(const auto & opt : testOptions) ui.comboSelectTest->addItem(opt.c_str());
+   if(!testName.empty()) ui.comboSelectTest->setCurrentText(testName.c_str());
 
 //    ui.buttonSetFlat->setEnabled(true);
 //    ui.buttonZeroFlat->setEnabled(true);
@@ -289,7 +337,7 @@ void dmCtrl::updateGUI()
 //    ui.buttonSetTest->setEnabled(true);
 //    ui.buttonZeroTest->setEnabled(true);
 //
-   if( m_appState != "NOTHOMED" && m_appState != "READY" && m_appState != "OPERATING" )
+   if( appState != "NOTHOMED" && appState != "READY" && appState != "OPERATING" )
    {
       //Disable & zero all
 
@@ -306,7 +354,7 @@ void dmCtrl::updateGUI()
       return;
    }
 
-   if( m_appState == "NOTHOMED" )
+   if( appState == "NOTHOMED" )
    {
 
       ui.buttonInit->setEnabled(true);
@@ -327,7 +375,7 @@ void dmCtrl::updateGUI()
    ui.buttonRelease->setEnabled(true);
 
 
-   if(m_flatSet == false)
+   if(flatSet == false)
    {
       ui.buttonSetFlat->setEnabled(true);
       ui.buttonZeroFlat->setEnabled(false);
@@ -338,7 +386,7 @@ void dmCtrl::updateGUI()
       ui.buttonZeroFlat->setEnabled(true);
    }
 
-   if(m_testSet == false)
+   if(testSet == false)
    {
       ui.buttonSetTest->setEnabled(true);
       ui.buttonZeroTest->setEnabled(false);

--- a/gui/widgets/pwr/pwr.hpp
+++ b/gui/widgets/pwr/pwr.hpp
@@ -118,10 +118,6 @@ void pwr::subscribe()
 {
     for( size_t n = 0; n < m_devices.size(); ++n )
     {
-        QObject::connect(
-            m_devices[n], SIGNAL( chChange( pcf::IndiProperty & ) ), this, SLOT( chChange( pcf::IndiProperty & ) ) );
-        QObject::connect( m_devices[n], SIGNAL( loadChanged() ), this, SLOT( updateGauges() ) );
-
         m_parent->addSubscriberProperty( this, m_devices[n]->deviceName(), "load" );
         m_parent->addSubscriberProperty( this, m_devices[n]->deviceName(), "channelOutlets" );
         m_parent->addSubscriberProperty( this, m_devices[n]->deviceName(), "channelOnDelays" );
@@ -136,12 +132,6 @@ void pwr::subscribe()
 
     for( size_t n = 0; n < m_adminDevices.size(); ++n )
     {
-        QObject::connect( m_adminDevices[n],
-                          SIGNAL( chChange( pcf::IndiProperty & ) ),
-                          this,
-                          SLOT( chChange( pcf::IndiProperty & ) ) );
-        QObject::connect( m_adminDevices[n], SIGNAL( loadChanged() ), this, SLOT( updateGauges() ) );
-
         m_parent->addSubscriberProperty( this, m_adminDevices[n]->deviceName(), "load" );
         m_parent->addSubscriberProperty( this, m_adminDevices[n]->deviceName(), "channelOutlets" );
         m_parent->addSubscriberProperty( this, m_adminDevices[n]->deviceName(), "channelOnDelays" );
@@ -276,6 +266,11 @@ void pwr::loadConfig( mx::app::appConfigurator &config )
             m_devices.push_back( new pwrDevice( this ) );
             m_devices.back()->deviceName( sections[i] );
             m_devices.back()->setChannels( user );
+            QObject::connect( m_devices.back(),
+                              SIGNAL( chChange( pcf::IndiProperty & ) ),
+                              this,
+                              SLOT( chChange( pcf::IndiProperty & ) ) );
+            QObject::connect( m_devices.back(), SIGNAL( loadChanged() ), this, SLOT( updateGauges() ) );
         }
 
         if( admin.size() > 0 )
@@ -283,6 +278,11 @@ void pwr::loadConfig( mx::app::appConfigurator &config )
             m_adminDevices.push_back( new pwrDevice( this ) );
             m_adminDevices.back()->deviceName( sections[i] );
             m_adminDevices.back()->setChannels( admin );
+            QObject::connect( m_adminDevices.back(),
+                              SIGNAL( chChange( pcf::IndiProperty & ) ),
+                              this,
+                              SLOT( chChange( pcf::IndiProperty & ) ) );
+            QObject::connect( m_adminDevices.back(), SIGNAL( loadChanged() ), this, SLOT( updateGauges() ) );
         }
     }
 

--- a/gui/widgets/xWidgets/fsmDisplay.hpp
+++ b/gui/widgets/xWidgets/fsmDisplay.hpp
@@ -1,6 +1,8 @@
 #ifndef fsmDisplay_hpp
 #define fsmDisplay_hpp
 
+#include <mutex>
+
 #include "xWidget.hpp"
 #include "statusLabel.hpp"
 
@@ -24,6 +26,7 @@ protected:
    bool m_valChanged {false};
 
    std::string m_value;
+   std::mutex m_stateMutex;
 
    std::string m_NOTHOMED {"NOTHOMED"};
    std::string m_HOMING {"HOMING"};
@@ -63,10 +66,14 @@ public:
 
 public slots:
 
+   void onConnectGUI();
+   void onDisconnectGUI();
    void updateGUI();
 
 signals:
 
+   void doOnConnect();
+   void doOnDisconnect();
    void doUpdateGUI();
 
 private:
@@ -79,9 +86,11 @@ fsmDisplay::fsmDisplay( QWidget * Parent,
 {
    ui.setupUi(this);
 
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()));
+   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
 
-   onDisconnect();
+   onDisconnectGUI();
 }
 
 fsmDisplay::fsmDisplay( const std::string & device,
@@ -89,8 +98,10 @@ fsmDisplay::fsmDisplay( const std::string & device,
                         Qt::WindowFlags f) : xWidget(Parent, f), m_device{device}
 {
    ui.setupUi(this);
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()));
-   onDisconnect();
+   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
+   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
+   onDisconnectGUI();
 }
 
 void fsmDisplay::device( const std::string & dev)
@@ -113,12 +124,27 @@ void fsmDisplay::subscribe()
 
 void fsmDisplay::onConnect()
 {
+   emit doOnConnect();
+}
+
+void fsmDisplay::onConnectGUI()
+{
+   std::lock_guard<std::mutex> lock(m_stateMutex);
    m_valChanged = true;
 }
 
 void fsmDisplay::onDisconnect()
 {
-   m_value = "---";
+   emit doOnDisconnect();
+}
+
+void fsmDisplay::onDisconnectGUI()
+{
+   {
+      std::lock_guard<std::mutex> lock(m_stateMutex);
+      m_value = "---";
+      m_valChanged = false;
+   }
    ui.fsm->setText("---");
 }
 
@@ -154,6 +180,7 @@ void fsmDisplay::handleSetProperty( const pcf::IndiProperty & ipRecv)
             value = m_OPERATING;
          }
 
+         std::lock_guard<std::mutex> lock(m_stateMutex);
          if(value != m_value) m_valChanged = true;
          m_value = value;
       }
@@ -185,18 +212,27 @@ void fsmDisplay::OPERATING( const std::string & s )
 
 void fsmDisplay::updateGUI()
 {
+   bool valChanged {false};
+   std::string valueStr;
+   {
+      std::lock_guard<std::mutex> lock(m_stateMutex);
+      valChanged = m_valChanged;
+      valueStr = m_value;
+   }
+
    if(isEnabled())
    {
-      if(m_valChanged)
+      if(valChanged)
       {
-         QString value(m_value.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
+         QString value(valueStr.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
          ui.fsm->setTextChanged(value);
+         std::lock_guard<std::mutex> lock(m_stateMutex);
          m_valChanged = false;
       }
    }
    else
    {
-      QString value(m_value.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
+      QString value(valueStr.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
       ui.fsm->setText(value);
    }
 

--- a/gui/widgets/xWidgets/fsmDisplay.hpp
+++ b/gui/widgets/xWidgets/fsmDisplay.hpp
@@ -1,3 +1,6 @@
+/** \file fsmDisplay.hpp
+ * \brief Widget that displays and highlights FSM state from an INDI property.
+ */
 #ifndef fsmDisplay_hpp
 #define fsmDisplay_hpp
 
@@ -13,100 +16,121 @@ namespace xqt
 
 class fsmDisplay : public xWidget
 {
-   Q_OBJECT
+    Q_OBJECT
 
-protected:
+  protected:
+    std::string m_device;             ///< INDI device name this display subscribes to.
+    std::string m_property{ "fsm" };  ///< INDI property name used for FSM state.
+    std::string m_element{ "state" }; ///< INDI element name containing FSM state text.
 
-   std::string m_device;
-   std::string m_property {"fsm"};
-   std::string m_element {"state"};
+    bool m_highlightChanges{ true }; ///< Enables changed-state text highlighting behavior.
 
-   bool m_highlightChanges {true};
+    bool m_valChanged{ false }; ///< True when cached value differs from last displayed value.
 
-   bool m_valChanged {false};
+    std::string m_value;      ///< Cached display value mirrored from INDI updates.
+    std::mutex  m_stateMutex; ///< Guards value cache shared between callback and GUI thread.
 
-   std::string m_value;
-   std::mutex m_stateMutex;
+    std::string m_NOTHOMED{ "NOTHOMED" };   ///< Display label mapping for NOTHOMED state.
+    std::string m_HOMING{ "HOMING" };       ///< Display label mapping for HOMING state.
+    std::string m_READY{ "READY" };         ///< Display label mapping for READY state.
+    std::string m_OPERATING{ "OPERATING" }; ///< Display label mapping for OPERATING state.
 
-   std::string m_NOTHOMED {"NOTHOMED"};
-   std::string m_HOMING {"HOMING"};
-   std::string m_READY {"READY"};
-   std::string m_OPERATING {"OPERATING"};
+  public:
+    /// Constructs the FSM display widget.
+    fsmDisplay( QWidget        *Parent = 0,                /**< [in] Optional parent widget. */
+                Qt::WindowFlags f      = Qt::WindowFlags() /**< [in] Qt window flags. */
+    );
 
-public:
-   fsmDisplay( QWidget * Parent = 0,
-               Qt::WindowFlags f = Qt::WindowFlags()
-             );
+    /// Constructs the FSM display widget with initial target device.
+    explicit fsmDisplay( const std::string &device,                    /**< [in] INDI device name. */
+                         QWidget           *Parent = 0,                /**< [in] Optional parent widget. */
+                         Qt::WindowFlags    f      = Qt::WindowFlags() /**< [in] Qt window flags. */
+    );
 
-   explicit fsmDisplay( const std::string & device,
-                        QWidget * Parent = 0,
-                        Qt::WindowFlags f = Qt::WindowFlags()
-                      );
+    /// Destroys the FSM display widget.
+    ~fsmDisplay();
 
-   ~fsmDisplay();
+    /// Sets the target INDI device for subscription.
+    void device( const std::string &dev /**< [in] INDI device name. */ );
 
-   void device( const std::string & dev);
+    /// Subscribes to configured FSM property updates.
+    virtual void subscribe();
 
-   virtual void subscribe();
+    /// Handles parent connection notifications.
+    virtual void onConnect();
 
-   virtual void onConnect();
+    /// Handles parent disconnection notifications.
+    virtual void onDisconnect();
 
-   virtual void onDisconnect();
+    /// Clears keyboard focus on this widget.
+    virtual void clearFocus();
 
-   virtual void clearFocus();
+    /// Handles defProperty notifications.
+    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Property which has changed. */ );
 
-   virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handles setProperty notifications.
+    virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Property which has changed. */ );
 
-   virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Overrides text shown for NOTHOMED state.
+    void NOTHOMED( const std::string &s /**< [in] Replacement label text. */ );
 
-   void NOTHOMED( const std::string & s );
-   void HOMING( const std::string & s );
-   void READY( const std::string & s );
-   void OPERATING( const std::string & s );
+    /// Overrides text shown for HOMING state.
+    void HOMING( const std::string &s /**< [in] Replacement label text. */ );
 
-public slots:
+    /// Overrides text shown for READY state.
+    void READY( const std::string &s /**< [in] Replacement label text. */ );
 
-   void onConnectGUI();
-   void onDisconnectGUI();
-   void updateGUI();
+    /// Overrides text shown for OPERATING state.
+    void OPERATING( const std::string &s /**< [in] Replacement label text. */ );
 
-signals:
+  public slots:
+    /// Applies connected-state GUI behavior on widget thread.
+    void onConnectGUI();
 
-   void doOnConnect();
-   void doOnDisconnect();
-   void doUpdateGUI();
+    /// Applies disconnected-state GUI behavior on widget thread.
+    void onDisconnectGUI();
 
-private:
+    /// Refreshes display from cached state.
+    void updateGUI();
 
-   Ui::fsmDisplay ui;
+  signals:
+    /// Queues connected-state GUI update onto widget thread.
+    void doOnConnect();
+
+    /// Queues disconnected-state GUI update onto widget thread.
+    void doOnDisconnect();
+
+    /// Queues display refresh onto widget thread.
+    void doUpdateGUI();
+
+  private:
+    Ui::fsmDisplay ui; ///< Generated Qt UI object.
 };
 
-fsmDisplay::fsmDisplay( QWidget * Parent,
-                        Qt::WindowFlags f) : xWidget(Parent, f)
+fsmDisplay::fsmDisplay( QWidget *Parent, Qt::WindowFlags f ) : xWidget( Parent, f )
 {
-   ui.setupUi(this);
+    ui.setupUi( this );
 
-   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
+    connect( this, SIGNAL( doOnConnect() ), this, SLOT( onConnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doOnDisconnect() ), this, SLOT( onDisconnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ), Qt::QueuedConnection );
 
-   onDisconnectGUI();
+    onDisconnectGUI();
 }
 
-fsmDisplay::fsmDisplay( const std::string & device,
-                        QWidget * Parent,
-                        Qt::WindowFlags f) : xWidget(Parent, f), m_device{device}
+fsmDisplay::fsmDisplay( const std::string &device, QWidget *Parent, Qt::WindowFlags f )
+    : xWidget( Parent, f ), m_device{ device }
 {
-   ui.setupUi(this);
-   connect(this, SIGNAL(doOnConnect()), this, SLOT(onConnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doOnDisconnect()), this, SLOT(onDisconnectGUI()), Qt::QueuedConnection);
-   connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()), Qt::QueuedConnection);
-   onDisconnectGUI();
+    ui.setupUi( this );
+    connect( this, SIGNAL( doOnConnect() ), this, SLOT( onConnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doOnDisconnect() ), this, SLOT( onDisconnectGUI() ), Qt::QueuedConnection );
+    connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ), Qt::QueuedConnection );
+    onDisconnectGUI();
 }
 
-void fsmDisplay::device( const std::string & dev)
+void fsmDisplay::device( const std::string &dev )
 {
-   m_device = dev;
+    m_device = dev;
 }
 
 fsmDisplay::~fsmDisplay()
@@ -115,134 +139,137 @@ fsmDisplay::~fsmDisplay()
 
 void fsmDisplay::subscribe()
 {
-   if(!m_parent) return;
+    if( !m_parent )
+        return;
 
-   if(m_property != "") m_parent->addSubscriberProperty(this, m_device, m_property);
+    if( m_property != "" )
+        m_parent->addSubscriberProperty( this, m_device, m_property );
 
-   return;
+    return;
 }
 
 void fsmDisplay::onConnect()
 {
-   emit doOnConnect();
+    emit doOnConnect();
 }
 
 void fsmDisplay::onConnectGUI()
 {
-   std::lock_guard<std::mutex> lock(m_stateMutex);
-   m_valChanged = true;
+    std::lock_guard<std::mutex> lock( m_stateMutex );
+    m_valChanged = true;
 }
 
 void fsmDisplay::onDisconnect()
 {
-   emit doOnDisconnect();
+    emit doOnDisconnect();
 }
 
 void fsmDisplay::onDisconnectGUI()
 {
-   {
-      std::lock_guard<std::mutex> lock(m_stateMutex);
-      m_value = "---";
-      m_valChanged = false;
-   }
-   ui.fsm->setText("---");
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_value      = "---";
+        m_valChanged = false;
+    }
+    ui.fsm->setText( "---" );
 }
 
-void fsmDisplay::handleDefProperty( const pcf::IndiProperty & ipRecv)
+void fsmDisplay::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   return handleSetProperty(ipRecv);
+    return handleSetProperty( ipRecv );
 }
 
-void fsmDisplay::handleSetProperty( const pcf::IndiProperty & ipRecv)
+void fsmDisplay::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getDevice() != m_device) return;
+    if( ipRecv.getDevice() != m_device )
+        return;
 
-   if(ipRecv.getName() == m_property)
-   {
-      if(ipRecv.find(m_element))
-      {
-         std::string value = ipRecv[m_element].get();
+    if( ipRecv.getName() == m_property )
+    {
+        if( ipRecv.find( m_element ) )
+        {
+            std::string value = ipRecv[m_element].get();
 
-         if(value == "NOTHOMED")
-         {
-            value = m_NOTHOMED;
-         }
-         else if(value == "HOMING")
-         {
-            value = m_HOMING;
-         }
-         else if(value == "READY")
-         {
-            value = m_READY;
-         }
-         else if(value == "OPERATING")
-         {
-            value = m_OPERATING;
-         }
+            if( value == "NOTHOMED" )
+            {
+                value = m_NOTHOMED;
+            }
+            else if( value == "HOMING" )
+            {
+                value = m_HOMING;
+            }
+            else if( value == "READY" )
+            {
+                value = m_READY;
+            }
+            else if( value == "OPERATING" )
+            {
+                value = m_OPERATING;
+            }
 
-         std::lock_guard<std::mutex> lock(m_stateMutex);
-         if(value != m_value) m_valChanged = true;
-         m_value = value;
-      }
-   }
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( value != m_value )
+                m_valChanged = true;
+            m_value = value;
+        }
+    }
 
-   emit doUpdateGUI();
+    emit doUpdateGUI();
 }
 
-void fsmDisplay::NOTHOMED( const std::string & s )
+void fsmDisplay::NOTHOMED( const std::string &s )
 {
     m_NOTHOMED = s;
 }
 
-void fsmDisplay::HOMING( const std::string & s )
+void fsmDisplay::HOMING( const std::string &s )
 {
     m_HOMING = s;
 }
 
-void fsmDisplay::READY( const std::string & s )
+void fsmDisplay::READY( const std::string &s )
 {
     m_READY = s;
 }
 
-void fsmDisplay::OPERATING( const std::string & s )
+void fsmDisplay::OPERATING( const std::string &s )
 {
     m_OPERATING = s;
 }
 
-
 void fsmDisplay::updateGUI()
 {
-   bool valChanged {false};
-   std::string valueStr;
-   {
-      std::lock_guard<std::mutex> lock(m_stateMutex);
-      valChanged = m_valChanged;
-      valueStr = m_value;
-   }
+    bool        valChanged{ false };
+    std::string valueStr;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        valChanged = m_valChanged;
+        valueStr   = m_value;
+    }
 
-   if(isEnabled())
-   {
-      if(valChanged)
-      {
-         QString value(valueStr.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
-         ui.fsm->setTextChanged(value);
-         std::lock_guard<std::mutex> lock(m_stateMutex);
-         m_valChanged = false;
-      }
-   }
-   else
-   {
-      QString value(valueStr.c_str()); //in future provide translatiosn for "RIP" "MODULATING", etc.
-      ui.fsm->setText(value);
-   }
+    if( isEnabled() )
+    {
+        if( valChanged )
+        {
+            QString value( valueStr.c_str() ); // in future provide translatiosn for "RIP" "MODULATING", etc.
+            ui.fsm->setTextChanged( value );
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_valChanged = false;
+        }
+    }
+    else
+    {
+        QString value( valueStr.c_str() ); // in future provide translatiosn for "RIP" "MODULATING", etc.
+        ui.fsm->setText( value );
+    }
 
-} //updateGUI()
+} // updateGUI()
 
 void fsmDisplay::clearFocus()
 {
 }
 
-} //namespace xqt
+} // namespace xqt
 
 #include "moc_fsmDisplay.cpp"
 


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex 

## Summary
This PR hardens GUI INDI reconnect/subscriber behavior to prevent segfaults during server disconnect/restart events. It also includes a full documentation/structure cleanup pass across the touched GUI headers.

## Key Changes
- Improved reconnect/disconnect handling in shared GUI INDI management.
- Hardened subscriber/publisher lifecycle behavior during connection loss and server restart.
- Added QObject-aware dispatch for callbacks that can cross thread boundaries.
- Reduced risk around publisher pointer handoff/reset during reconnect logic.
- Updated documentation across all changed files (full-file pass, not only edited lines).
- Moved non-trivial function definitions out of class declarations in touched headers.
- Standardized lock-lifetime scoping comments for mutex-only blocks.


## Validation
- `clang-format` run on all touched GUI header files.
- On-instrument smoke testing looks good so far.
- Full crash/stability matrix has not yet been run.

