### PR TITLE
cursesINDI: handle Ctrl-C as ETX in ncurses input paths

### DIFF
--- a/utils/cursesINDI/cursesINDI.cpp
+++ b/utils/cursesINDI/cursesINDI.cpp
@@ -132,6 +132,11 @@ retry:
          if( ci->getQuitProcess() || ci->m_shutdown) break;
          else continue;
       }
+      else if(ch == 3)
+      {
+         ci->m_shutdown = true;
+         break;
+      }
 
       //Get hold downs
       int ch0 = ch;
@@ -184,6 +189,7 @@ retry:
          default:
             if(fpout) *fpout << "other: " << npress << std::endl;
             ci->keyPressed(ch0);
+            if(ci->m_shutdown) break;
             continue;
             break;
       }

--- a/utils/cursesINDI/cursesINDI.hpp
+++ b/utils/cursesINDI/cursesINDI.hpp
@@ -920,6 +920,11 @@ void cursesINDI::keyPressed( int ch )
                }
                else continue;
             }
+            else if(nch == 3)
+            {
+               m_shutdown = true;
+               break;
+            }
 
             cursStat(1);
 
@@ -951,6 +956,7 @@ void cursesINDI::keyPressed( int ch )
             }
          }
          if(escape) break;
+         if(m_shutdown) break;
 
          //mutex scope
          {
@@ -963,6 +969,12 @@ void cursesINDI::keyPressed( int ch )
          nch = 0;
          while( (nch = wgetch(w_interactWin)) == ERR)
          {
+         }
+
+         if(nch == 3)
+         {
+            m_shutdown = true;
+            break;
          }
 
          if(nch == 'y')
@@ -1032,6 +1044,12 @@ void cursesINDI::keyPressed( int ch )
          {
          }
 
+         if(nch == 3)
+         {
+            m_shutdown = true;
+            break;
+         }
+
          if(nch == 'y')
          {
             pcf::IndiProperty ipSend(knownProps[it->second.propKey].getType());
@@ -1080,6 +1098,12 @@ void cursesINDI::keyPressed( int ch )
          int nch = 0;
          while( (nch = wgetch(w_interactWin)) == ERR)
          {
+         }
+
+         if(nch == 3)
+         {
+            m_shutdown = true;
+            break;
          }
 
          if(nch == 'y')


### PR DESCRIPTION
This work was performed by GPT-5.3-Codex in response to the prompt: "the program cursesINDI under utils/cursesINDI has stopped exiting on ctrl-c in newer installations ... please add `ch == 3` handling in all the places where we should detect, and make sure there are clean paths out to exit."

## Summary
On Fedora 42/KDE, `Ctrl-C` was no longer reliably exiting `cursesINDI` because input could arrive as ETX (`ch == 3`) in raw-mode ncurses paths rather than triggering the previous `ERR`/signal-dependent behavior.

This PR adds explicit ETX handling and clean shutdown propagation in all relevant interactive `wgetch()` loops.

## Changes
- Added `ch == 3` handling in main input loop:
  - `utils/cursesINDI/cursesINDI.cpp`
- Added `nch == 3` handling in nested interaction loops (`edit`, `toggle`, `press`, confirmations):
  - `utils/cursesINDI/cursesINDI.hpp`
- Ensured `keyPressed()`-initiated shutdown is honored by main loop before continuing.

## Behavior
- `Ctrl-C` now exits cleanly through existing shutdown path (`m_shutdown` -> loop break -> `shutDown()` -> `endwin()`).

## Validation
- Verified locally by user.
- Verified on Fedora 42 KDE deployment targets by user.

## Scope/Risk
- Minimal, targeted input-handling change.
- No protocol or device logic changes.
- No functional changes outside `cursesINDI` interactive key handling.