### PR TITLE
dmctrlgui reconnect segfault fix

### DIFF
--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -1,5 +1,6 @@
 /** \file dmCtrl.hpp
  * \brief Deformable mirror control widget for INDI-backed operations.
+ * \author Jared R. Males
  */
 
 #ifndef dmCtrl_hpp
@@ -15,6 +16,7 @@
 namespace xqt
 {
 
+/// Deformable mirror control widget backed by INDI properties.
 class dmCtrl : public xWidget
 {
     Q_OBJECT
@@ -122,7 +124,6 @@ class dmCtrl : public xWidget
 dmCtrl::dmCtrl( std::string &dmName, QWidget *Parent, Qt::WindowFlags f ) : xWidget( Parent, f ), m_dmName{ dmName }
 {
     ui.setupUi( this );
-    // ui.labelDMName->setText(m_dmName.c_str());
 
     setWindowTitle( QString( m_dmName.c_str() ) );
 
@@ -143,8 +144,6 @@ dmCtrl::dmCtrl( std::string &dmName, QWidget *Parent, Qt::WindowFlags f ) : xWid
     setXwFont( ui.buttonZeroTest );
     setXwFont( ui.comboSelectFlat );
     setXwFont( ui.comboSelectTest );
-
-    // setXwFont(ui.fsmState);
 
     setXwFont( ui.labelShmimName );
     setXwFont( ui.labelShmimName_value );
@@ -191,7 +190,6 @@ void dmCtrl::onConnectGUI()
 {
     m_connected = true;
 
-    // ui.labelDMName->setEnabled(true);
     ui.fsmState->setEnabled( true );
     ui.labelShmimName->setEnabled( true );
     ui.labelShmimName_value->setEnabled( true );
@@ -235,7 +233,6 @@ void dmCtrl::onDisconnectGUI()
         m_testOptions.clear();
     }
 
-    // ui.labelDMName->setEnabled(false);
     ui.fsmState->setEnabled( false );
     ui.labelShmimName->setEnabled( false );
     ui.labelShmimName_value->setEnabled( false );
@@ -406,12 +403,6 @@ void dmCtrl::updateGUI()
     if( !testName.empty() )
         ui.comboSelectTest->setCurrentText( testName.c_str() );
 
-    //    ui.buttonSetFlat->setEnabled(true);
-    //    ui.buttonZeroFlat->setEnabled(true);
-    //
-    //    ui.buttonSetTest->setEnabled(true);
-    //    ui.buttonZeroTest->setEnabled(true);
-    //
     if( appState != "NOTHOMED" && appState != "READY" && appState != "OPERATING" )
     {
         // Disable & zero all

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -37,6 +37,9 @@ class dmCtrl : public xWidget
 
     std::mutex m_stateMutex; ///< Guards cached state copied into the GUI thread.
 
+    bool m_connected{ false }; ///< True once the widget has processed an INDI connect event.
+    bool m_inUpdate{ false };  ///< Prevents re-entrant queued GUI refresh work.
+
   public:
     /// Constructs the DM control widget.
     explicit dmCtrl( std::string    &dmName,                    /**< [in] INDI device name for the DM controller. */
@@ -176,8 +179,6 @@ void dmCtrl::subscribe()
     m_parent->addSubscriberProperty( this, m_dmName, "test" );
     m_parent->addSubscriberProperty( this, m_dmName, "test_shmim" );
     m_parent->addSubscriberProperty( this, m_dmName, "test_set" );
-    m_parent->addSubscriber( ui.fsmState );
-
     return;
 }
 
@@ -188,6 +189,8 @@ void dmCtrl::onConnect()
 
 void dmCtrl::onConnectGUI()
 {
+    m_connected = true;
+
     // ui.labelDMName->setEnabled(true);
     ui.fsmState->setEnabled( true );
     ui.labelShmimName->setEnabled( true );
@@ -205,6 +208,8 @@ void dmCtrl::onConnectGUI()
     ui.fsmState->onConnect();
 
     setWindowTitle( QString( m_dmName.c_str() ) );
+
+    emit doUpdateGUI();
 }
 
 void dmCtrl::onDisconnect()
@@ -214,6 +219,22 @@ void dmCtrl::onDisconnect()
 
 void dmCtrl::onDisconnectGUI()
 {
+    m_connected = false;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_appState.clear();
+        m_shmimName.clear();
+        m_flatShmim.clear();
+        m_flatSet = false;
+        m_flatName.clear();
+        m_flatOptions.clear();
+        m_testShmim.clear();
+        m_testSet = false;
+        m_testName.clear();
+        m_testOptions.clear();
+    }
+
     // ui.labelDMName->setEnabled(false);
     ui.fsmState->setEnabled( false );
     ui.labelShmimName->setEnabled( false );
@@ -236,6 +257,12 @@ void dmCtrl::onDisconnectGUI()
 
     ui.comboSelectFlat->setEnabled( false );
     ui.comboSelectTest->setEnabled( false );
+
+    ui.labelShmimName_value->setText( "" );
+    ui.labelFlatShmim_value->setText( "" );
+    ui.labelTestShmim_value->setText( "" );
+    ui.comboSelectFlat->clear();
+    ui.comboSelectTest->clear();
 
     setWindowTitle( QString( m_dmName.c_str() ) + QString( " (disconnected)" ) );
 
@@ -261,6 +288,8 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
         {
             m_appState = ipRecv["state"].get<std::string>();
         }
+
+        ui.fsmState->handleSetProperty( ipRecv );
     }
     else if( ipRecv.getName() == "sm_shmimName" )
     {
@@ -331,6 +360,11 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
 
 void dmCtrl::updateGUI()
 {
+    if( m_inUpdate || !m_connected )
+        return;
+
+    m_inUpdate = true;
+
     std::string              appState;
     std::string              shmimName;
     std::string              flatShmim;
@@ -392,6 +426,7 @@ void dmCtrl::updateGUI()
         ui.buttonSetTest->setEnabled( false );
         ui.buttonZeroTest->setEnabled( false );
 
+        m_inUpdate = false;
         return;
     }
 
@@ -408,6 +443,7 @@ void dmCtrl::updateGUI()
         ui.buttonSetTest->setEnabled( false );
         ui.buttonZeroTest->setEnabled( false );
 
+        m_inUpdate = false;
         return;
     }
 
@@ -436,6 +472,8 @@ void dmCtrl::updateGUI()
         ui.buttonSetTest->setEnabled( false );
         ui.buttonZeroTest->setEnabled( true );
     }
+
+    m_inUpdate = false;
 
 } // updateGUI()
 


### PR DESCRIPTION
This work was performed by GPT-5.4-Codex in response to the prompt: "please review agent_context.md and provide a PR description".

## Summary

Fix `dmCtrlGUI` so it no longer segfaults when `indiserver` restarts, and follow with a separate cleanup-only commit to keep the history easy to review.

## What Changed

- Hardened `dmCtrl` reconnect handling in [gui/widgets/dmCtrl/dmCtrl.hpp](/home/jrmales/Source/MagAOX/gui/widgets/dmCtrl/dmCtrl.hpp)
- Removed the extra direct INDI subscription for the embedded `fsmState` widget and routed FSM updates through `dmCtrl`
- Added reconnect/disconnect state guards to avoid stale queued GUI updates running after disconnect
- Cleared cached DM state and visible combo/text state on disconnect so reconnect starts from a clean UI state
- Added a follow-up cleanup commit with minor documentation/comment cleanup and formatting only

## Commits

- `42415a75` `gui: harden dmCtrl reconnect handling`
- `c47f7c5d` `gui: clean up dmCtrl docs and comments`

## Verification

- Built successfully with:
  - `make -C gui/apps/dmCtrlGUI`

## Notes

- I was not able to run a live GUI restart test in this environment, so the remaining validation is to confirm `dmCtrlGUI` stays up through a real `indiserver` restart.
