### PR TITLE
Jrmales/zaber low level binary

### DIFF
--- a/agents/plans/zaberLowLevelBinary-implementation.md
+++ b/agents/plans/zaberLowLevelBinary-implementation.md
@@ -1,0 +1,392 @@
+Prompt: We need to implement a version of apps/zaberLowLevel that uses the binary protocol of zaber instead of ASCII. The new app `zaberLowLevelBinary` should function identically to the ASCII version as much as possible. A previous implementation of a similar app can be found in `../VisAO/zaberStage`. I can also provide the protocol reference documents if needed.
+
+## Analysis
+
+The existing `apps/zaberLowLevel` app already contains almost all of the MagAO-X-facing behavior we want to preserve:
+
+- configuration loading through `tty::usbDevice`
+- stage discovery from config sections keyed by serial number
+- INDI property schema used by `zaberCtrl`
+- stage state persistence in `m_sysPath/<configName>/<stageName>`
+- FSM / power-management behavior inherited from `MagAOXApp`
+
+The protocol-specific logic is currently spread across two places:
+
+- `apps/zaberLowLevel/zaberLowLevel.hpp`
+  - connection setup
+  - chain renumbering
+  - stage enumeration via `get system.serial`
+- `apps/zaberLowLevel/zaberStage.hpp`
+  - command formatting/parsing
+  - status, warnings, homing, parking, temperature, max position, motion commands
+
+There is already a bundled Zaber binary C transport implementation in this tree:
+
+- `apps/zaberLowLevel/zaber-core-serial-c-v1.0/zb_serial.[ch]`
+
+The older `../VisAO/zaberStage` code is useful mainly as a reference for:
+
+- binary framing and `zb_*` API usage
+- command numbers for home / move / stop / status / position / device mode / max position
+- expected binary reply flow and timeout handling
+
+It is not a drop-in reuse candidate because it is single-device oriented and does not implement the current MagAO-X INDI interface, config shape, warning bookkeeping, or multi-stage chain mapping by serial number.
+
+We now also have the correct protocol/manual context for the target hardware:
+
+- hardware: `T-LSM050B-S-KT03`
+- confirmed firmware: `5.35`
+- authoritative command reference: `/home/jrmales/Documents/MyPapers/Projects/MagAOX/Electronics/Zaber/zaber/T-LSM_Users_Manual-Zaber.pdf`
+
+This matters because the generic Zaber Binary Protocol Manual we first reviewed is written around firmware `6.xx` and points firmware `5.xx` users back to the product manual. The `T-LSM` manual explicitly covers firmware `5.00 and up` and is therefore the correct implementation reference for this app.
+
+## Implementation Plan
+
+### 1. Create a new app by cloning the current low-level interface shape
+
+Add a sibling app `apps/zaberLowLevelBinary` instead of mutating `apps/zaberLowLevel` in place.
+
+Reasoning:
+
+- `zaberCtrl` already supports selecting a low-level app name through `stage.lowLevelName`
+- this lets us preserve the current ASCII implementation during bring-up
+- it minimizes operational risk and makes side-by-side comparison possible
+
+Initial file set:
+
+- `apps/zaberLowLevelBinary/Makefile`
+- `apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp`
+- `apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp`
+- `apps/zaberLowLevelBinary/zaberBinaryStage.hpp`
+- `apps/zaberLowLevelBinary/tests/...`
+
+Also vendor or reference the binary transport sources in the new app build:
+
+- prefer compiling `zb_serial.c`
+- reuse `z_common.h` / `zb_serial.h`
+
+### 2. Preserve the MagAO-X and INDI contract exactly where possible
+
+The new app should expose the same externally visible properties and semantics as `zaberLowLevel`:
+
+- same power-management behavior
+- same config discovery pattern for stage sections by serial number
+- same INDI properties:
+  - `curr_state`
+  - `max_pos`
+  - `parked`
+  - `last_homed`
+  - `curr_pos`
+  - `temp`
+  - `warning`
+  - `tgt_pos`
+  - `req_home`
+  - `home_all`
+  - `req_halt`
+  - `req_ehalt`
+- same state-file format if feasible
+- same stage-name keyed INDI elements
+
+This is important so `apps/zaberCtrl` can target `zaberLowLevelBinary` by configuration only, with no code changes required in the controller.
+
+### 3. Split protocol-independent stage state from binary transport details
+
+Do not copy the current ASCII `zaberStage` blindly. Instead, use the current `zaberStage` responsibilities as the interface target and re-implement the protocol layer for binary.
+
+Suggested structure:
+
+- `zaberLowLevelBinary`
+  - owns the serial port
+  - performs connection / reset / bus discovery
+  - maintains maps:
+    - serial -> configured stage index
+    - address -> active stage index
+    - name -> stage index
+- `zaberBinaryStage`
+  - stores MagAO-X-visible state:
+    - name, serial, address, axis
+    - position, target, max position
+    - homing, parked, warnings, temperature, last homed
+  - exposes stage operations analogous to the ASCII version:
+    - `getMaxPos`
+    - `getParked`
+    - `updatePos`
+    - `updateTemp`
+    - `disableKnob`
+    - `stop`
+    - `estop`
+    - `home`
+    - `park`
+    - `unpark`
+    - `moveAbs`
+    - warning/state helpers
+
+This keeps most of the current app logic readable and makes it easier to compare method-for-method against the ASCII implementation.
+
+### 4. Implement binary connection and discovery carefully
+
+The biggest design question is how to reproduce the ASCII startup sequence:
+
+- ASCII app:
+  - connect
+  - drain
+  - renumber
+  - query `system.serial`
+  - match discovered serial numbers to configured stage sections
+
+Binary app needs an equivalent discovery path. The likely approach, based on the bundled binary API and old VisAO code, is:
+
+- connect with `zb_connect`
+- optionally set timeout explicitly with `zb_set_timeout`
+- issue global/broadcast renumber if supported by the binary protocol
+- probe device addresses after renumber to read serial number and identify configured devices
+
+The plan here is to implement discovery in two phases:
+
+1. Minimal viable discovery:
+   - renumber chain
+   - scan a bounded address range
+   - query each responding device for serial number
+   - map serial number to configured stage
+
+2. Hardened discovery:
+   - stop scan once a reasonable consecutive-miss threshold is reached
+   - log unknown but present devices
+   - clearly distinguish configured-but-missing vs discovered-but-unconfigured
+
+For the target `T-LSM` firmware `5.35`, the product manual confirms that `Return Serial Number` is available as `Cmd 63`, so serial-number based discovery is a valid plan.
+
+### 5. Port core device commands from ASCII text to binary command IDs
+
+From the old `VisAO/zaberStage` implementation, the following binary commands appear directly relevant:
+
+- `1`: home
+- `20`: move absolute
+- `21`: move relative
+- `23`: stop
+- `53`: return setting
+- `54`: return status
+- `60`: return current position
+
+The old code also uses setting numbers:
+
+- `40`: device mode / flags, including homed bit and reply/LED-related bits
+- `44`: max position
+
+The implementation should define named constants or a small enum for these command IDs and setting numbers instead of scattering raw integers.
+
+For the target `T-LSM` firmware `5.35`, the local manual confirms these additional points:
+
+- all commands are 6-byte binary packets at `9600 8N1`
+- `Cmd 2` renumber remains valid, but for firmware `5xx` device numbers persist across power cycles
+- `Cmd 51` returns firmware version
+- `Cmd 63` returns serial number
+- `Cmd 40` `Set Device Mode` includes the manual-knob control bits
+
+### 6. Reconcile feature gaps between ASCII and binary
+
+The current ASCII app does more than the old VisAO binary controller:
+
+- reads warning state and logs per-warning flags
+- tracks parked / unparked state
+- reads temperature
+- disables the knob every startup
+- persists last known stage state to disk
+
+Before coding the full FSM, verify which of these are available in the binary protocol for the target hardware:
+
+- serial number query
+- warning retrieval
+- parked state query and park/unpark commands
+- temperature query
+- knob-disable / lockout support
+
+Updated target-hardware conclusions from the `T-LSM` manual and your notes:
+
+- serial number query: available via `Cmd 63`
+- knob disable: available via `Set Device Mode (Cmd 40)`, specifically using `bit_3`
+- parked state: not native in the same way as the ASCII app; we should emulate parking using stored positions
+- temperature: still needs verification for this exact device/firmware path
+- warning retrieval: still needs verification against firmware `5.35` behavior and current operational needs
+
+Implementation policy:
+
+- if a feature exists in binary, implement it and preserve behavior
+- if a feature does not exist, keep the property but degrade gracefully
+  - example: fixed default for `parked` or `temp`
+  - log once per stage that the value is unavailable in binary mode
+- do not silently fake safety-critical behavior
+
+Parking plan for this app:
+
+- preserve the `parked` INDI/state-file concept for compatibility
+- implement "park" as a move to a configured or persisted parked raw position
+- implement "unpark" as clearing the parked bookkeeping state after a successful move away from the parked position
+- document clearly that this is MagAO-X parking semantics layered on top of Zaber motion control, not a native device park latch unless the firmware proves otherwise
+
+### 7. Reuse as much of the existing FSM as practical
+
+The current `appLogic()` sequencing is already appropriate for MagAO-X operations:
+
+- `POWERON`
+- `NODEVICE`
+- `NOTCONNECTED`
+- `CONNECTED`
+- `READY`
+- power-off handling
+
+Plan:
+
+- copy the ASCII FSM into the new app as the starting point
+- replace only the protocol-dependent calls
+- preserve locking and INDI update sequencing
+- preserve state-file read/write behavior
+
+This should keep operational behavior aligned and reduce surprises for downstream clients.
+
+### 8. Keep the initial implementation single-axis per device unless proven otherwise
+
+The current app defaults `m_axisNumber` to `0` and operationally treats each configured stage as one logical axis. The old VisAO code also targets a single axis per device.
+
+Plan:
+
+- keep the same assumption for v1 of `zaberLowLevelBinary`
+- make axis number explicit in the stage class so future extension is easy
+- do not expand to general multi-axis support unless the target hardware requires it
+
+### 9. Add focused tests around behavior, not just protocol calls
+
+The current `zaberLowLevel` tests are light and partly stale, so the binary app should at least add unit coverage where protocol mapping is easy to regress.
+
+Priority test areas:
+
+- config section parsing into named stages
+- mapping discovered serial numbers to configured stages
+- state-file read/write compatibility
+- INDI property creation and callback plumbing
+- command encoding wrappers around binary operations where mockable
+- stage status interpretation:
+  - moving
+  - homing
+  - homed
+  - unknown / not connected
+
+If direct mocking of `zb_*` is awkward, factor binary I/O behind small helper methods so tests can override them in a harness subclass.
+
+### 10. Stage rollout in two implementation passes
+
+Pass 1:
+
+- compile new app
+- connect to device
+- discover configured stages by serial
+- read position / max position
+- support move, home, stop
+- disable the manual knob using `Set Device Mode` bit 3
+- expose compatible INDI properties
+
+Pass 2:
+
+- warnings
+- parked state
+- temperature
+- emergency stop semantics
+- operational polish and fuller tests
+
+This should get us to hardware validation faster while keeping the plan realistic.
+
+## File-Level Work Plan
+
+### `apps/zaberLowLevelBinary/Makefile`
+
+- set `TARGET=zaberLowLevelBinary`
+- compile/link `zb_serial.o`
+- mirror the current app build structure
+
+### `apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp`
+
+- copy the current class skeleton from `zaberLowLevel`
+- rename class / include guard / Doxygen groups
+- swap ASCII transport include for binary transport include
+- keep public INDI surface and FSM method structure aligned
+
+### `apps/zaberLowLevelBinary/zaberBinaryStage.hpp`
+
+- implement the stage state container and binary command wrappers
+- use named constants for command IDs/settings
+- preserve documentation and declaration style from `agent_context.md`
+
+### `apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp`
+
+- minimal main program only, matching existing app conventions
+
+### `apps/zaberLowLevelBinary/tests/*`
+
+- start by cloning the current low-level test scaffolding
+- update for new class names
+- add test seams around binary transport behavior
+
+## Risks and Open Questions
+
+### Highest-risk items
+
+- availability of warning, parked, and temperature features in binary mode
+- whether all target Zaber devices support the same binary command set as the old VisAO hardware
+- defining robust MagAO-X "parking" semantics on top of firmware `5.35` motion commands without surprising operators
+
+### Questions to resolve during implementation
+
+- Is the binary app expected to read the exact same config file format as `zaberLowLevel`?
+  - ANSWER: if new/different config options are needed it's ok
+  - Plan update: preserve the current config format by default, but allow new binary-only options if they materially improve reliability. Likely candidates are:
+    - parked raw position
+    - renumber-on-connect enable/disable
+    - discovery max address / timeout tuning
+- Should `zaberCtrl` remain unchanged and switch by `stage.lowLevelName` only?
+  - ANSWER: yes
+- Are there deployed stages where ASCII-only features were relied on operationally?
+  - ANSWER: 
+      - we will need to hack the "parking" using stored positions
+      - knob can be disabled with "Set Device Mode" bit_3
+
+### Resolved assumptions
+
+- `zaberCtrl` should remain unchanged and select the backend through `stage.lowLevelName`
+- serial-number discovery is supported on the target firmware/hardware via `Cmd 63`
+- parking should be implemented in MagAO-X as a compatibility layer using stored positions
+- knob disable should be implemented early using `Set Device Mode (Cmd 40)` bit 3
+      - I don't see an obvious parallel to warnings
+      - looks like temperature is not available
+
+### When to request protocol docs
+
+I do not need the docs to start scaffolding the new app and porting the FSM/interface. I would want the Zaber binary protocol reference before locking in:
+
+- device discovery by serial number
+- warning retrieval mapping
+- parked / unparked support
+- temperature and knob-disable equivalents
+- emergency stop semantics
+
+## Recommended Execution Order
+
+1. Scaffold `apps/zaberLowLevelBinary` by copying the current MagAO-X app shape.
+2. Replace ASCII transport with `zb_*` transport and get a successful connect/disconnect build.
+3. Implement binary discovery and serial-number mapping using `Cmd 63`, with firmware `5.35` timing/renumber behavior from the `T-LSM` manual.
+4. Port motion/status primitives into `zaberBinaryStage`.
+5. Implement manual-knob disable via `Set Device Mode (Cmd 40)` bit 3 during startup.
+6. Reconnect the existing FSM and INDI publication flow.
+7. Implement MagAO-X parking semantics via stored positions and explicit bookkeeping.
+8. Add tests for discovery, stage-state interpretation, parking bookkeeping, and callback wiring.
+9. Validate remaining parity features, then either implement or document graceful degradation.
+
+## Deliverable Definition
+
+The plan is complete when `zaberLowLevelBinary`:
+
+- builds as a separate MagAO-X app
+- can be selected by `zaberCtrl` through configuration only
+- discovers configured stages by serial number
+- publishes the same core INDI interface as `zaberLowLevel`
+- supports home / move / halt with equivalent operational behavior
+- clearly documents any remaining binary-vs-ASCII feature gaps

--- a/apps/zaberLowLevelBinary/Makefile
+++ b/apps/zaberLowLevelBinary/Makefile
@@ -1,0 +1,7 @@
+
+allall: all
+
+OTHER_HEADERS=zaberBinaryStage.hpp zb_serial.h z_common.h
+OTHER_OBJS=zb_serial.o
+TARGET=zaberLowLevelBinary
+include ../../Make/magAOXApp.mk

--- a/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
+++ b/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
@@ -1,6 +1,8 @@
 /** \file zaberLowLevelBinary_test.cpp
  * \brief Catch2 tests for the zaberLowLevelBinary app.
  * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup zaberLowLevelBinary_files
  */
 
 extern "C"
@@ -21,6 +23,7 @@ namespace ZLLBTEST
 class zaberLowLevelBinary_test : public zaberLowLevelBinary
 {
   public:
+    /// Construct the test harness and set up INDI callback fixtures.
     zaberLowLevelBinary_test( const std::string &device )
     {
         m_configName = device;

--- a/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
+++ b/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
@@ -1,0 +1,43 @@
+/** \file zaberLowLevelBinary_test.cpp
+ * \brief Catch2 tests for the zaberLowLevelBinary app.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
+
+extern "C"
+{
+#include "../zb_serial.c"
+}
+
+#include "../../../tests/catch2/catch.hpp"
+#include "../../tests/testMacrosINDI.hpp"
+
+#include "../zaberLowLevelBinary.hpp"
+
+using namespace MagAOX::app;
+
+namespace ZLLBTEST
+{
+
+class zaberLowLevelBinary_test : public zaberLowLevelBinary
+{
+  public:
+    zaberLowLevelBinary_test( const std::string &device )
+    {
+        m_configName = device;
+
+        XWCTEST_SETUP_INDI_NEW_PROP( tgt_pos );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_home );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_halt );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_ehalt );
+    }
+};
+
+SCENARIO( "INDI Callbacks", "[zaberLowLevelBinary]" )
+{
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, tgt_pos );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_home );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_halt );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_ehalt );
+}
+
+} // namespace ZLLBTEST

--- a/apps/zaberLowLevelBinary/z_common.h
+++ b/apps/zaberLowLevelBinary/z_common.h
@@ -1,0 +1,80 @@
+/**
+ * \file z_common.h
+ * \author Eric Dand
+ * \version 1.0
+ * \date 28 November 2014
+ * \copyright Apache Software License Version 2.0
+ *
+ * \brief Defines a few things that all of the serial API has in common.
+ *
+ * This file should not be included directly: only include either za_serial.h
+ * or zb_serial.h, which will in turn include this file. The purpose of this
+ * file is to avoid code duplication and to enable a user to include both
+ * halves of the API in one source file without too many include guards and
+ * other preprocessor mess.
+ */
+#if !defined(Z_COMMON_H)
+#define Z_COMMON_H
+
+/** Allows for programmatic access to the library's version number. */
+#define VERSION 1.0
+
+/** \typedef z_port
+ *
+ * A type to represent a port connected to one or more Zaber devices.
+ * Essentially a wrapper, this type is a `HANDLE` on Windows, and a file
+ * descriptor (`int`) on *NIX. za_connect() and zb_connect() will properly
+ * set and configure a `z_port`.
+ */
+#if defined(_WIN32)
+#include <windows.h>
+typedef HANDLE z_port;
+#elif defined(__unix__) || defined(__APPLE__)
+typedef int z_port;
+#endif /* if defined(_WIN32) and other OS checks */
+
+/** Defines how long, in milliseconds, za_receive() and zb_receive() should
+ * wait for input before returning without a full message.
+ *
+ * This number acts as an upper bound on how long the receive functions will
+ * take: they will return immediately once a full message is received.
+ *
+ * A note about the read timeout on *NIX operating systems: because of the way
+ * the POSIX "termios" functions work, this value will be rounded down to the
+ * nearest tenth of a second (eg. 200ms = 246ms = 0.2s). A value between 0 and
+ * 100 will be rounded up to 100 instead of down to 0 to give slightly more
+ * consistent behaviour between Windows and *NIX systems.
+ *
+ * Change this value with caution. It is set to two seconds by default,
+ * but a shorter time may be desired if many operations in your program
+ * depend on reading until a timeout. See zb_set_timeout() for more
+ * info on how this value affects the behaviour of zb_serial.h.
+ */
+#define READ_TIMEOUT 2000
+
+/** \enum z_returns Defines a set of return values in case things go wrong.
+ *
+ * All errors are negative values in order to not be confused with the
+ * 0-or-greater regular return values. This was done so that a user can check
+ * whether a return value is < 0 to check for all error codes simultaneously.
+ *
+ * Remember to check your return values! It's good for you.
+ */
+enum z_returns {
+	/** Everything is OK! */
+	Z_SUCCESS = 0,
+	/** Something went wrong in system code */
+	Z_ERROR_SYSTEM_ERROR = -1,
+	/** Tried to write to a buffer that wasn't long enough */
+	Z_ERROR_BUFFER_TOO_SMALL = -2,
+	/** Was passed NULL when not expecting it */
+	Z_ERROR_NULL_PARAMETER = -3,
+	/** Tried to set an unsupported baudrate */
+	Z_ERROR_INVALID_BAUDRATE = -4,
+	/** Tried to decode a partial reply,
+	 * or a string that wasn't a reply at all */
+	Z_ERROR_COULD_NOT_DECODE = -5
+};
+
+#endif /* if !defined(Z_COMMON_H) */
+

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -1,0 +1,939 @@
+/** \file zaberBinaryStage.hpp
+ * \brief A class with details of a single binary-protocol Zaber stage.
+ *
+ * \ingroup zaberLowLevelBinary_files
+ */
+
+#ifndef zaberBinaryStage_hpp
+#define zaberBinaryStage_hpp
+
+#include <ctime>
+#include <fstream>
+#include <limits>
+#include <string>
+
+#include "../../libMagAOX/libMagAOX.hpp" // Note this is included on command line to trigger pch
+
+#include "zb_serial.h"
+
+namespace MagAOX
+{
+namespace app
+{
+
+/// A class to manage the details of one binary-protocol stage in a Zaber system.
+/**
+ * \ingroup zaberLowLevelBinary
+ */
+template <class parentT>
+class zaberBinaryStage
+{
+  public:
+    /// Binary protocol command numbers used by the T-LSM firmware 5.xx implementation.
+    enum commandCodes : uint8_t
+    {
+        cmdHome                  = 1,
+        cmdRenumber              = 2,
+        cmdStoreCurrentPosition  = 16,
+        cmdMoveToStoredPosition  = 18,
+        cmdMoveAbsolute          = 20,
+        cmdMoveRelative          = 21,
+        cmdStop                  = 23,
+        cmdSetDeviceMode         = 40,
+        cmdSetMaximumPosition    = 44,
+        cmdSetCurrentPosition    = 45,
+        cmdReturnFirmwareVersion = 51,
+        cmdReturnSetting         = 53,
+        cmdReturnStatus          = 54,
+        cmdReturnCurrentPosition = 60,
+        cmdReturnSerialNumber    = 63
+    };
+
+    /// Device-mode bits used by the implementation.
+    enum modeBits : int32_t
+    {
+        modeDisableAutoReply   = ( 1 << 0 ),
+        modeDisablePotentiomer = ( 1 << 3 ),
+        modeHomeStatus         = ( 1 << 7 )
+    };
+
+  protected:
+    /// Parent application used for logging and power-state checks.
+    parentT *m_parent{ nullptr };
+
+    /// Configured stage name used in INDI properties.
+    std::string m_name;
+
+    /// Configured stage serial number.
+    std::string m_serial;
+
+    /// Current binary device address.
+    int m_deviceAddress{ -1 };
+
+    /// Axis number placeholder for future multi-axis support.
+    int m_axisNumber{ 0 };
+
+    /// Whether the most recent command was accepted.
+    bool m_commandStatus{ true };
+
+    /// Current device state mapped to ASCII-app semantics.
+    char m_deviceStatus{ 'U' };
+
+    /// Whether the stage is currently homing.
+    bool m_homing{ false };
+
+    /// Time stamp of the last successful home operation.
+    timespec m_lastHomed{ 0, 0 };
+
+    /// Whether MagAO-X currently considers this stage parked.
+    bool m_parked{ false };
+
+    /// Current raw position in microsteps.
+    long m_rawPos{ 0 };
+
+    /// Last target position sent to the device in microsteps.
+    long m_tgtPos{ 0 };
+
+    /// Maximum position in microsteps.
+    long m_maxPos{ -1 };
+
+    /// Emulated parked position in microsteps.
+    long m_parkPos{ 0 };
+
+    /// Last reported stage temperature. Firmware 5.35 does not expose this directly.
+    float m_temp{ -999.0 };
+
+    /// Whether any warning-equivalent condition is active.
+    bool m_warn{ false };
+
+    /// Driver disabled warning flag.
+    bool m_warnFD{ false };
+
+    /// Device-specific warning flag placeholders retained for API compatibility.
+    bool m_warnFQ{ false };
+    bool m_warnFS{ false };
+    bool m_warnFT{ false };
+    bool m_warnFB{ false };
+    bool m_warnFP{ false };
+    bool m_warnFE{ false };
+    bool m_warnWH{ false };
+    bool m_warnWL{ false };
+    bool m_warnWP{ false };
+    bool m_warnWV{ false };
+    bool m_warnWT{ false };
+    bool m_warnWM{ false };
+    bool m_warnWR{ false };
+    bool m_warnNC{ false };
+    bool m_warnNI{ false };
+    bool m_warnND{ false };
+    bool m_warnNU{ false };
+    bool m_warnNJ{ false };
+    bool m_warnUNK{ false };
+
+  public:
+    /// Default constructor deleted because stages require a parent app.
+    zaberBinaryStage() = delete;
+
+    /// Construct the stage helper.
+    zaberBinaryStage( parentT *parent /**< [in] the parent application */ )
+    {
+        if( parent == nullptr )
+        {
+            throw mx::exception( mx::error_t::invalidarg, "parent was null on construction of zaberBinaryStage" );
+        }
+
+        m_parent = parent;
+    }
+
+    /// Get the stage name.
+    std::string name();
+
+    /// Set the stage name.
+    int name( const std::string &n /**< [in] the new stage name */ );
+
+    /// Get the stage serial number.
+    std::string serial();
+
+    /// Set the stage serial number.
+    int serial( const std::string &s /**< [in] the new stage serial number */ );
+
+    /// Get the device address.
+    int deviceAddress();
+
+    /// Set the device address.
+    int deviceAddress( const int &da /**< [in] the new device address */ );
+
+    /// Get the axis number.
+    int axisNumber();
+
+    /// Set the axis number.
+    int axisNumber( const int &an /**< [in] the new axis number */ );
+
+    /// Get the status of the last command.
+    bool commandStatus();
+
+    /// Get the current device status.
+    char deviceStatus();
+
+    /// Get the homing state.
+    bool homing();
+
+    /// Get the last home time.
+    time_t lastHomed();
+
+    /// Get the parked state.
+    int parked();
+
+    /// Get the current raw position.
+    long rawPos();
+
+    /// Get the target raw position.
+    long tgtPos();
+
+    /// Get the maximum position.
+    long maxPos();
+
+    /// Get whether any warning-equivalent flag is set.
+    bool warn();
+
+    /// Get the driver temperature.
+    float temp();
+
+    /// Get whether any warning-equivalent flag is set.
+    bool warningState();
+
+    bool warnFD();
+    bool warnFQ();
+    bool warnFS();
+    bool warnFT();
+    bool warnFB();
+    bool warnFP();
+    bool warnFE();
+    bool warnWH();
+    bool warnWL();
+    bool warnWP();
+    bool warnWV();
+    bool warnWT();
+    bool warnWM();
+    bool warnWR();
+    bool warnNC();
+    bool warnNI();
+    bool warnND();
+    bool warnNU();
+    bool warnNJ();
+    bool warnUNK();
+
+    /// Send a command and wait for the corresponding binary reply.
+    int queryCommand( int32_t &response,      /**< [out] decoded reply data */
+                      z_port   port,          /**< [in] the port with which to communicate */
+                      uint8_t  commandNumber, /**< [in] the command number to send */
+                      int32_t  data,          /**< [in] the command data */
+                      uint8_t  expectedReply  /**< [in] the expected reply command number */
+    );
+
+    /// Send a command for which no reply is expected.
+    int sendCommandNoReply( z_port  port,          /**< [in] the port with which to communicate */
+                            uint8_t commandNumber, /**< [in] the command number to send */
+                            int32_t data           /**< [in] the command data */
+    );
+
+    /// Return a setting value from the device.
+    int getSetting( int32_t &value,        /**< [out] the setting value */
+                    z_port   port,         /**< [in] the port with which to communicate */
+                    uint8_t  settingNumber /**< [in] the setting command number to query */
+    );
+
+    /// Get the maximum position from the device.
+    int getMaxPos( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Get the parked state for MagAO-X compatibility.
+    int getParked( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Update the current position and derived motion state.
+    int updatePos( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Update the stage temperature, if supported.
+    int updateTemp( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Disable the manual knob and asynchronous command replies.
+    int disableKnob( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Stop the stage.
+    int stop( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Emergency-stop the stage.
+    int estop( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Home the stage.
+    int home( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Mark the stage parked using MagAO-X bookkeeping semantics.
+    int park( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Clear the parked bookkeeping state.
+    int unpark( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Move to a new absolute position.
+    int moveAbs( z_port port, /**< [in] the port with which to communicate */
+                 long   rawPos /**< [in] the position to move to in microsteps */ );
+
+    /// Clear all warning flags.
+    int unsetWarnings();
+
+    /// Refresh warning-equivalent state from firmware 5.xx information.
+    int getWarnings( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Clear transient state on power-off.
+    int onPowerOff();
+
+    /// Write the state file used by the low-level app.
+    int writeStateFile( std::ofstream &fout /**< [in] an open output stream */ );
+
+    /// Read the state file used by the low-level app.
+    int readStateFile( std::ifstream &fin /**< [in] an open input stream */ );
+};
+
+template <class parentT>
+std::string zaberBinaryStage<parentT>::name()
+{
+    return m_name;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::name( const std::string &n )
+{
+    m_name = n;
+    return 0;
+}
+
+template <class parentT>
+std::string zaberBinaryStage<parentT>::serial()
+{
+    return m_serial;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::serial( const std::string &s )
+{
+    m_serial = s;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::deviceAddress()
+{
+    return m_deviceAddress;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::deviceAddress( const int &da )
+{
+    m_deviceAddress = da;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::axisNumber()
+{
+    return m_axisNumber;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::axisNumber( const int &an )
+{
+    m_axisNumber = an;
+    return 0;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::commandStatus()
+{
+    return m_commandStatus;
+}
+
+template <class parentT>
+char zaberBinaryStage<parentT>::deviceStatus()
+{
+    return m_deviceStatus;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::homing()
+{
+    return m_homing;
+}
+
+template <class parentT>
+time_t zaberBinaryStage<parentT>::lastHomed()
+{
+    return m_lastHomed.tv_sec;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::parked()
+{
+    return m_parked;
+}
+
+template <class parentT>
+long zaberBinaryStage<parentT>::rawPos()
+{
+    return m_rawPos;
+}
+
+template <class parentT>
+long zaberBinaryStage<parentT>::tgtPos()
+{
+    return m_tgtPos;
+}
+
+template <class parentT>
+long zaberBinaryStage<parentT>::maxPos()
+{
+    return m_maxPos;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warn()
+{
+    return m_warn;
+}
+
+template <class parentT>
+float zaberBinaryStage<parentT>::temp()
+{
+    return m_temp;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warningState()
+{
+    return m_warn;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFD()
+{
+    return m_warnFD;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFQ()
+{
+    return m_warnFQ;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFS()
+{
+    return m_warnFS;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFT()
+{
+    return m_warnFT;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFB()
+{
+    return m_warnFB;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFP()
+{
+    return m_warnFP;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnFE()
+{
+    return m_warnFE;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWH()
+{
+    return m_warnWH;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWL()
+{
+    return m_warnWL;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWP()
+{
+    return m_warnWP;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWV()
+{
+    return m_warnWV;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWT()
+{
+    return m_warnWT;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWM()
+{
+    return m_warnWM;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnWR()
+{
+    return m_warnWR;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnNC()
+{
+    return m_warnNC;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnNI()
+{
+    return m_warnNI;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnND()
+{
+    return m_warnND;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnNU()
+{
+    return m_warnNU;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnNJ()
+{
+    return m_warnNJ;
+}
+
+template <class parentT>
+bool zaberBinaryStage<parentT>::warnUNK()
+{
+    return m_warnUNK;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::queryCommand(
+    int32_t &response, z_port port, uint8_t commandNumber, int32_t data, uint8_t expectedReply )
+{
+    if( m_deviceAddress < 1 )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "stage {} with s/n {} not found in system.", m_name, m_serial ) );
+    }
+
+    uint8_t command[6];
+    if( zb_encode( command, static_cast<uint8_t>( m_deviceAddress ), commandNumber, data ) != Z_SUCCESS )
+    {
+        return MagAOXAppT::log<software_error, -1>( "zb_encode failed" );
+    }
+
+    if( zb_send( port, command ) != 6 )
+    {
+        return MagAOXAppT::log<software_error, -1>( "zb_send failed" );
+    }
+
+    uint8_t reply[6];
+    int     rv = zb_receive( port, reply );
+    if( rv != 6 )
+    {
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        {
+            return -1;
+        }
+
+        return MagAOXAppT::log<software_error, -1>( "zb_receive failed" );
+    }
+
+    if( reply[0] != static_cast<uint8_t>( m_deviceAddress ) )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "unexpected reply from device {} while querying {}", reply[0], m_name ) );
+    }
+
+    if( reply[1] == 255 )
+    {
+        int32_t errorCode;
+        zb_decode( &errorCode, reply );
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} command {} returned error {}", m_name, commandNumber, errorCode ) );
+    }
+
+    if( reply[1] != expectedReply )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} returned reply {} while expecting {}", m_name, reply[1], expectedReply ) );
+    }
+
+    if( zb_decode( &response, reply ) != Z_SUCCESS )
+    {
+        return MagAOXAppT::log<software_error, -1>( "zb_decode failed" );
+    }
+
+    m_commandStatus = true;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::sendCommandNoReply( z_port port, uint8_t commandNumber, int32_t data )
+{
+    if( m_deviceAddress < 1 )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "stage {} with s/n {} not found in system.", m_name, m_serial ) );
+    }
+
+    uint8_t command[6];
+    if( zb_encode( command, static_cast<uint8_t>( m_deviceAddress ), commandNumber, data ) != Z_SUCCESS )
+    {
+        return MagAOXAppT::log<software_error, -1>( "zb_encode failed" );
+    }
+
+    if( zb_send( port, command ) != 6 )
+    {
+        return MagAOXAppT::log<software_error, -1>( "zb_send failed" );
+    }
+
+    m_commandStatus = true;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::getSetting( int32_t &value, z_port port, uint8_t settingNumber )
+{
+    return queryCommand( value, port, cmdReturnSetting, settingNumber, settingNumber );
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::getMaxPos( z_port port )
+{
+    int32_t value;
+    int     rv = getSetting( value, port, cmdSetMaximumPosition );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    m_maxPos = value;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::getParked( z_port )
+{
+    if( m_parked && m_rawPos != m_parkPos )
+    {
+        m_parked = false;
+    }
+
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::updatePos( z_port port )
+{
+    int32_t status;
+    int     rv = queryCommand( status, port, cmdReturnStatus, 0, cmdReturnStatus );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    if( status == 0 )
+    {
+        m_deviceStatus = 'I';
+    }
+    else
+    {
+        m_deviceStatus = 'B';
+    }
+
+    m_homing = ( status == 1 );
+
+    if( status == 0 )
+    {
+        int32_t pos;
+        rv = queryCommand( pos, port, cmdReturnCurrentPosition, 0, cmdReturnCurrentPosition );
+        if( rv < 0 )
+        {
+            return rv;
+        }
+
+        m_rawPos = pos;
+
+        if( m_homing == false && m_warnWR == false && m_tgtPos == 0 && m_rawPos == 0 && m_lastHomed.tv_sec == 0 )
+        {
+            if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
+            {
+                MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
+            }
+        }
+    }
+
+    return getWarnings( port );
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::updateTemp( z_port )
+{
+    m_temp = -999.0;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::disableKnob( z_port port )
+{
+    int32_t mode;
+    int     rv = getSetting( mode, port, cmdSetDeviceMode );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    mode |= modeDisableAutoReply;
+    mode |= modeDisablePotentiomer;
+
+    rv = queryCommand( mode, port, cmdSetDeviceMode, mode, cmdSetDeviceMode );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::stop( z_port port )
+{
+    int rv = sendCommandNoReply( port, cmdStop, 0 );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    m_homing = false;
+    m_parked = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::estop( z_port port )
+{
+    return stop( port );
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::home( z_port port )
+{
+    int rv = sendCommandNoReply( port, cmdHome, 0 );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    m_homing = true;
+    m_tgtPos = 0;
+    m_parked = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::park( z_port )
+{
+    m_parked  = true;
+    m_parkPos = m_rawPos;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::unpark( z_port )
+{
+    m_parked = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::moveAbs( z_port port, long rawPos )
+{
+    if( m_parked )
+    {
+        int rv = unpark( port );
+        if( rv < 0 )
+        {
+            return rv;
+        }
+    }
+
+    int rv = sendCommandNoReply( port, cmdMoveAbsolute, rawPos );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    m_tgtPos = rawPos;
+    m_homing = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::unsetWarnings()
+{
+    m_warn    = false;
+    m_warnFD  = false;
+    m_warnFQ  = false;
+    m_warnFS  = false;
+    m_warnFT  = false;
+    m_warnFB  = false;
+    m_warnFP  = false;
+    m_warnFE  = false;
+    m_warnWH  = false;
+    m_warnWL  = false;
+    m_warnWP  = false;
+    m_warnWV  = false;
+    m_warnWT  = false;
+    m_warnWM  = false;
+    m_warnWR  = false;
+    m_warnNC  = false;
+    m_warnNI  = false;
+    m_warnND  = false;
+    m_warnNU  = false;
+    m_warnNJ  = false;
+    m_warnUNK = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::getWarnings( z_port port )
+{
+    unsetWarnings();
+
+    int32_t mode;
+    int     rv = getSetting( mode, port, cmdSetDeviceMode );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    if( ( mode & modeHomeStatus ) == 0 )
+    {
+        m_warn   = true;
+        m_warnWR = true;
+    }
+
+    if( m_warnWR == false && m_homing == false && m_tgtPos == 0 && m_rawPos == 0 && m_lastHomed.tv_sec == 0 )
+    {
+        if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
+        {
+            MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
+        }
+    }
+
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::onPowerOff()
+{
+    m_commandStatus = true;
+    m_deviceStatus  = 'U';
+    m_homing        = false;
+    m_temp          = -999.0;
+    unsetWarnings();
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::writeStateFile( std::ofstream &fout )
+{
+    fout << m_rawPos << '\n';
+    if( !fout )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error writing raw position" } );
+    }
+
+    fout << m_parked << '\n';
+    if( !fout )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error writing parked state" } );
+    }
+
+    fout << m_maxPos << '\n';
+    if( !fout )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error writing max position" } );
+    }
+
+    fout << m_lastHomed.tv_sec << '\n';
+    if( !fout )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error writing last home time" } );
+    }
+
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::readStateFile( std::ifstream &fin )
+{
+    long   rawPos;
+    bool   parked;
+    long   maxPos;
+    time_t lastHomed;
+
+    fin >> rawPos;
+    if( !fin )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error reading raw position" } );
+    }
+
+    fin >> parked;
+    if( !fin )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error reading parked state" } );
+    }
+
+    fin >> maxPos;
+    if( !fin )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error reading max position" } );
+    }
+
+    fin >> lastHomed;
+    if( !fin )
+    {
+        return MagAOXAppT::log<software_error, -1>( { "error reading last home time" } );
+    }
+
+    m_rawPos            = rawPos;
+    m_tgtPos            = rawPos;
+    m_parked            = parked;
+    m_parkPos           = rawPos;
+    m_maxPos            = maxPos;
+    m_lastHomed.tv_sec  = lastHomed;
+    m_lastHomed.tv_nsec = 0;
+    return 0;
+}
+
+} // namespace app
+} // namespace MagAOX
+
+#endif // zaberBinaryStage_hpp

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -40,6 +40,7 @@ class zaberBinaryStage
         cmdMoveAbsolute          = 20,
         cmdMoveRelative          = 21,
         cmdStop                  = 23,
+        cmdSetHoldCurrent        = 39,
         cmdSetDeviceMode         = 40,
         cmdSetTargetSpeed        = 42,
         cmdSetMaximumPosition    = 44,
@@ -110,6 +111,15 @@ class zaberBinaryStage
 
     /// Whether a parked position has been recovered from device non-volatile memory.
     bool m_hasParkPos{ false };
+
+    /// Whether a parked state file has been loaded from disk.
+    bool m_hasStateFile{ false };
+
+    /// Raw position loaded from the parked state file.
+    long m_stateFileRawPos{ 0 };
+
+    /// Parked flag loaded from the parked state file.
+    bool m_stateFileParked{ false };
 
     /// Last reported stage temperature. Firmware 5.35 does not expose this directly.
     float m_temp{ -999.0 };
@@ -280,6 +290,11 @@ class zaberBinaryStage
                         int32_t speed /**< [in] the target speed command value */
     );
 
+    /// Set the hold current used while the stage is idle.
+    int setHoldCurrent( z_port  port, /**< [in] the port with which to communicate */
+                        int32_t value /**< [in] the hold current command value */
+    );
+
     /// Stop the stage.
     int stop( z_port port /**< [in] the port with which to communicate */ );
 
@@ -297,6 +312,9 @@ class zaberBinaryStage
 
     /// Recall the MagAO-X parked position from device non-volatile memory.
     int recallParkPosition( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Restore parked state after a power cycle if device and disk state agree.
+    int restoreParkedState( z_port port /**< [in] the port with which to communicate */ );
 
     /// Move to a new absolute position.
     int moveAbs( z_port port, /**< [in] the port with which to communicate */
@@ -800,6 +818,31 @@ int zaberBinaryStage<parentT>::setTargetSpeed( z_port port, int32_t speed )
 }
 
 template <class parentT>
+int zaberBinaryStage<parentT>::setHoldCurrent( z_port port, int32_t value )
+{
+    int rv = sendCommandNoReply( port, cmdSetHoldCurrent, value );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    int32_t appliedValue;
+    rv = getSetting( appliedValue, port, cmdSetHoldCurrent );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    if( appliedValue != value )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} reported hold current {} after requesting {}", m_name, appliedValue, value ) );
+    }
+
+    return 0;
+}
+
+template <class parentT>
 int zaberBinaryStage<parentT>::stop( z_port port )
 {
     int rv = sendCommandNoReply( port, cmdStop, 0 );
@@ -843,7 +886,19 @@ int zaberBinaryStage<parentT>::park( z_port port )
         return rv;
     }
 
-    return recallParkPosition( port );
+    rv = recallParkPosition( port );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    rv = setHoldCurrent( port, 0 );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    return 0;
 }
 
 template <class parentT>
@@ -868,6 +923,51 @@ int zaberBinaryStage<parentT>::recallParkPosition( z_port port )
     m_parkPos    = storedPosition;
     m_hasParkPos = true;
     m_parked     = ( m_rawPos == m_parkPos );
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::restoreParkedState( z_port port )
+{
+    if( !m_hasStateFile || !m_stateFileParked || !m_hasParkPos )
+    {
+        return 0;
+    }
+
+    if( m_stateFileRawPos != m_parkPos )
+    {
+        return MagAOXAppT::log<software_warning, 0>(
+            std::format( "parked state mismatch for {}: disk {} device {}", m_name, m_stateFileRawPos, m_parkPos ) );
+    }
+
+    int rv = setHoldCurrent( port, 0 );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    rv = sendCommandNoReply( port, cmdSetCurrentPosition, m_stateFileRawPos );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    int32_t restoredPos;
+    rv = queryCommand( restoredPos, port, cmdReturnCurrentPosition, 0, cmdReturnCurrentPosition );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    if( restoredPos != m_stateFileRawPos )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} restored position {} but expected {}", m_name, restoredPos, m_stateFileRawPos ) );
+    }
+
+    m_rawPos = restoredPos;
+    m_tgtPos = restoredPos;
+    m_parked = true;
     return 0;
 }
 
@@ -1028,6 +1128,9 @@ int zaberBinaryStage<parentT>::readStateFile( std::ifstream &fin )
     m_parked            = parked;
     m_parkPos           = rawPos;
     m_hasParkPos        = parked;
+    m_hasStateFile      = true;
+    m_stateFileRawPos   = rawPos;
+    m_stateFileParked   = parked;
     m_maxPos            = maxPos;
     m_lastHomed.tv_sec  = lastHomed;
     m_lastHomed.tv_nsec = 0;

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -672,8 +672,6 @@ int zaberBinaryStage<parentT>::getMaxPos( z_port port )
     }
 
     m_maxPos = value;
-    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} max position read as {}", m_name, m_maxPos ),
-                               logPrio::LOG_DEBUG );
     return 0;
 }
 
@@ -721,9 +719,6 @@ int zaberBinaryStage<parentT>::updatePos( z_port port )
     }
 
     m_rawPos = pos;
-    MagAOXAppT::log<text_log>(
-        std::format( "zaberBinary {} status {} rawPos {} tgtPos {}", m_name, status, m_rawPos, m_tgtPos ),
-        logPrio::LOG_DEBUG );
 
     if( status == 0 && m_homing == false && m_warnWR == false && m_tgtPos == 0 && m_rawPos == 0 &&
         m_lastHomed.tv_sec == 0 )
@@ -755,7 +750,7 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
     }
 
     mode |= modeDisableAutoReply;
-    mode &= ~modeDisablePotentiomer;
+    mode |= modeDisablePotentiomer;
 
     rv = sendCommandNoReply( port, cmdSetDeviceMode, mode );
     if( rv < 0 )
@@ -770,15 +765,11 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
         return rv;
     }
 
-    if( ( appliedMode & modeDisableAutoReply ) == 0 )
+    if( ( appliedMode & modeDisablePotentiomer ) == 0 || ( appliedMode & modeDisableAutoReply ) == 0 )
     {
         return MagAOXAppT::log<software_error, -1>(
             std::format( "device {} did not apply requested device mode {}", m_name, mode ) );
     }
-
-    MagAOXAppT::log<text_log>(
-        std::format( "zaberBinary {} device mode now {} (potentiometer enabled)", m_name, appliedMode ),
-        logPrio::LOG_DEBUG );
 
     return 0;
 }
@@ -798,9 +789,6 @@ int zaberBinaryStage<parentT>::setTargetSpeed( z_port port, int32_t speed )
     {
         return rv;
     }
-
-    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} target speed configured to {}", m_name, appliedSpeed ),
-                               logPrio::LOG_DEBUG );
 
     if( appliedSpeed != speed )
     {
@@ -903,8 +891,6 @@ int zaberBinaryStage<parentT>::moveAbs( z_port port, long rawPos )
 
     m_tgtPos = rawPos;
     m_homing = false;
-    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} moveAbs target {} maxPos {}", m_name, rawPos, m_maxPos ),
-                               logPrio::LOG_DEBUG );
     return 0;
 }
 

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -726,10 +726,23 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
     mode |= modeDisableAutoReply;
     mode |= modeDisablePotentiomer;
 
-    rv = queryCommand( mode, port, cmdSetDeviceMode, mode, cmdSetDeviceMode );
+    rv = sendCommandNoReply( port, cmdSetDeviceMode, mode );
     if( rv < 0 )
     {
         return rv;
+    }
+
+    int32_t appliedMode;
+    rv = getSetting( appliedMode, port, cmdSetDeviceMode );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    if( ( appliedMode & modeDisablePotentiomer ) == 0 || ( appliedMode & modeDisableAutoReply ) == 0 )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} did not apply requested device mode {}", m_name, mode ) );
     }
 
     return 0;
@@ -773,17 +786,13 @@ int zaberBinaryStage<parentT>::home( z_port port )
 template <class parentT>
 int zaberBinaryStage<parentT>::park( z_port port )
 {
-    int32_t response;
-    int     rv = queryCommand( response, port, cmdStoreCurrentPosition, parkPositionRegister, cmdStoreCurrentPosition );
+    int rv = sendCommandNoReply( port, cmdStoreCurrentPosition, parkPositionRegister );
     if( rv < 0 )
     {
         return rv;
     }
 
-    m_parked     = true;
-    m_parkPos    = m_rawPos;
-    m_hasParkPos = true;
-    return 0;
+    return recallParkPosition( port );
 }
 
 template <class parentT>

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -1,5 +1,6 @@
 /** \file zaberBinaryStage.hpp
  * \brief A class with details of a single binary-protocol Zaber stage.
+ * \author Jared R. Males (jaredmales@gmail.com)
  *
  * \ingroup zaberLowLevelBinary_files
  */
@@ -229,25 +230,45 @@ class zaberBinaryStage
     /// Get whether any warning-equivalent flag is set.
     bool warningState();
 
+    /// Get the driver-disabled warning flag.
     bool warnFD();
+    /// Get the FQ warning flag.
     bool warnFQ();
+    /// Get the FS warning flag.
     bool warnFS();
+    /// Get the FT warning flag.
     bool warnFT();
+    /// Get the FB warning flag.
     bool warnFB();
+    /// Get the FP warning flag.
     bool warnFP();
+    /// Get the FE warning flag.
     bool warnFE();
+    /// Get the WH warning flag.
     bool warnWH();
+    /// Get the WL warning flag.
     bool warnWL();
+    /// Get the WP warning flag.
     bool warnWP();
+    /// Get the WV warning flag.
     bool warnWV();
+    /// Get the WT warning flag.
     bool warnWT();
+    /// Get the WM warning flag.
     bool warnWM();
+    /// Get the WR warning flag.
     bool warnWR();
+    /// Get the NC warning flag.
     bool warnNC();
+    /// Get the NI warning flag.
     bool warnNI();
+    /// Get the ND warning flag.
     bool warnND();
+    /// Get the NU warning flag.
     bool warnNU();
+    /// Get the NJ warning flag.
     bool warnNJ();
+    /// Get the unknown-warning flag.
     bool warnUNK();
 
     /// Send a command and wait for the corresponding binary reply.

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -35,6 +35,7 @@ class zaberBinaryStage
         cmdHome                  = 1,
         cmdRenumber              = 2,
         cmdStoreCurrentPosition  = 16,
+        cmdReturnStoredPosition  = 17,
         cmdMoveToStoredPosition  = 18,
         cmdMoveAbsolute          = 20,
         cmdMoveRelative          = 21,
@@ -56,6 +57,9 @@ class zaberBinaryStage
         modeDisablePotentiomer = ( 1 << 3 ),
         modeHomeStatus         = ( 1 << 7 )
     };
+
+    /// Stored-position register used to persist the MagAO-X parked position.
+    static constexpr int32_t parkPositionRegister = 0;
 
   protected:
     /// Parent application used for logging and power-state checks.
@@ -99,6 +103,9 @@ class zaberBinaryStage
 
     /// Emulated parked position in microsteps.
     long m_parkPos{ 0 };
+
+    /// Whether a parked position has been recovered from device non-volatile memory.
+    bool m_hasParkPos{ false };
 
     /// Last reported stage temperature. Firmware 5.35 does not expose this directly.
     float m_temp{ -999.0 };
@@ -272,6 +279,9 @@ class zaberBinaryStage
 
     /// Clear the parked bookkeeping state.
     int unpark( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Recall the MagAO-X parked position from device non-volatile memory.
+    int recallParkPosition( z_port port /**< [in] the port with which to communicate */ );
 
     /// Move to a new absolute position.
     int moveAbs( z_port port, /**< [in] the port with which to communicate */
@@ -640,7 +650,11 @@ int zaberBinaryStage<parentT>::getMaxPos( z_port port )
 template <class parentT>
 int zaberBinaryStage<parentT>::getParked( z_port )
 {
-    if( m_parked && m_rawPos != m_parkPos )
+    if( m_hasParkPos && m_rawPos == m_parkPos )
+    {
+        m_parked = true;
+    }
+    else
     {
         m_parked = false;
     }
@@ -757,10 +771,18 @@ int zaberBinaryStage<parentT>::home( z_port port )
 }
 
 template <class parentT>
-int zaberBinaryStage<parentT>::park( z_port )
+int zaberBinaryStage<parentT>::park( z_port port )
 {
-    m_parked  = true;
-    m_parkPos = m_rawPos;
+    int32_t response;
+    int     rv = queryCommand( response, port, cmdStoreCurrentPosition, parkPositionRegister, cmdStoreCurrentPosition );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    m_parked     = true;
+    m_parkPos    = m_rawPos;
+    m_hasParkPos = true;
     return 0;
 }
 
@@ -768,6 +790,24 @@ template <class parentT>
 int zaberBinaryStage<parentT>::unpark( z_port )
 {
     m_parked = false;
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::recallParkPosition( z_port port )
+{
+    int32_t storedPosition;
+    int     rv =
+        queryCommand( storedPosition, port, cmdReturnStoredPosition, parkPositionRegister, cmdReturnStoredPosition );
+    if( rv < 0 )
+    {
+        m_hasParkPos = false;
+        return -1;
+    }
+
+    m_parkPos    = storedPosition;
+    m_hasParkPos = true;
+    m_parked     = ( m_rawPos == m_parkPos );
     return 0;
 }
 
@@ -927,6 +967,7 @@ int zaberBinaryStage<parentT>::readStateFile( std::ifstream &fin )
     m_tgtPos            = rawPos;
     m_parked            = parked;
     m_parkPos           = rawPos;
+    m_hasParkPos        = parked;
     m_maxPos            = maxPos;
     m_lastHomed.tv_sec  = lastHomed;
     m_lastHomed.tv_nsec = 0;

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -41,6 +41,7 @@ class zaberBinaryStage
         cmdMoveRelative          = 21,
         cmdStop                  = 23,
         cmdSetDeviceMode         = 40,
+        cmdSetTargetSpeed        = 42,
         cmdSetMaximumPosition    = 44,
         cmdSetCurrentPosition    = 45,
         cmdReturnFirmwareVersion = 51,
@@ -97,6 +98,9 @@ class zaberBinaryStage
 
     /// Last target position sent to the device in microsteps.
     long m_tgtPos{ 0 };
+
+    /// Configured target speed command value for this stage.
+    int32_t m_targetSpeed{ 1000 };
 
     /// Maximum position in microsteps.
     long m_maxPos{ -1 };
@@ -200,6 +204,12 @@ class zaberBinaryStage
     /// Get the maximum position.
     long maxPos();
 
+    /// Get the configured target speed.
+    int32_t targetSpeed();
+
+    /// Set the configured target speed.
+    int targetSpeed( const int32_t &speed /**< [in] the target speed command value */ );
+
     /// Get whether any warning-equivalent flag is set.
     bool warn();
 
@@ -264,6 +274,11 @@ class zaberBinaryStage
 
     /// Disable the manual knob and asynchronous command replies.
     int disableKnob( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Set the target speed used for absolute and relative moves.
+    int setTargetSpeed( z_port  port, /**< [in] the port with which to communicate */
+                        int32_t speed /**< [in] the target speed command value */
+    );
 
     /// Stop the stage.
     int stop( z_port port /**< [in] the port with which to communicate */ );
@@ -401,6 +416,19 @@ template <class parentT>
 long zaberBinaryStage<parentT>::maxPos()
 {
     return m_maxPos;
+}
+
+template <class parentT>
+int32_t zaberBinaryStage<parentT>::targetSpeed()
+{
+    return m_targetSpeed;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::targetSpeed( const int32_t &speed )
+{
+    m_targetSpeed = speed;
+    return 0;
 }
 
 template <class parentT>
@@ -751,6 +779,34 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
     MagAOXAppT::log<text_log>(
         std::format( "zaberBinary {} device mode now {} (potentiometer enabled)", m_name, appliedMode ),
         logPrio::LOG_DEBUG );
+
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::setTargetSpeed( z_port port, int32_t speed )
+{
+    int rv = sendCommandNoReply( port, cmdSetTargetSpeed, speed );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    int32_t appliedSpeed;
+    rv = getSetting( appliedSpeed, port, cmdSetTargetSpeed );
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} target speed configured to {}", m_name, appliedSpeed ),
+                               logPrio::LOG_DEBUG );
+
+    if( appliedSpeed != speed )
+    {
+        return MagAOXAppT::log<software_error, -1>(
+            std::format( "device {} reported target speed {} after requesting {}", m_name, appliedSpeed, speed ) );
+    }
 
     return 0;
 }

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -644,6 +644,8 @@ int zaberBinaryStage<parentT>::getMaxPos( z_port port )
     }
 
     m_maxPos = value;
+    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} max position read as {}", m_name, m_maxPos ),
+                               logPrio::LOG_DEBUG );
     return 0;
 }
 
@@ -683,23 +685,24 @@ int zaberBinaryStage<parentT>::updatePos( z_port port )
 
     m_homing = ( status == 1 );
 
-    if( status == 0 )
+    int32_t pos;
+    rv = queryCommand( pos, port, cmdReturnCurrentPosition, 0, cmdReturnCurrentPosition );
+    if( rv < 0 )
     {
-        int32_t pos;
-        rv = queryCommand( pos, port, cmdReturnCurrentPosition, 0, cmdReturnCurrentPosition );
-        if( rv < 0 )
-        {
-            return rv;
-        }
+        return rv;
+    }
 
-        m_rawPos = pos;
+    m_rawPos = pos;
+    MagAOXAppT::log<text_log>(
+        std::format( "zaberBinary {} status {} rawPos {} tgtPos {}", m_name, status, m_rawPos, m_tgtPos ),
+        logPrio::LOG_DEBUG );
 
-        if( m_homing == false && m_warnWR == false && m_tgtPos == 0 && m_rawPos == 0 && m_lastHomed.tv_sec == 0 )
+    if( status == 0 && m_homing == false && m_warnWR == false && m_tgtPos == 0 && m_rawPos == 0 &&
+        m_lastHomed.tv_sec == 0 )
+    {
+        if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
         {
-            if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
-            {
-                MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
-            }
+            MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
         }
     }
 
@@ -724,7 +727,7 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
     }
 
     mode |= modeDisableAutoReply;
-    mode |= modeDisablePotentiomer;
+    mode &= ~modeDisablePotentiomer;
 
     rv = sendCommandNoReply( port, cmdSetDeviceMode, mode );
     if( rv < 0 )
@@ -739,11 +742,15 @@ int zaberBinaryStage<parentT>::disableKnob( z_port port )
         return rv;
     }
 
-    if( ( appliedMode & modeDisablePotentiomer ) == 0 || ( appliedMode & modeDisableAutoReply ) == 0 )
+    if( ( appliedMode & modeDisableAutoReply ) == 0 )
     {
         return MagAOXAppT::log<software_error, -1>(
             std::format( "device {} did not apply requested device mode {}", m_name, mode ) );
     }
+
+    MagAOXAppT::log<text_log>(
+        std::format( "zaberBinary {} device mode now {} (potentiometer enabled)", m_name, appliedMode ),
+        logPrio::LOG_DEBUG );
 
     return 0;
 }
@@ -840,6 +847,8 @@ int zaberBinaryStage<parentT>::moveAbs( z_port port, long rawPos )
 
     m_tgtPos = rawPos;
     m_homing = false;
+    MagAOXAppT::log<text_log>( std::format( "zaberBinary {} moveAbs target {} maxPos {}", m_name, rawPos, m_maxPos ),
+                               logPrio::LOG_DEBUG );
     return 0;
 }
 

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp
@@ -1,0 +1,14 @@
+/** \file zaberLowLevelBinary.cpp
+ * \brief The MagAO-X low-level binary-protocol Zaber controller main program.
+ *
+ * \ingroup zaberLowLevelBinary_files
+ */
+
+#include "zaberLowLevelBinary.hpp"
+
+int main( int argc, char **argv )
+{
+    MagAOX::app::zaberLowLevelBinary zll;
+
+    return zll.main( argc, argv );
+}

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.cpp
@@ -1,5 +1,6 @@
 /** \file zaberLowLevelBinary.cpp
  * \brief The MagAO-X low-level binary-protocol Zaber controller main program.
+ * \author Jared R. Males (jaredmales@gmail.com)
  *
  * \ingroup zaberLowLevelBinary_files
  */

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -1,0 +1,1088 @@
+/** \file zaberLowLevelBinary.hpp
+ * \brief The MagAO-X low-level binary-protocol Zaber controller.
+ *
+ * \ingroup zaberLowLevelBinary_files
+ */
+
+#ifndef zaberLowLevelBinary_hpp
+#define zaberLowLevelBinary_hpp
+
+#include <iostream>
+#include <thread>
+
+#include "../../libMagAOX/libMagAOX.hpp" // Note this is included on command line to trigger pch
+#include "../../magaox_git_version.h"
+
+typedef MagAOX::app::MagAOXApp<true> MagAOXAppT;
+
+#include "zaberBinaryStage.hpp"
+#include "zb_serial.h"
+
+#define ZBC_CONNECTED ( 0 )
+#define ZBC_ERROR ( -1 )
+#define ZBC_NOT_CONNECTED ( 10 )
+
+/** \defgroup zaberLowLevelBinary low-level binary zaber controller
+ * \brief The low-level binary interface to a set of chained Zaber stages
+ *
+ * \ingroup apps
+ */
+
+/** \defgroup zaberLowLevelBinary_files zaber low-level binary files
+ * \ingroup zaberLowLevelBinary
+ */
+
+namespace MagAOX
+{
+namespace app
+{
+
+/// The low-level binary-protocol Zaber controller.
+/**
+ * This app mirrors `zaberLowLevel` as closely as possible while speaking the
+ * firmware 5.xx T-series binary protocol.
+ *
+ * \ingroup zaberLowLevelBinary
+ */
+class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
+{
+    friend class zaberLowLevelBinary_test;
+
+  protected:
+    /// Number of configured stages.
+    int m_numStages{ 0 };
+
+    /// Connected binary protocol port.
+    z_port m_port{ 0 };
+
+    /** \name Configurable Parameters
+     *
+     * @{
+     */
+    bool m_renumberOnConnect{ true };
+
+    int m_maxDiscoveryAddress{ 16 };
+
+    int m_commandTimeout{ 250 };
+
+    int m_renumberPauseMs{ 750 };
+
+    ///@}
+
+    /** \name Stage Mapping - Data
+     *
+     * @{
+     */
+    std::vector<zaberBinaryStage<zaberLowLevelBinary>> m_stages;
+
+    std::unordered_map<int, size_t> m_stageAddress;
+
+    std::unordered_map<std::string, size_t> m_stageSerial;
+
+    std::unordered_map<std::string, size_t> m_stageName;
+
+    ///@}
+
+  public:
+    /// Default constructor.
+    zaberLowLevelBinary();
+
+    /// Destructor.
+    ~zaberLowLevelBinary() noexcept
+    {
+    }
+
+    /// Set up application configuration.
+    virtual void setupConfig();
+
+    /// Load application configuration.
+    virtual void loadConfig();
+
+    /// Connect to the binary-protocol stage chain and discover configured devices.
+    int connect();
+
+    /// Discover configured stages on the binary bus.
+    int loadStages();
+
+    /// Query a device directly for discovery-time replies.
+    int queryDevice( int32_t &response,      /**< [out] decoded reply data */
+                     uint8_t  deviceAddress, /**< [in] device address */
+                     uint8_t  commandNumber, /**< [in] command number */
+                     int32_t  data,          /**< [in] command data */
+                     uint8_t  expectedReply  /**< [in] expected reply command number */
+    );
+
+    /// Send a broadcast or address-specific command with no awaited reply.
+    int sendCommandNoReply( uint8_t deviceAddress, /**< [in] device address */
+                            uint8_t commandNumber, /**< [in] command number */
+                            int32_t data           /**< [in] command data */
+    );
+
+    /// Startup logic.
+    virtual int appStartup();
+
+    /// Main FSM implementation.
+    virtual int appLogic();
+
+    /// Power-off transition handler.
+    virtual int onPowerOff();
+
+    /// Powered-off loop handler.
+    virtual int whilePowerOff();
+
+    /// Shutdown handler.
+    virtual int appShutdown();
+
+  protected:
+    /** \name INDI Stage State - Data
+     *
+     * @{
+     */
+    pcf::IndiProperty m_indiP_curr_state;
+
+    pcf::IndiProperty m_indiP_max_pos;
+
+    pcf::IndiProperty m_indiP_parked;
+
+    pcf::IndiProperty m_indiP_lastHomed;
+
+    pcf::IndiProperty m_indiP_curr_pos;
+
+    pcf::IndiProperty m_indiP_temp;
+
+    pcf::IndiProperty m_indiP_warn;
+
+    pcf::IndiProperty m_indiP_tgt_pos;
+
+    pcf::IndiProperty m_indiP_req_home;
+
+    pcf::IndiProperty m_indiP_req_home_all;
+
+    pcf::IndiProperty m_indiP_req_halt;
+
+    pcf::IndiProperty m_indiP_req_ehalt;
+
+    ///@}
+
+  public:
+    /** \name INDI Stage State
+     *
+     * @{
+     */
+    INDI_NEWCALLBACK_DECL( zaberLowLevelBinary, m_indiP_tgt_pos );
+    INDI_NEWCALLBACK_DECL( zaberLowLevelBinary, m_indiP_req_home );
+    INDI_NEWCALLBACK_DECL( zaberLowLevelBinary, m_indiP_req_home_all );
+    INDI_NEWCALLBACK_DECL( zaberLowLevelBinary, m_indiP_req_halt );
+    INDI_NEWCALLBACK_DECL( zaberLowLevelBinary, m_indiP_req_ehalt );
+    ///@}
+};
+
+zaberLowLevelBinary::zaberLowLevelBinary() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
+{
+    m_powerMgtEnabled = true;
+}
+
+void zaberLowLevelBinary::setupConfig()
+{
+    tty::usbDevice::setupConfig( config );
+
+    config.add( "stages.renumberOnConnect",
+                "",
+                "stages.renumberOnConnect",
+                argType::Required,
+                "stages",
+                "renumberOnConnect",
+                false,
+                "bool",
+                "Whether to issue a broadcast renumber on connect. Default is true." );
+
+    config.add( "stages.maxDiscoveryAddress",
+                "",
+                "stages.maxDiscoveryAddress",
+                argType::Required,
+                "stages",
+                "maxDiscoveryAddress",
+                false,
+                "int",
+                "Maximum device address to scan when matching configured serial numbers." );
+
+    config.add( "stages.commandTimeout",
+                "",
+                "stages.commandTimeout",
+                argType::Required,
+                "stages",
+                "commandTimeout",
+                false,
+                "int",
+                "Binary command timeout in milliseconds." );
+
+    config.add( "stages.renumberPauseMs",
+                "",
+                "stages.renumberPauseMs",
+                argType::Required,
+                "stages",
+                "renumberPauseMs",
+                false,
+                "int",
+                "Pause in milliseconds after a renumber command before discovery begins." );
+}
+
+void zaberLowLevelBinary::loadConfig()
+{
+    this->m_baudRate = B9600;
+
+    int rv = tty::usbDevice::loadConfig( config );
+    if( rv != 0 && rv != TTY_E_NODEVNAMES && rv != TTY_E_DEVNOTFOUND )
+    {
+        log<software_error>( { rv, tty::ttyErrorString( rv ) } );
+    }
+
+    config( m_renumberOnConnect, "stages.renumberOnConnect" );
+    config( m_maxDiscoveryAddress, "stages.maxDiscoveryAddress" );
+    config( m_commandTimeout, "stages.commandTimeout" );
+    config( m_renumberPauseMs, "stages.renumberPauseMs" );
+
+    std::vector<std::string> sections;
+    config.unusedSections( sections );
+
+    if( sections.size() == 0 )
+    {
+        log<software_error>( { "No stages found" } );
+        return;
+    }
+
+    for( size_t n = 0; n < sections.size(); ++n )
+    {
+        if( config.isSetUnused( mx::app::iniFile::makeKey( sections[n], "serial" ) ) )
+        {
+            m_stages.push_back( zaberBinaryStage<zaberLowLevelBinary>( this ) );
+
+            size_t idx = m_stages.size() - 1;
+            m_stages[idx].name( sections[n] );
+
+            std::string tmp = m_stages[idx].serial();
+            config.configUnused( tmp, mx::app::iniFile::makeKey( sections[n], "serial" ) );
+            m_stages[idx].serial( tmp );
+
+            m_stageName.insert( { m_stages[idx].name(), idx } );
+            m_stageSerial.insert( { m_stages[idx].serial(), idx } );
+        }
+    }
+}
+
+int zaberLowLevelBinary::queryDevice(
+    int32_t &response, uint8_t deviceAddress, uint8_t commandNumber, int32_t data, uint8_t expectedReply )
+{
+    uint8_t command[6];
+    if( zb_encode( command, deviceAddress, commandNumber, data ) != Z_SUCCESS )
+    {
+        return log<software_error, -1>( "zb_encode failed" );
+    }
+
+    if( zb_send( m_port, command ) != 6 )
+    {
+        return log<software_error, -1>( "zb_send failed" );
+    }
+
+    uint8_t reply[6];
+    int     rv = zb_receive( m_port, reply );
+    if( rv != 6 )
+    {
+        return -1;
+    }
+
+    if( reply[0] != deviceAddress )
+    {
+        return -1;
+    }
+
+    if( reply[1] == 255 )
+    {
+        return -1;
+    }
+
+    if( reply[1] != expectedReply )
+    {
+        return -1;
+    }
+
+    if( zb_decode( &response, reply ) != Z_SUCCESS )
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+int zaberLowLevelBinary::sendCommandNoReply( uint8_t deviceAddress, uint8_t commandNumber, int32_t data )
+{
+    uint8_t command[6];
+    if( zb_encode( command, deviceAddress, commandNumber, data ) != Z_SUCCESS )
+    {
+        return log<software_error, -1>( "zb_encode failed" );
+    }
+
+    if( zb_send( m_port, command ) != 6 )
+    {
+        return log<software_error, -1>( "zb_send failed" );
+    }
+
+    return 0;
+}
+
+int zaberLowLevelBinary::connect()
+{
+    if( m_port > 0 )
+    {
+        int rv = zb_disconnect( m_port );
+        if( rv < 0 )
+        {
+            log<text_log>( "Error disconnecting from zaber binary system.", logPrio::LOG_ERROR );
+        }
+        m_port = 0;
+    }
+
+    int zrv;
+    { // mutex scope
+        elevatedPrivileges elPriv( this );
+        zrv = zb_connect( &m_port, m_deviceName.c_str() );
+    }
+
+    if( zrv != Z_SUCCESS || m_port <= 0 )
+    {
+        if( m_port > 0 )
+        {
+            zb_disconnect( m_port );
+            m_port = 0;
+        }
+
+        if( !stateLogged() )
+        {
+            log<software_error>( { "can not connect to zaber binary stage(s)" } );
+        }
+
+        return ZBC_NOT_CONNECTED;
+    }
+
+    if( zb_set_timeout( m_port, m_commandTimeout ) < 0 )
+    {
+        log<software_error>( { "error setting binary command timeout" } );
+        state( stateCodes::ERROR );
+        return ZBC_ERROR;
+    }
+
+    if( zb_drain( m_port ) != Z_SUCCESS )
+    {
+        log<software_error>( { "error draining binary port" } );
+        state( stateCodes::ERROR );
+        return ZBC_ERROR;
+    }
+
+    if( m_renumberOnConnect )
+    {
+        if( sendCommandNoReply( 0, zaberBinaryStage<zaberLowLevelBinary>::cmdRenumber, 0 ) < 0 )
+        {
+            log<text_log>( "Error sending renumber query to stages", logPrio::LOG_ERROR );
+            state( stateCodes::ERROR );
+            return ZBC_ERROR;
+        }
+
+        std::this_thread::sleep_for( std::chrono::milliseconds( m_renumberPauseMs ) );
+        zb_drain( m_port );
+    }
+
+    return loadStages();
+}
+
+int zaberLowLevelBinary::loadStages()
+{
+    m_stageAddress.clear();
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        m_stages[n].deviceAddress( -1 );
+    }
+
+    for( int address = 1; address <= m_maxDiscoveryAddress; ++address )
+    {
+        int32_t serialNumber;
+        if( queryDevice( serialNumber,
+                         static_cast<uint8_t>( address ),
+                         zaberBinaryStage<zaberLowLevelBinary>::cmdReturnSerialNumber,
+                         0,
+                         zaberBinaryStage<zaberLowLevelBinary>::cmdReturnSerialNumber ) < 0 )
+        {
+            continue;
+        }
+
+        std::string serial = std::to_string( serialNumber );
+        if( m_stageSerial.count( serial ) == 1 )
+        {
+            size_t idx = m_stageSerial[serial];
+            m_stages[idx].deviceAddress( address );
+            m_stageAddress.insert( { address, idx } );
+            log<text_log>( "stage @" + std::to_string( address ) + " with s/n " + serial + " corresponds to " +
+                           m_stages[idx].name() );
+        }
+        else
+        {
+            log<text_log>( "Unknown stage @" + std::to_string( address ) + " with s/n " + serial,
+                           logPrio::LOG_WARNING );
+        }
+    }
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        if( m_stages[n].deviceAddress() < 1 )
+        {
+            log<text_log>(
+                std::format( "stage {} with s/n {} not found in system.", m_stages[n].name(), m_stages[n].serial() ),
+                logPrio::LOG_ERROR );
+            state( state(), true );
+        }
+    }
+
+    return ZBC_CONNECTED;
+}
+
+int zaberLowLevelBinary::appStartup()
+{
+    if( state() == stateCodes::UNINITIALIZED )
+    {
+        log<text_log>( "In appStartup but in state UNINITIALIZED.", logPrio::LOG_CRITICAL );
+        return -1;
+    }
+
+    if( m_stages.size() == 0 )
+    {
+        log<text_log>( "No stages configured.", logPrio::LOG_CRITICAL );
+        return -1;
+    }
+
+    REG_INDI_NEWPROP_NOCB( m_indiP_curr_state, "curr_state", pcf::IndiProperty::Text );
+    REG_INDI_NEWPROP_NOCB( m_indiP_max_pos, "max_pos", pcf::IndiProperty::Text );
+    REG_INDI_NEWPROP_NOCB( m_indiP_parked, "parked", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP_NOCB( m_indiP_lastHomed, "last_homed", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP_NOCB( m_indiP_curr_pos, "curr_pos", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP_NOCB( m_indiP_temp, "temp", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP_NOCB( m_indiP_warn, "warning", pcf::IndiProperty::Switch );
+    m_indiP_warn.setRule( pcf::IndiProperty::AnyOfMany );
+
+    REG_INDI_NEWPROP( m_indiP_tgt_pos, "tgt_pos", pcf::IndiProperty::Number );
+    REG_INDI_NEWPROP( m_indiP_req_home, "req_home", pcf::IndiProperty::Switch );
+    m_indiP_req_home.setRule( pcf::IndiProperty::AtMostOne );
+
+    CREATE_REG_INDI_NEW_REQUESTSWITCH( m_indiP_req_home_all, "home_all" );
+
+    REG_INDI_NEWPROP( m_indiP_req_halt, "req_halt", pcf::IndiProperty::Switch );
+    m_indiP_req_halt.setRule( pcf::IndiProperty::AtMostOne );
+
+    REG_INDI_NEWPROP( m_indiP_req_ehalt, "req_ehalt", pcf::IndiProperty::Switch );
+    m_indiP_req_ehalt.setRule( pcf::IndiProperty::AtMostOne );
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        m_indiP_curr_state.add( pcf::IndiElement( m_stages[n].name() ) );
+
+        m_indiP_max_pos.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_max_pos[m_stages[n].name()] = -1;
+
+        m_indiP_parked.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_lastHomed.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_curr_pos.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_temp.add( pcf::IndiElement( m_stages[n].name() ) );
+
+        m_indiP_warn.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_warn[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
+
+        m_indiP_tgt_pos.add( pcf::IndiElement( m_stages[n].name() ) );
+
+        m_indiP_req_home.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_home[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
+
+        m_indiP_req_halt.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_halt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
+
+        m_indiP_req_ehalt.add( pcf::IndiElement( m_stages[n].name() ) );
+        m_indiP_req_ehalt[m_stages[n].name()].setSwitchState( pcf::IndiElement::Off );
+
+        std::ifstream posIn;
+        posIn.open( std::format( "{}/{}/{}", m_sysPath, m_configName, m_stages[n].name() ) );
+        if( !posIn )
+        {
+            continue;
+        }
+
+        if( m_stages[n].readStateFile( posIn ) < 0 )
+        {
+            return log<software_critical, -1>( std::format( "error reading state file for {}", m_stages[n].name() ) );
+        }
+
+        m_indiP_curr_pos[m_stages[n].name()].set( m_stages[n].rawPos() );
+        m_indiP_tgt_pos[m_stages[n].name()].set( m_stages[n].tgtPos() );
+        m_indiP_parked[m_stages[n].name()].set( m_stages[n].parked() );
+        m_indiP_lastHomed[m_stages[n].name()].set( m_stages[n].lastHomed() );
+        m_indiP_max_pos[m_stages[n].name()].set( m_stages[n].maxPos() );
+    }
+
+    return 0;
+}
+
+int zaberLowLevelBinary::appLogic()
+{
+    if( state() == stateCodes::INITIALIZED )
+    {
+        log<text_log>( "In appLogic but in state INITIALIZED.", logPrio::LOG_CRITICAL );
+        return -1;
+    }
+
+    if( state() == stateCodes::POWERON )
+    {
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "POWERON" ) );
+        }
+
+        state( stateCodes::NODEVICE );
+        return 0;
+    }
+
+    if( state() == stateCodes::NODEVICE )
+    {
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+        }
+
+        int rv = tty::usbDevice::getDeviceName();
+        if( rv < 0 && rv != TTY_E_DEVNOTFOUND && rv != TTY_E_NODEVNAMES )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+            {
+                return 0;
+            }
+
+            state( stateCodes::FAILURE );
+            if( !stateLogged() )
+            {
+                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+            }
+            return -1;
+        }
+
+        if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
+        {
+            if( !stateLogged() )
+            {
+                log<text_log>(
+                    std::format( "USB Device {}:{}:{} not found in udev", m_idVendor, m_idProduct, m_serial ) );
+            }
+            return 0;
+        }
+
+        log<text_log>(
+            std::format( "USB Device {}:{}:{} found in udev as {}", m_idVendor, m_idProduct, m_serial, m_deviceName ) );
+
+        state( stateCodes::NOTCONNECTED );
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            if( m_stages[i].deviceAddress() < 1 )
+            {
+                continue;
+            }
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NOTCONNECTED" ) );
+        }
+
+        return 0;
+    }
+
+    if( state() == stateCodes::NOTCONNECTED )
+    {
+        std::lock_guard<std::mutex> guard( m_indiMutex );
+
+        int rv = connect();
+        if( rv == ZBC_CONNECTED )
+        {
+            state( stateCodes::CONNECTED );
+            for( size_t i = 0; i < m_stages.size(); ++i )
+            {
+                if( m_stages[i].deviceAddress() < 1 )
+                {
+                    continue;
+                }
+
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "CONNECTED" ) );
+            }
+
+            if( !stateLogged() )
+            {
+                log<text_log>( "Connected to binary stage(s) on " + m_deviceName );
+            }
+        }
+        else if( rv == ZBC_NOT_CONNECTED )
+        {
+            return 0;
+        }
+    }
+
+    if( state() == stateCodes::CONNECTED )
+    {
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            if( m_stages[i].deviceAddress() < 1 )
+            {
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+                continue;
+            }
+
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+
+            if( m_stages[i].disableKnob( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            if( m_stages[i].getMaxPos( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            updateIfChanged( m_indiP_max_pos, m_stages[i].name(), m_stages[i].maxPos() );
+
+            if( m_stages[i].unpark( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            if( m_stages[i].getWarnings( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+        }
+
+        state( stateCodes::READY );
+        return 0;
+    }
+
+    if( state() == stateCodes::READY )
+    {
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            if( m_stages[i].deviceAddress() < 1 )
+            {
+                continue;
+            }
+
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+
+            if( m_stages[i].updatePos( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            if( m_stages[i].getParked( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
+            updateIfChanged( m_indiP_lastHomed, m_stages[i].name(), m_stages[i].lastHomed() );
+            updateIfChanged( m_indiP_curr_pos, m_stages[i].name(), m_stages[i].rawPos() );
+            updateIfChanged( m_indiP_tgt_pos, m_stages[i].name(), m_stages[i].tgtPos() );
+
+            if( m_stages[i].deviceStatus() == 'B' )
+            {
+                if( m_stages[i].homing() )
+                {
+                    updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "HOMING" ) );
+                }
+                else
+                {
+                    updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "OPERATING" ) );
+                }
+            }
+            else if( m_stages[i].deviceStatus() == 'I' )
+            {
+                if( m_stages[i].homing() )
+                {
+                    log<software_error>( std::format( "stage {} idle but in state homing. bug.", m_stages[i].name() ) );
+                    return 0;
+                }
+
+                if( m_stages[i].warnWR() )
+                {
+                    updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NOTHOMED" ) );
+                }
+                else
+                {
+                    if( !m_stages[i].parked() )
+                    {
+                        if( m_stages[i].park( m_port ) < 0 )
+                        {
+                            log<software_error>();
+                            state( stateCodes::ERROR );
+                            return 0;
+                        }
+
+                        std::ofstream posOut;
+                        { // mutex scope
+                            elevatedPrivileges ep( this );
+                            posOut.open( std::format( "{}/{}/{}", m_sysPath, m_configName, m_stages[i].name() ) );
+                        }
+
+                        if( !posOut )
+                        {
+                            log<software_error>( std::format( "error opening state file for {}", m_stages[i].name() ) );
+                        }
+                        else if( m_stages[i].writeStateFile( posOut ) < 0 )
+                        {
+                            log<software_error>( std::format( "error writing state file for {}", m_stages[i].name() ) );
+                        }
+
+                        updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
+                    }
+
+                    updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "READY" ) );
+                }
+            }
+            else
+            {
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+            }
+
+            if( m_stages[i].warn() )
+            {
+                updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::On );
+            }
+            else
+            {
+                updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::Off );
+            }
+
+            m_stages[i].updateTemp( m_port );
+            updateIfChanged( m_indiP_temp, m_stages[i].name(), m_stages[i].temp() );
+        }
+    }
+
+    if( state() == stateCodes::ERROR )
+    {
+        int rv = tty::usbDevice::getDeviceName();
+        if( rv < 0 && rv != TTY_E_DEVNOTFOUND && rv != TTY_E_NODEVNAMES )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+            {
+                return 0;
+            }
+
+            state( stateCodes::FAILURE );
+            for( size_t i = 0; i < m_stages.size(); ++i )
+            {
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
+            }
+            if( !stateLogged() )
+            {
+                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+            }
+            return rv;
+        }
+
+        if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
+        {
+            state( stateCodes::NODEVICE );
+            for( size_t i = 0; i < m_stages.size(); ++i )
+            {
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+            }
+            return 0;
+        }
+
+        if( powerState() != 1 || powerStateTarget() != 1 )
+        {
+            return 0;
+        }
+
+        state( stateCodes::FAILURE );
+        for( size_t i = 0; i < m_stages.size(); ++i )
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
+        }
+
+        log<software_critical>();
+        log<text_log>( "Binary-protocol error not due to loss of USB connection.", logPrio::LOG_CRITICAL );
+    }
+
+    if( powerState() != 1 || powerStateTarget() != 1 )
+    {
+        return 0;
+    }
+
+    if( state() == stateCodes::FAILURE )
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
+inline int zaberLowLevelBinary::onPowerOff()
+{
+    if( m_port > 0 )
+    {
+        int rv = zb_disconnect( m_port );
+        if( rv < 0 )
+        {
+            log<text_log>( "Error disconnecting from zaber binary system.", logPrio::LOG_ERROR );
+        }
+    }
+
+    m_port = 0;
+
+    std::lock_guard<std::mutex> lock( m_indiMutex );
+    for( size_t i = 0; i < m_stages.size(); ++i )
+    {
+        updateIfChanged( m_indiP_temp, m_stages[i].name(), std::string( "" ) );
+        m_stages[i].onPowerOff();
+        updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "POWEROFF" ) );
+        updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::Off );
+    }
+
+    return 0;
+}
+
+inline int zaberLowLevelBinary::whilePowerOff()
+{
+    return 0;
+}
+
+inline int zaberLowLevelBinary::appShutdown()
+{
+    for( size_t i = 0; i < m_stages.size(); ++i )
+    {
+        if( m_stages[i].deviceAddress() < 1 )
+        {
+            continue;
+        }
+
+        updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_tgt_pos )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_tgt_pos, ipRecv );
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        if( ipRecv.find( m_stages[n].name() ) )
+        {
+            long tgt = ipRecv[m_stages[n].name()].get<long>();
+            if( tgt >= 0 )
+            {
+                if( m_stages[n].deviceAddress() < 1 )
+                {
+                    return log<software_error, -1>( std::format(
+                        "stage {} with s/n {} not found in system.", m_stages[n].name(), m_stages[n].serial() ) );
+                }
+
+                std::lock_guard<std::mutex> guard( m_indiMutex );
+                if( m_stages[n].moveAbs( m_port, tgt ) < 0 )
+                {
+                    return log<software_error, -1>( { "error from moveAbs for " + m_stages[n].name() } );
+                }
+
+                updateIfChanged( m_indiP_tgt_pos, m_stages[n].name(), m_stages[n].tgtPos() );
+                updateIfChanged( m_indiP_parked, m_stages[n].name(), m_stages[n].parked() );
+                updateIfChanged( m_indiP_curr_state, m_stages[n].name(), std::string( "OPERATING" ) );
+            }
+        }
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_req_home )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_req_home, ipRecv );
+
+    size_t stageno = std::numeric_limits<size_t>::max();
+    bool   found   = false;
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        if( ipRecv.find( m_stages[n].name() ) )
+        {
+            if( found )
+            {
+                return log<software_error, -1>( "more than one stage specified in req_home, rejecting request" );
+            }
+
+            if( m_stages[n].deviceAddress() < 1 )
+            {
+                return log<software_error, -1>(
+                    std::format( "stage {} with s/n {} not found", m_stages[n].name(), m_stages[n].serial() ) );
+            }
+
+            stageno = n;
+            found   = true;
+        }
+    }
+
+    if( !found || stageno >= m_stages.size() )
+    {
+        return log<software_error, -1>( "no valid stage specified in req_home, rejecting request" );
+    }
+
+    if( ipRecv[m_stages[stageno].name()].getSwitchState() != pcf::IndiElement::On )
+    {
+        return log<software_warning, 0>(
+            std::format( "request off for stage {} in req_home", m_stages[stageno].name() ) );
+    }
+
+    std::lock_guard<std::mutex> guard( m_indiMutex );
+    if( m_stages[stageno].homing() )
+    {
+        return log<software_warning, 0>(
+            std::format( "stage {} is already homing in req_home", m_stages[stageno].name() ) );
+    }
+
+    if( m_stages[stageno].home( m_port ) < 0 )
+    {
+        return log<software_error, -1>( std::format( "error from home for {}", m_stages[stageno].name() ) );
+    }
+
+    updateIfChanged( m_indiP_tgt_pos, m_stages[stageno].name(), 0 );
+    updateIfChanged( m_indiP_parked, m_stages[stageno].name(), m_stages[stageno].parked() );
+    updateIfChanged( m_indiP_curr_state, m_stages[stageno].name(), std::string( "HOMING" ) );
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_req_home_all )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_req_home_all, ipRecv );
+
+    if( !ipRecv.find( "request" ) )
+    {
+        return 0;
+    }
+
+    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+    {
+        for( size_t n = 0; n < m_stages.size(); ++n )
+        {
+            if( m_stages[n].deviceAddress() < 1 )
+            {
+                continue;
+            }
+
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+            if( m_stages[n].homing() )
+            {
+                continue;
+            }
+
+            if( m_stages[n].home( m_port ) < 0 )
+            {
+                return log<software_error, -1>( { "error from home for " + m_stages[n].name() } );
+            }
+
+            updateIfChanged( m_indiP_tgt_pos, m_stages[n].name(), 0 );
+            updateIfChanged( m_indiP_parked, m_stages[n].name(), m_stages[n].parked() );
+            updateIfChanged( m_indiP_curr_state, m_stages[n].name(), std::string( "HOMING" ) );
+        }
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_req_halt )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_req_halt, ipRecv );
+
+    size_t stageno = std::numeric_limits<size_t>::max();
+    bool   found   = false;
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        if( ipRecv.find( m_stages[n].name() ) )
+        {
+            if( found )
+            {
+                return log<software_error, -1>( "more than one stage specified in req_halt, rejecting request" );
+            }
+
+            if( m_stages[n].deviceAddress() < 1 )
+            {
+                return log<software_error, -1>(
+                    std::format( "stage {} with s/n {} not present", m_stages[n].name(), m_stages[n].serial() ) );
+            }
+
+            stageno = n;
+            found   = true;
+        }
+    }
+
+    if( !found || stageno == std::numeric_limits<size_t>::max() )
+    {
+        return log<software_error, -1>( "no valid stage specified in req_halt, rejecting request" );
+    }
+
+    if( ipRecv[m_stages[stageno].name()].getSwitchState() != pcf::IndiElement::On )
+    {
+        return log<software_warning, 0>(
+            std::format( "request off for stage {} in req_halt", m_stages[stageno].name() ) );
+    }
+
+    std::lock_guard<std::mutex> guard( m_indiMutex );
+    if( m_stages[stageno].stop( m_port ) < 0 )
+    {
+        return log<software_error, -1>( std::format( "error from stop for {}", m_stages[stageno].name() ) );
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_req_ehalt )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_req_ehalt, ipRecv );
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        if( ipRecv.find( m_stages[n].name() ) && ipRecv[m_stages[n].name()].getSwitchState() == pcf::IndiElement::On )
+        {
+            if( m_stages[n].deviceAddress() < 1 )
+            {
+                log<software_error>(
+                    std::format( "stage {} with s/n {} not present", m_stages[n].name(), m_stages[n].serial() ) );
+                continue;
+            }
+
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+            if( m_stages[n].estop( m_port ) < 0 )
+            {
+                log<software_error>( { "error from estop for " + m_stages[n].name() } );
+            }
+        }
+    }
+
+    return 0;
+}
+
+} // namespace app
+} // namespace MagAOX
+
+#endif // zaberLowLevelBinary_hpp

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -241,7 +241,6 @@ void zaberLowLevelBinary::loadConfig()
     config( m_maxDiscoveryAddress, "stages.maxDiscoveryAddress" );
     config( m_commandTimeout, "stages.commandTimeout" );
     config( m_renumberPauseMs, "stages.renumberPauseMs" );
-
     std::vector<std::string> sections;
     config.unusedSections( sections );
 
@@ -263,6 +262,10 @@ void zaberLowLevelBinary::loadConfig()
             std::string tmp = m_stages[idx].serial();
             config.configUnused( tmp, mx::app::iniFile::makeKey( sections[n], "serial" ) );
             m_stages[idx].serial( tmp );
+
+            int32_t targetSpeed = m_stages[idx].targetSpeed();
+            config.configUnused( targetSpeed, mx::app::iniFile::makeKey( sections[n], "targetSpeed" ) );
+            m_stages[idx].targetSpeed( targetSpeed );
 
             m_stageName.insert( { m_stages[idx].name(), idx } );
             m_stageSerial.insert( { m_stages[idx].serial(), idx } );
@@ -645,6 +648,13 @@ int zaberLowLevelBinary::appLogic()
             }
 
             if( m_stages[i].getMaxPos( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+
+            if( m_stages[i].setTargetSpeed( m_port, m_stages[i].targetSpeed() ) < 0 )
             {
                 log<software_error>();
                 state( stateCodes::ERROR );

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -653,11 +653,16 @@ int zaberLowLevelBinary::appLogic()
 
             updateIfChanged( m_indiP_max_pos, m_stages[i].name(), m_stages[i].maxPos() );
 
-            if( m_stages[i].unpark( m_port ) < 0 )
+            if( m_stages[i].updatePos( m_port ) < 0 )
             {
                 log<software_error>();
                 state( stateCodes::ERROR );
                 return 0;
+            }
+
+            if( m_stages[i].recallParkPosition( m_port ) < 0 )
+            {
+                log<text_log>( "No stored parked position found for " + m_stages[i].name(), logPrio::LOG_INFO );
             }
 
             if( m_stages[i].getWarnings( m_port ) < 0 )

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -1,5 +1,6 @@
 /** \file zaberLowLevelBinary.hpp
  * \brief The MagAO-X low-level binary-protocol Zaber controller.
+ * \author Jared R. Males (jaredmales@gmail.com)
  *
  * \ingroup zaberLowLevelBinary_files
  */
@@ -59,12 +60,16 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
      *
      * @{
      */
+    /// Whether to renumber the daisy chain during connect.
     bool m_renumberOnConnect{ true };
 
+    /// Maximum device address to probe while matching configured serial numbers.
     int m_maxDiscoveryAddress{ 16 };
 
+    /// Binary command timeout in milliseconds.
     int m_commandTimeout{ 250 };
 
+    /// Pause in milliseconds after renumbering before further commands are sent.
     int m_renumberPauseMs{ 750 };
 
     ///@}
@@ -73,12 +78,16 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
      *
      * @{
      */
+    /// Stage helpers in configuration order.
     std::vector<zaberBinaryStage<zaberLowLevelBinary>> m_stages;
 
+    /// Map from binary device address to configured stage index.
     std::unordered_map<int, size_t> m_stageAddress;
 
+    /// Map from configured serial number to configured stage index.
     std::unordered_map<std::string, size_t> m_stageSerial;
 
+    /// Map from configured stage name to configured stage index.
     std::unordered_map<std::string, size_t> m_stageName;
 
     ///@}
@@ -138,28 +147,40 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
      *
      * @{
      */
+    /// Current stage state reported per configured stage.
     pcf::IndiProperty m_indiP_curr_state;
 
+    /// Maximum raw position reported per configured stage.
     pcf::IndiProperty m_indiP_max_pos;
 
+    /// Parked-state bookkeeping reported per configured stage.
     pcf::IndiProperty m_indiP_parked;
 
+    /// Last-homed timestamps reported per configured stage.
     pcf::IndiProperty m_indiP_lastHomed;
 
+    /// Current raw position reported per configured stage.
     pcf::IndiProperty m_indiP_curr_pos;
 
+    /// Driver temperature reported per configured stage.
     pcf::IndiProperty m_indiP_temp;
 
+    /// Warning-state switch reported per configured stage.
     pcf::IndiProperty m_indiP_warn;
 
+    /// Requested target raw position per configured stage.
     pcf::IndiProperty m_indiP_tgt_pos;
 
+    /// Per-stage home requests.
     pcf::IndiProperty m_indiP_req_home;
 
+    /// Global request to home all configured stages.
     pcf::IndiProperty m_indiP_req_home_all;
 
+    /// Per-stage halt requests.
     pcf::IndiProperty m_indiP_req_halt;
 
+    /// Per-stage emergency-halt requests.
     pcf::IndiProperty m_indiP_req_ehalt;
 
     ///@}

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -674,6 +674,12 @@ int zaberLowLevelBinary::appLogic()
             {
                 log<text_log>( "No stored parked position found for " + m_stages[i].name(), logPrio::LOG_INFO );
             }
+            else if( m_stages[i].restoreParkedState( m_port ) < 0 )
+            {
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
 
             if( m_stages[i].getWarnings( m_port ) < 0 )
             {

--- a/apps/zaberLowLevelBinary/zb_serial.c
+++ b/apps/zaberLowLevelBinary/zb_serial.c
@@ -1,0 +1,425 @@
+/*
+ * \file zb_serial.c
+ * \author Eric Dand
+ * \version 1.0
+ * \date 28 November 2014
+ * \copyright Apache Software License Version 2.0
+ *
+ * Implementation file for binary portion of the Zaber Serial API in C.
+ * See zb_serial.h for documentation.
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <limits.h>
+
+#include "zb_serial.h"
+
+static int zb_verbose = 1;
+
+void zb_set_verbose(int value)
+{
+	zb_verbose = value;
+}
+
+int zb_encode(uint8_t *destination, uint8_t device_number,
+		uint8_t command_number, int32_t data)
+{
+	unsigned int i;
+	uint32_t udata = (uint32_t)data;
+
+	if (destination == NULL)
+	{
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+	destination[0] = device_number;
+	destination[1] = command_number;
+
+	for (i = 2; i < 6; i++)
+	{
+		destination[i] = (uint8_t)udata;
+		udata >>= 8;
+	}
+
+	return Z_SUCCESS;
+}
+
+int zb_decode(int32_t *destination, const uint8_t *reply)
+{
+	unsigned int i;
+	uint32_t data = 0;
+
+	if (destination == NULL)
+	{
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+	for (i = 5; i > 1; i--)
+	{
+		data <<= 8;
+		data |= reply[i];
+	}
+
+	if ((data & 0x80000000UL) == 0)
+	{
+		*destination = (int32_t)data;
+	}
+	else
+	{
+		*destination = -(int32_t)(UINT32_MAX - data) - 1;
+	}
+
+	return Z_SUCCESS;
+}
+
+#if defined(_WIN32)
+
+/* These macros save us a lot of repetition. Call the specified function,
+ * and complain and return early with -1 if things go badly. */
+#if defined(NDEBUG)
+#define PRINT_ERROR(M)
+#define PRINT_SYSCALL_ERROR(M)
+#else
+#define PRINT_ERROR(M) do { if (zb_verbose) { fprintf(stderr, "(%s: %d)" M\
+		"\n", __FILE__, __LINE__); } } while(0)
+#define PRINT_SYSCALL_ERROR(M) do { if (zb_verbose) { fprintf(stderr,\
+		"(%s: %d) [ERROR] " M " failed with error code %d.\n",\
+		__FILE__, __LINE__, GetLastError()); } } while(0)
+#endif
+#define SYSCALL(F) do { if ((F) == 0) {\
+		PRINT_SYSCALL_ERROR(#F); return Z_ERROR_SYSTEM_ERROR; } } while (0)
+
+int zb_connect(z_port *port, const char *port_name)
+{
+	DCB dcb = { 0 };
+	COMMTIMEOUTS timeouts;
+
+	if (port_name == NULL)
+	{
+		PRINT_ERROR("[ERROR] port name cannot be NULL.");
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+	*port = CreateFileA(port_name,
+			GENERIC_READ | GENERIC_WRITE,
+			0,
+			NULL,
+			OPEN_EXISTING,
+			0,
+			NULL);
+	if (*port == INVALID_HANDLE_VALUE)
+	{
+		PRINT_SYSCALL_ERROR("CreateFileA");
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+	SYSCALL(GetCommState(*port, &dcb));
+	dcb.DCBlength = sizeof(DCB);
+	dcb.BaudRate = 9600;
+	dcb.fBinary = TRUE;  /* Binary Mode (skip EOF check) */
+	dcb.fParity = FALSE;  /* Disable parity checking */
+	dcb.fOutxCtsFlow = FALSE; /* No CTS handshaking on output */
+	dcb.fOutxDsrFlow = FALSE; /* No DSR handshaking on output */
+	dcb.fDtrControl = DTR_CONTROL_DISABLE;  /* Disable DTR Flow control */
+	dcb.fDsrSensitivity = FALSE; /* No DSR Sensitivity */
+	dcb.fTXContinueOnXoff = TRUE; /* Continue TX when Xoff sent */
+	dcb.fOutX = FALSE; /* Disable output X-ON/X-OFF */
+	dcb.fInX = FALSE;  /* Disable input X-ON/X-OFF */
+	dcb.fErrorChar = FALSE;  /* Disable Err Replacement */
+	dcb.fNull = FALSE; /* Disable Null stripping */
+	dcb.fRtsControl = RTS_CONTROL_DISABLE;  /* Disable Rts Flow control */
+	dcb.fAbortOnError = FALSE; /* Do not abort all reads and writes on Error */
+	dcb.wReserved = 0; /* Not currently used, but must be set to 0 */
+	dcb.XonLim = 0; /* Transmit X-ON threshold */
+	dcb.XoffLim = 0;   /* Transmit X-OFF threshold */
+	dcb.ByteSize = 8;  /* Number of bits/byte, 4-8 */
+	dcb.Parity = NOPARITY; /* 0-4=None,Odd,Even,Mark,Space */
+	dcb.StopBits = ONESTOPBIT;  /* 0,1,2 = 1, 1.5, 2 */
+	SYSCALL(SetCommState(*port, &dcb));
+
+	timeouts.ReadIntervalTimeout = MAXDWORD;
+	timeouts.ReadTotalTimeoutMultiplier = MAXDWORD;
+	timeouts.ReadTotalTimeoutConstant = READ_TIMEOUT; /* #defined in header */
+	timeouts.WriteTotalTimeoutMultiplier = 0;
+	timeouts.WriteTotalTimeoutConstant = 100;
+	SYSCALL(SetCommTimeouts(*port, &timeouts));
+
+	return Z_SUCCESS;
+}
+
+int zb_disconnect(z_port port)
+{
+	SYSCALL(CloseHandle(port));
+	return Z_SUCCESS;
+}
+
+int zb_send(z_port port, const uint8_t *command)
+{
+	DWORD nbytes;
+
+	if (command == NULL)
+	{
+		PRINT_ERROR("[ERROR] command cannot be NULL.");
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+	SYSCALL(WriteFile(port, command, 6, &nbytes, NULL));
+	if (nbytes == 6)
+	{
+		return (int) nbytes;
+	}
+	return Z_ERROR_SYSTEM_ERROR;
+}
+
+/* We read bytes one-at-a-time as ReadFile(port, destination, 6, &nread, NULL)
+ * often enough will "read" bytes of \0 in the middle of a message when it
+ * should instead be waiting for a real byte of data down the line.
+ * Worse, it reports afterwards that it has read a full 6 bytes, making this
+ * behaviour hard to track and harder to debug and compensate for. */
+int zb_receive(z_port port, uint8_t *destination)
+{
+	DWORD nread;
+	int i;
+	char c;
+
+	for (i = 0; i < 6; i++)
+	{
+		SYSCALL(ReadFile(port, &c, 1, &nread, NULL));
+
+		if (nread == 0) /* timed out */
+		{
+			PRINT_ERROR("[INFO] Read timed out.");
+			break;
+		}
+
+		if (destination != NULL) destination[i] = c;
+	}
+
+	if (i == 6)
+	{
+		return i;
+	}
+	/* if we didn't read a whole 6 bytes, we count that as an error. */
+	return Z_ERROR_SYSTEM_ERROR;
+}
+
+int zb_drain(z_port port)
+{
+	char c;
+	DWORD nread,
+		  old_timeout;
+	COMMTIMEOUTS timeouts;
+
+	SYSCALL(PurgeComm(port, PURGE_RXCLEAR));
+	SYSCALL(GetCommTimeouts(port, &timeouts));
+	old_timeout = timeouts.ReadTotalTimeoutConstant;
+	timeouts.ReadTotalTimeoutConstant = 100;
+	SYSCALL(SetCommTimeouts(port, &timeouts));
+
+	do
+	{
+		SYSCALL(ReadFile(port, &c, 1, &nread, NULL));
+	}
+	while (nread == 1);
+
+	timeouts.ReadTotalTimeoutConstant = old_timeout;
+	SYSCALL(SetCommTimeouts(port, &timeouts));
+
+	return Z_SUCCESS;
+}
+
+int zb_set_timeout(z_port port, int milliseconds)
+{
+	COMMTIMEOUTS timeouts;
+
+	SYSCALL(GetCommTimeouts(port, &timeouts));
+	timeouts.ReadTotalTimeoutConstant = milliseconds;
+	SYSCALL(SetCommTimeouts(port, &timeouts));
+
+	return milliseconds;
+}
+
+#elif defined(__unix__) || defined(__APPLE__) /* end of if defined(_WIN32) */
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <termios.h>
+#include <unistd.h>
+
+/* A little sugar for checking return values from system calls.
+ * I would have liked to use GNU/GCC's "statement expressions" so that one
+ * do something like "z_port port = SYSCALL(open([parameters]))", but they're
+ * a GNU extension, and therefore unfriendly to non-GCC compilers.
+ * Workaround to avoid dependence on statement expressions for SYSCALL macro:
+ * use SYSCALL on result of assignment instead. */
+#if defined(NDEBUG)
+#define PRINT_ERROR(M)
+#define PRINT_SYSCALL_ERROR(M)
+#else
+#include <errno.h>
+#define PRINT_ERROR(M) do { if (zb_verbose) { fprintf(stderr, "(%s: %d)" M\
+		"\n", __FILE__, __LINE__); } } while(0)
+#define PRINT_SYSCALL_ERROR(M) do { if (zb_verbose) {\
+		fprintf(stderr, "(%s: %d) [ERROR] " M " failed: %s.\n",\
+		__FILE__, __LINE__, strerror(errno)); } } while(0)
+#endif
+/* A little sugar for checking return values from system calls.
+ * I would have liked to use GNU/GCC's "statement expressions" so that one
+ * do something like "z_port port = SYSCALL(open([parameters]))", but they're
+ * a GNU extension, and therefore unfriendly to non-GCC compilers.
+ * Workaround to avoid dependence on statement expressions for SYSCALL macro:
+ * use SYSCALL on result of assignment instead. */
+#define SYSCALL(F) do { if ((F) < 0) { PRINT_SYSCALL_ERROR(#F);\
+	return Z_ERROR_SYSTEM_ERROR; } } while(0)
+
+int zb_connect(z_port *port, const char *port_name)
+{
+	struct termios tio, orig_tio;
+
+	if (port == NULL || port_name == NULL)
+	{
+		PRINT_ERROR("[ERROR] port and port_name cannot be NULL.");
+		return Z_ERROR_NULL_PARAMETER;
+	}
+
+    /* blocking read/write */
+	SYSCALL(*port = open(port_name, O_RDWR | O_NOCTTY));
+	SYSCALL(tcgetattr(*port, &orig_tio));
+	memcpy(&tio, &orig_tio, sizeof(struct termios)); /* copy padding too */
+
+	/* cfmakeraw() without cfmakeraw() for cygwin compatibility */
+	tio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR
+			| IGNCR | ICRNL | IXON);
+	tio.c_oflag &= ~OPOST;
+	tio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	tio.c_cflag &= ~(CSIZE | PARENB);
+	/* end cfmakeraw() */
+	tio.c_cflag = CS8|CREAD|CLOCAL;
+
+	/* READ_TIMEOUT is defined in zb_serial.h */
+	if (READ_TIMEOUT % 100 != 0)
+	{
+		tio.c_cc[VTIME] = READ_TIMEOUT / 100 + 1; /* Round up */
+	}
+	else
+	{
+		tio.c_cc[VTIME] = READ_TIMEOUT / 100;
+	}
+	tio.c_cc[VMIN] = 0;
+
+	SYSCALL(cfsetospeed(&tio, B9600) & cfsetispeed(&tio, B9600));
+
+	while(memcmp(&orig_tio, &tio, sizeof(struct termios)) != 0)
+	{ /* memcmp is only OK here because we used memcpy above */
+		SYSCALL(tcsetattr(*port, TCSAFLUSH, &tio));
+		SYSCALL(tcgetattr(*port, &orig_tio));
+	}
+
+	return Z_SUCCESS;
+}
+
+int zb_disconnect(z_port port)
+{
+	SYSCALL(close(port));
+	return Z_SUCCESS;
+}
+
+int zb_send(z_port port, const uint8_t *command)
+{
+	int nbytes;
+
+	SYSCALL(nbytes = write(port, command, 6));
+	if (nbytes == 6)
+	{
+		return nbytes;
+	}
+	return Z_ERROR_SYSTEM_ERROR;
+}
+
+/* More struggles with termios: we're forced to read one byte at a time on
+ * *NIX because of how termios.c_cc[VTIME] and [VMIN] work. From the termios
+ * man page:
+ *
+ * * if MIN == 0; TIME > 0: "read(2) returns either when at least one
+ * byte of data is available, or when the timer expires."
+ * * if MIN > 0; TIME > 0: "Because the timer is started only after the
+ * initial byte becomes available, at least one byte will be read."
+ *
+ * Neither of these cases are what we want, namely to start the timer
+ * immediately, and to only return when all 6 requested/MIN bytes are received
+ * or the timer times out. As a result, we instead set MIN to 0 (the first
+ * case above), then read 1 byte at a time to get the behaviour we want. */
+int zb_receive(z_port port, uint8_t *destination)
+{
+	int nread,
+		i;
+	char c;
+
+    for (i = 0; i < 6; i++)
+    {
+        SYSCALL(nread = (int) read(port, &c, 1));
+
+		if (nread == 0) /* timed out */
+		{
+			PRINT_ERROR("[INFO] Read timed out.");
+			break;
+		}
+
+		if (destination != NULL) destination[i] = c;
+	}
+
+	if (i == 6)
+	{
+		return i;
+	}
+	/* if we didn't read a whole 6 bytes, we count that as an error. */
+	return Z_ERROR_SYSTEM_ERROR;
+}
+
+int zb_drain(z_port port)
+{
+	struct termios tio;
+	int old_timeout;
+	char c;
+
+	/* set timeout to 0.1s */
+	SYSCALL(tcgetattr(port, &tio));
+	old_timeout = tio.c_cc[VTIME];
+	tio.c_cc[VTIME] = 1;
+	SYSCALL(tcsetattr(port, TCSANOW, &tio));
+
+	/* flush and read whatever else comes in */
+	SYSCALL(tcflush(port, TCIFLUSH));
+	while(read(port, &c, 1) > 0);
+
+	/* set timeout back to what it was */
+	tio.c_cc[VTIME] = old_timeout;
+	SYSCALL(tcsetattr(port, TCSANOW, &tio));
+
+	return Z_SUCCESS;
+}
+
+int zb_set_timeout(z_port port, int milliseconds)
+{
+	struct termios tio;
+	int new_time;
+
+	if (milliseconds % 100 != 0)
+	{
+		new_time = milliseconds / 100 + 1;
+	}
+	else
+	{
+		new_time = milliseconds / 100; /* VTIME is in increments of 0.1s */
+	}
+
+	SYSCALL(tcgetattr(port, &tio));
+	tio.c_cc[VTIME] = new_time;
+	SYSCALL(tcsetattr(port, TCSANOW, &tio));
+
+	return new_time * 100;
+}
+
+#endif
+

--- a/apps/zaberLowLevelBinary/zb_serial.h
+++ b/apps/zaberLowLevelBinary/zb_serial.h
@@ -1,0 +1,215 @@
+/**
+ * \file zb_serial.h
+ * \author Eric Dand
+ * \version 1.0
+ * \date 28 November 2014
+ * \copyright Apache Software License Version 2.0
+ *
+ * \brief Provides a set of functions for interacting with Zaber devices in
+ * the binary protocol.
+ *
+ * Before using this library, it is recommended to read about the message
+ * format of the binary protocol. The manual can be found at the link below,
+ * as of November 2014:
+ *
+ * http://www.zaber.com/wiki/Manuals/Binary_Protocol_Manual#Message_Format
+ *
+ * Note especially that binary replies are sent when a command has *finished*
+ * as opposed to when the command was received. It is up to you to wait for
+ * appropriate responses to commands.
+ */
+
+#if !defined(ZB_SERIAL_H)
+#define ZB_SERIAL_H
+
+#if defined(__cplusplus)
+extern "C"{
+#endif /* if defined(__cplusplus) */
+
+#include "z_common.h"
+
+/** Connect to a serial port specified by \a port_name.
+ *
+ * Configures the port to the binary protocol defaults (9600 baud, 8N1).
+ * It is not recommended to use a device in binary at any other baud rate.
+ *
+ * On Linux the port name will likely be something like "/dev/ttyUSB0",
+ * on Windows "COM1", and on OS X and BSD systems "/dev/cu.usbserial-A4017CQX".
+ * It is important that OS X/BSD systems use the "callout" (cu.* or cua.*) port
+ * as opposed to the "dial in" ports with names starting with tty.*,
+ * which will not work with Zaber devices.
+ *
+ * If you are re-using a `z_port`, make sure to use zb_disconnect() to
+ * disconnect the old port before overwriting it with a new one.
+ *
+ * \param[out] port a pointer to a `z_port` to be written-over with the
+ * newly-connected port.
+ * \param[in] port_name a string containing the name of the port to be opened.
+ *
+ * \return Z_SUCCESS on success, Z_ERROR_NULL_PARAMETER if \a port or
+ * \a port_name is NULL, or Z_ERROR_SYSTEM_ERROR in case of system error.
+ */
+int zb_connect(z_port *port, const char *port_name);
+
+/** Gracefully closes a connection.
+ *
+ * \param[in] port the port to be disconnected.
+ *
+ * \return Z_SUCCESS on success, Z_ERROR_SYSTEM_ERROR on failure.
+ */
+int zb_disconnect(z_port port);
+
+/** Sends a command to a serial port.
+ *
+ * It is recommended that before sending any commands, you read the Binary
+ * Protocol Manual to understand how these commands should be formatted
+ * (least-significant byte first). See zb_encode() for help encoding commands.
+ *
+ * Note that this function does not typically crash if \a command is not six
+ * (or greater) bytes long: it will simply write the first six bytes found at
+ * the address \a command, whatever they may be. It is up to you to make sure
+ * that \a command is long enough.
+ *
+ * \param[in] port the port to which to send the command.
+ * \param[in] command a string of bytes containing the command to be sent.
+ *
+ * \return the number of bytes written (will always be 6 if successful), or
+ * Z_ERROR_SYSTEM_ERROR on failure.
+ */
+int zb_send(z_port port, const uint8_t *command);
+
+/** Receives a message from the serial port.
+ *
+ * Blocks while reading until 6 bytes have been read, or its timeout has
+ * elapsed. The default timeout is defined by #READ_TIMEOUT, and can also be
+ * changed programmatically by zb_set_timeout().
+ *
+ * The reply received will follow the message format specified
+ * in Zaber's Binary Protocol Manual. This means that the final 4 bytes
+ * received will be ordered from least to most significant. It is recommended
+ * to use zb_decode() to get the last 4 bytes of data as a convenient,
+ * well-formed 32-bit integer that matches your system.
+ *
+ * Note that this function will simply read the first six bytes on the input
+ * buffer, whatever they may be. If you have sent many commands without
+ * receiving their corresponding replies, sorting them all out may be a real
+ * headache. Note also that this buffer is finite, and allowing it to
+ * fill up will result in undefined behaviour. See zb_drain() for a solution
+ * to this problem.
+ *
+ * \param[in] port the port to receive a message from.
+ * \param[out] destination a pointer to which to write the reply read. Must be
+ * at least 6 bytes long.
+ *
+ * \return the number of bytes received (will always be 6 if successful), or
+ * Z_ERROR_SYSTEM_ERROR on failure.
+ */
+int zb_receive(z_port port, uint8_t *destination);
+
+/** Encodes a command according to Zaber's Binary Protocol Manual.
+ *
+ * This function performs the necessary transposition of data bytes for
+ * transmission to Zaber devices using the binary protocol.
+ *
+ * This function does not support the encoding of Message IDs.
+ *
+ * \param[out] destination a pointer to an array to which to write the encoded
+ * command. Assumed to be at least 6 bytes long.
+ * \param[in] device_number the number of the device to which to send the
+ * command.
+ * \param[in] command_number the number of the command to be sent.
+ * \param[in] data the data to be sent along with the command. The contents of
+ * this field depend on the command number being sent. See the Binary Protocol
+ * Manual for info on specific commands.
+ *
+ * \return Z_SUCCESS on success, or Z_ERROR_NULL_PARAMETER if \a destination
+ * is NULL.
+ */
+int zb_encode(uint8_t *destination, uint8_t device_number,
+		uint8_t command_number, int32_t data);
+
+/** Decodes the last 4 bytes of a 6-byte (complete) reply.
+ *
+ * This function wraps the last four bytes of the reply into a 32-bit integer
+ * matching the architecture of the compilation target (typically the machine
+ * which compiled the code, unless otherwise specified).
+ *
+ * This function only writes the "data" portion of a reply (the last four
+ * bytes) into \a destination. You will still need to manually read the first
+ * two bytes of your reply to get the device and command IDs.
+ *
+ * This function does not support the decoding of Message IDs. If your device
+ * does have Message IDs enabled, the data decoded by this function will be
+ * incorrect and should be considered undefined.
+ *
+ * \param[out] destination a pointer to a 32-bit integer to which to write the
+ * reply's data.
+ * \param[in] reply a pointer to an array containing a 6-byte reply message.
+ *
+ * \return Z_SUCCESS on success, or Z_ERROR_NULL_PARAMETER if \a destination
+ * or \a reply is NULL.
+ */
+int zb_decode(int32_t *destination, const uint8_t *reply);
+
+/** Flushes all input received but not yet read, and attempts to drain all
+ * input that would be incoming.
+ *
+ * This function is intended to be used when many commands have been sent
+ * without reading any responses, and there is a need to read a response from
+ * a certain command. In other words, call this function before sending a
+ * command whose response you would like to read if you have not been
+ * consistently reading the responses to previous commands.
+ *
+ * This function will always take at least 100ms to complete, as it tries to
+ * read input until it is certain no more is arriving by waiting 100ms before
+ * deciding there is no more input incoming. Do not use it for
+ * time-sensitive operations, or in any kind of "chatty" setup, eg. multiple
+ * devices daisy-chained together with move tracking enabled. In such a setup,
+ * the only reliable way to retrieve any reply data is to always follow
+ * calls to zb_send() with calls to zb_receive().
+ *
+ * \param[in] port the port to drain.
+ *
+ * \return Z_SUCCESS on success, or Z_ERROR_SYSTEM_ERROR on failure.
+ */
+int zb_drain(z_port port);
+
+/** Change the duration zb_receive() will wait before timing out and returning
+ * without having read anything.
+ *
+ * A Zaber device using the binary protocol will only respond once a command
+ * has been completed. Though we recommend users implement their own "wait"
+ * behaviour for commands they expect to take a long time, this function can
+ * be used to wait for such commands to complete before continuing execution.
+ *
+ * A value of 0 for milliseconds will block indefinitely until a reply is
+ * received. Use with caution.
+ *
+ * On *NIX systems, the value of milliseconds will be rounded up to the
+ * nearest tenth of a second (0.1s). This function returns the new timeout
+ * value to aid with compatibility between Windows and *NIX.
+ *
+ * \param[in] port the port whose timeout shall be changed.
+ * \param[in] milliseconds the duration of the new timeout, in milliseconds.
+ *
+ * \return the new timeout value on success, Z_ERROR_SYSTEM_ERROR on failure.
+ */
+int zb_set_timeout(z_port port, int milliseconds);
+
+/** Sets whether errors and extra info are reported to stderr.
+ *
+ * Set \a value to 0 to disable all output. Additionally, you can compile this
+ * library with the macro NDEBUG defined, which will disable all output and
+ * skip checks to "verbose" altogether in the compiled code.
+ *
+ * \param[in] value whether (1) or not (0) the program should output
+ * error messages and info to stderr.
+ */
+void zb_set_verbose(int value);
+
+#if defined(__cplusplus)
+}
+#endif /* if defined(__cplusplus) */
+
+#endif /* if !defined(ZB_SERIAL_H) */
+


### PR DESCRIPTION
This work was performed by Codex (GPT-5.4).

## Summary

Adds a new `zaberLowLevelBinary` MagAO-X app that controls T-series Zaber stages using the binary protocol while preserving the existing low-level / `zaberCtrl` integration model as closely as possible.

Key outcomes:
- added `apps/zaberLowLevelBinary` as a sibling app to `zaberLowLevel`
- discovers configured stages by serial number using binary protocol commands
- preserves the core INDI interface expected by `zaberCtrl`
- adds per-stage `targetSpeed` configuration for safer motion tuning
- emulates MagAO-X parking using device non-volatile stored-position memory plus on-disk state
- restores parked position on power-up and returns to `READY` rather than `NOTHOMED` when restore succeeds

## Implementation Notes

Binary protocol work is based on the T-LSM firmware 5.xx command set and uses:
- device discovery by `Cmd 63`
- motion/status via `Cmd 20`, `Cmd 23`, `Cmd 54`, `Cmd 60`
- parking persistence via `Cmd 16`, `Cmd 17`
- parked-position restore on power-up via `Cmd 45`
- knob disable and auto-reply control via `Cmd 40`
- per-stage speed control via `Cmd 42`

Parking behavior:
- when the app parks a stage, it stores the current position in device non-volatile memory
- it also writes the parked state to disk
- on power-up, if device memory and disk state agree, the app restores the position and treats the stage as parked/ready

## Config

Per-stage sections now support:
- `serial`
- `targetSpeed`

Example:
```ini
[stageA]
serial=123456
targetSpeed=1000
