### PR TITLE
Harden GUI INDI reconnect and delProperty handling

### DIFF
--- a/gui/lib/multiIndiManager.hpp
+++ b/gui/lib/multiIndiManager.hpp
@@ -304,7 +304,11 @@ inline void multiIndiManager::connectClient()
                 {
                     candidate->addSubscriber( sub );
                 }
-                candidate->onConnect();
+
+                for( auto *sub : subs )
+                {
+                    _dispatchOnConnect( sub );
+                }
             }
         }
 

--- a/gui/widgets/camera/camera.hpp
+++ b/gui/widgets/camera/camera.hpp
@@ -98,6 +98,8 @@ public:
 
     void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+    void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
     void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
     void hideAll();
@@ -309,7 +311,7 @@ void camera::onConnect()
     if(ui_roiStatus) ui_roiStatus->onConnect();
     if(ui_modes) ui_modes->onConnect();
     if(ui_readoutSpd) ui_readoutSpd->onConnect();
-    if(ui_vshiftSpd) ui_readoutSpd->onConnect();
+    if(ui_vshiftSpd) ui_vshiftSpd->onConnect();
     if(ui_cropMode) ui_cropMode->onConnect();
 
     if(ui_expTime) ui_expTime->onConnect();
@@ -349,7 +351,7 @@ void camera::onDisconnect()
     if(ui_roiStatus) ui_roiStatus->onDisconnect();
     if(ui_modes) ui_modes->onDisconnect();
     if(ui_readoutSpd) ui_readoutSpd->onDisconnect();
-    if(ui_vshiftSpd) ui_readoutSpd->onDisconnect();
+    if(ui_vshiftSpd) ui_vshiftSpd->onDisconnect();
     if(ui_cropMode) ui_cropMode->onDisconnect();
 
     if(ui_expTime) ui_expTime->onDisconnect();
@@ -374,6 +376,28 @@ void camera::onDisconnect()
 void camera::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void camera::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_camName && ipRecv.getDevice() != m_darkName && ipRecv.getDevice() != m_avgName) return;
+
+   if(ipRecv.getDevice() == m_camName)
+   {
+      if(ipRecv.getName() == "fsm")
+      {
+         m_appState.clear();
+      }
+   }
+   else if(ipRecv.getDevice() == m_darkName)
+   {
+      if(ipRecv.getName() == "start")
+      {
+         m_takingDark = false;
+      }
+   }
+
+   emit doUpdateGUI();
 }
 
 void camera::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/camera/roiStatus.hpp
+++ b/gui/widgets/camera/roiStatus.hpp
@@ -44,6 +44,10 @@ public:
 
    virtual void subscribe();
 
+   void onDisconnect();
+
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void updateGUI();
@@ -75,6 +79,39 @@ void roiStatus::subscribe()
    statusDisplay::subscribe();
 
    return;
+}
+
+void roiStatus::onDisconnect()
+{
+   m_bin_x_curr = 0;
+   m_bin_x_tgt = 0;
+   m_bin_y_curr = 0;
+   m_bin_y_tgt = 0;
+   m_cen_x_curr = 0;
+   m_cen_x_tgt = 0;
+   m_cen_y_curr = 0;
+   m_cen_y_tgt = 0;
+   m_wid_curr = 0;
+   m_wid_tgt = 0;
+   m_hgt_curr = 0;
+   m_hgt_tgt = 0;
+
+   statusDisplay::onDisconnect();
+}
+
+void roiStatus::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_device) return;
+
+   if(ipRecv.getName() == "roi_region_bin_x" ||
+      ipRecv.getName() == "roi_region_bin_y" ||
+      ipRecv.getName() == "roi_region_x" ||
+      ipRecv.getName() == "roi_region_y" ||
+      ipRecv.getName() == "roi_region_w" ||
+      ipRecv.getName() == "roi_region_h")
+   {
+      onDisconnect();
+   }
 }
 
 void roiStatus::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/camera/shutterStatus.hpp
+++ b/gui/widgets/camera/shutterStatus.hpp
@@ -39,6 +39,8 @@ public:
 
    virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   virtual void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    virtual void updateGUI();
@@ -81,12 +83,26 @@ void shutterStatus::onConnect()
 
 void shutterStatus::onDisconnect()
 {
+   m_status.clear();
+   m_state = 0;
+   m_tgt_state = -1;
    ui.label->setText("shutter (disconnected)");
+   ui.shutter->onDisconnect();
 }
 
 void shutterStatus::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void shutterStatus::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_camName) return;
+
+   if(ipRecv.getName() == "shutter" || ipRecv.getName() == "shutter_status")
+   {
+      onDisconnect();
+   }
 }
 
 void shutterStatus::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/coronAlign/coronAlign.hpp
+++ b/gui/widgets/coronAlign/coronAlign.hpp
@@ -116,6 +116,7 @@ public:
    virtual void onDisconnect();
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void enablePicoButtons();
@@ -484,6 +485,20 @@ void coronAlign::handleDefProperty( const pcf::IndiProperty & ipRecv)
    }
 
    return;
+}
+
+void coronAlign::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   std::string dev = ipRecv.getDevice();
+   if( dev == "picomotors" ||
+       dev == "fwpupil" ||
+       dev == "fwlyot" ||
+       dev == "fwfpm" ||
+       dev == "stagepiaa" ||
+       dev == "stageipiaa" )
+   {
+      onDisconnect();
+   }
 }
 
 void coronAlign::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -64,6 +64,9 @@ class dmCtrl : public xWidget
     /// Handles defProperty notifications.
     void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has changed. */ );
 
+    /// Handles delProperty notifications.
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has been deleted. */ );
+
     /// Handles setProperty notifications.
     void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Property that has changed. */ );
 
@@ -269,6 +272,21 @@ void dmCtrl::onDisconnectGUI()
 void dmCtrl::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
     return handleSetProperty( ipRecv );
+}
+
+void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_dmName )
+    {
+        return;
+    }
+
+    if( ipRecv.getName() == "fsm" || ipRecv.getName() == "sm_shmimName" || ipRecv.getName() == "flat" ||
+        ipRecv.getName() == "flat_shmim" || ipRecv.getName() == "flat_set" || ipRecv.getName() == "test" ||
+        ipRecv.getName() == "test_shmim" || ipRecv.getName() == "test_set" )
+    {
+        emit doOnDisconnect();
+    }
 }
 
 void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/dmMode/dmMode.hpp
+++ b/gui/widgets/dmMode/dmMode.hpp
@@ -46,6 +46,8 @@ public:
 
    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv );
 
+   virtual void handleDelProperty( const pcf::IndiProperty &ipRecv );
+
    virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    int updateGUI( QLabel * currLabel,
@@ -258,8 +260,45 @@ void dmMode::onConnect()
 
 void dmMode::onDisconnect()
 {
+   m_dmName.clear();
+   m_dmChannel.clear();
+   m_maxmode = -1;
+
    ui.title->setEnabled(false);
    ui.channel->setEnabled(false);
+
+   ui.title->setText("");
+   ui.channel->setText("");
+   ui.modeTarget_0->setText("");
+   ui.modeTarget_1->setText("");
+   ui.modeTarget_2->setText("");
+   ui.modeTarget_3->setText("");
+   ui.modeTarget_4->setText("");
+   ui.modeTarget_5->setText("");
+   ui.modeTarget_6->setText("");
+   ui.modeTarget_7->setText("");
+   ui.modeTarget_8->setText("");
+   ui.modeTarget_9->setText("");
+   ui.modeCurrent_0->setText("---");
+   ui.modeCurrent_1->setText("---");
+   ui.modeCurrent_2->setText("---");
+   ui.modeCurrent_3->setText("---");
+   ui.modeCurrent_4->setText("---");
+   ui.modeCurrent_5->setText("---");
+   ui.modeCurrent_6->setText("---");
+   ui.modeCurrent_7->setText("---");
+   ui.modeCurrent_8->setText("---");
+   ui.modeCurrent_9->setText("---");
+   ui.modeSlider_0->setValue(0);
+   ui.modeSlider_1->setValue(0);
+   ui.modeSlider_2->setValue(0);
+   ui.modeSlider_3->setValue(0);
+   ui.modeSlider_4->setValue(0);
+   ui.modeSlider_5->setValue(0);
+   ui.modeSlider_6->setValue(0);
+   ui.modeSlider_7->setValue(0);
+   ui.modeSlider_8->setValue(0);
+   ui.modeSlider_9->setValue(0);
 
    ui.modeName_0->setEnabled(false);
    ui.modeSlider_0->setEnabled(false);
@@ -337,6 +376,16 @@ void dmMode::handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the p
 
    return;
 
+}
+
+void dmMode::handleDelProperty( const pcf::IndiProperty & ipRecv )
+{
+   if(ipRecv.getDevice() != m_deviceName) return;
+
+   if(ipRecv.getName() == "current_amps" || ipRecv.getName() == "target_amps" || ipRecv.getName() == "dm")
+   {
+      onDisconnect();
+   }
 }
 
 void dmMode::handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/)
@@ -750,4 +799,3 @@ void dmMode::on_modeZero_all_pressed()
 #include "moc_dmMode.cpp"
 
 #endif
-

--- a/gui/widgets/offloadCtrl/offloadCtrl.hpp
+++ b/gui/widgets/offloadCtrl/offloadCtrl.hpp
@@ -43,6 +43,8 @@ public:
 
     void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+    void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
     void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
 public slots:
@@ -177,6 +179,11 @@ void offloadCtrl::onConnect()
 
 void offloadCtrl::onDisconnect()
 {
+    m_t2wFsmState.clear();
+    m_offlState = false;
+    m_tweeterAvgFsmState.clear();
+    m_tcsiFsmState.clear();
+
     setWindowTitle(QString("Offloading Ctrl (disconnected)"));
 
     xWidget::onDisconnect();
@@ -186,6 +193,31 @@ void offloadCtrl::onDisconnect()
 void offloadCtrl::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void offloadCtrl::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+    if(ipRecv.getDevice() == "t2wOffloader")
+    {
+        if(ipRecv.getName() == "fsm" || ipRecv.getName() == "offload")
+        {
+            onDisconnect();
+        }
+    }
+    else if(ipRecv.getDevice() == "dmtweeter-avg")
+    {
+        if(ipRecv.getName() == "fsm")
+        {
+            onDisconnect();
+        }
+    }
+    else if(ipRecv.getDevice() == "tcsi")
+    {
+        if(ipRecv.getName() == "fsm")
+        {
+            onDisconnect();
+        }
+    }
 }
 
 void offloadCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/pupilGuide/pupilGuide.hpp
+++ b/gui/widgets/pupilGuide/pupilGuide.hpp
@@ -200,6 +200,7 @@ class pupilGuide : public xWidget
     virtual void onDisconnect();
 
     void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
     void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
     void modGUISetEnable( bool enableModGUI, bool enableModArrows );
@@ -871,6 +872,20 @@ void pupilGuide::onDisconnect()
 void pupilGuide::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
     return handleSetProperty( ipRecv );
+}
+
+void pupilGuide::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    const std::string dev = ipRecv.getDevice();
+
+    if( dev == "modwfs" || dev == "camwfs" || dev == "tcsi" || dev == "dmwoofer" || dev == "wooferModes" ||
+        dev == "picomotors" || dev == "camwfs-fit" || dev == "camwfs-avg" || dev == "ttmpupil" ||
+        dev == "ttmperi" || dev == "dmtweeter" || dev == "dmncpc" || dev == "camwfs-align" ||
+        dev == "twAlign-camwfs-ctrl" || dev == "twAlign-camwfs-wfs" || dev == "stagecamlensx" ||
+        dev == "stagecamlensy" )
+    {
+        onDisconnect();
+    }
 }
 
 void pupilGuide::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/pwr/pwr.hpp
+++ b/gui/widgets/pwr/pwr.hpp
@@ -49,6 +49,8 @@ class pwr : public xWidget
      */
     virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been defined*/ );
 
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
+
     /// Callback for a SET PROPERTY message notifying us that the propery has changed.
     /** This is called by the publisher which is subscribed to.
      *
@@ -155,6 +157,16 @@ void pwr::onConnect()
 
 void pwr::onDisconnect()
 {
+    for( size_t n = 0; n < m_devices.size(); ++n )
+    {
+        m_devices[n]->onDisconnect();
+    }
+
+    for( size_t n = 0; n < m_adminDevices.size(); ++n )
+    {
+        m_adminDevices[n]->onDisconnect();
+    }
+
     ui.tabWidget->setEnabled( false );
     ui.tabWidget->setVisible( false );
 
@@ -170,6 +182,27 @@ void pwr::onDisconnect()
 void pwr::handleDefProperty( const pcf::IndiProperty &ipRecv /* [in] the property which has changed*/ )
 {
     handleSetProperty( ipRecv );
+}
+
+void pwr::handleDelProperty( const pcf::IndiProperty &ipRecv /* [in] the property which has been deleted*/ )
+{
+    for( size_t n = 0; n < m_devices.size(); ++n )
+    {
+        if( ipRecv.getDevice() == m_devices[n]->deviceName() )
+        {
+            m_devices[n]->handleDelProperty( ipRecv );
+            break;
+        }
+    }
+
+    for( size_t n = 0; n < m_adminDevices.size(); ++n )
+    {
+        if( ipRecv.getDevice() == m_adminDevices[n]->deviceName() )
+        {
+            m_adminDevices[n]->handleDelProperty( ipRecv );
+            return;
+        }
+    }
 }
 
 void pwr::handleSetProperty( const pcf::IndiProperty &ipRecv /* [in] the property which has changed*/ )

--- a/gui/widgets/pwr/pwrChannel.hpp
+++ b/gui/widgets/pwr/pwrChannel.hpp
@@ -110,6 +110,8 @@ class pwrChannel : public QWidget
         return m_isToggle;
     }
 
+    void onDisconnect();
+
   public slots:
 
     void sliderReleased();
@@ -322,6 +324,23 @@ void pwrChannel::timeOut()
     m_changing = false;
     m_swTarget = m_setSwitchState;
     switchState( m_setSwitchState );
+}
+
+void pwrChannel::onDisconnect()
+{
+    m_timer->stop();
+    m_changing       = false;
+    m_swTarget      = pwrChState::Unk;
+    m_setSwitchState = pwrChState::Off;
+    m_isToggle       = false;
+    m_outlets.clear();
+    m_onDelay    = 1000;
+    m_onTimeout  = 6000;
+    m_offDelay   = 1000;
+    m_offTimeout = 6000;
+
+    m_channelSwitch->setEnabled( false );
+    m_channelSwitch->setSliderPosition( m_channelSwitch->minimum() );
 }
 
 } // namespace xqt

--- a/gui/widgets/pwr/pwrDevice.hpp
+++ b/gui/widgets/pwr/pwrDevice.hpp
@@ -219,6 +219,10 @@ struct pwrDevice : public QWidget
 
     QwtTextLabel *deviceNameLabel();
 
+    void onDisconnect();
+
+    void handleDelProperty( const pcf::IndiProperty &ipRecv );
+
     void handleSetProperty( const pcf::IndiProperty &ipRecv );
 
     double current();
@@ -338,6 +342,51 @@ pwrChannel *pwrDevice::channel( size_t channelNo )
 QwtTextLabel *pwrDevice::deviceNameLabel()
 {
     return m_deviceNameLabel;
+}
+
+void pwrDevice::onDisconnect()
+{
+    m_current.resize( 60 );
+    m_voltage.resize( 60 );
+    m_frequency.resize( 60 );
+
+    for( size_t i = 0; i < m_numChannels; ++i )
+    {
+        m_channels[i]->onDisconnect();
+    }
+}
+
+void pwrDevice::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != deviceName() )
+        return;
+
+    if( ipRecv.getName() == "load" )
+    {
+        m_current.resize( 60 );
+        m_voltage.resize( 60 );
+        m_frequency.resize( 60 );
+        emit loadChanged();
+        return;
+    }
+
+    if( ipRecv.getName() == "channelOutlets" || ipRecv.getName() == "channelOnDelays" || ipRecv.getName() == "channelOffDelays" )
+    {
+        for( size_t i = 0; i < m_numChannels; ++i )
+        {
+            m_channels[i]->onDisconnect();
+        }
+        return;
+    }
+
+    for( size_t i = 0; i < m_numChannels; ++i )
+    {
+        if( ipRecv.getName() == m_channels[i]->channelName() )
+        {
+            m_channels[i]->onDisconnect();
+            return;
+        }
+    }
 }
 
 void pwrDevice::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/roi/roi.hpp
+++ b/gui/widgets/roi/roi.hpp
@@ -69,6 +69,8 @@ public:
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void clear_focus();
@@ -170,6 +172,20 @@ void roi::onConnect()
 
 void roi::onDisconnect()
 {
+   m_appState.clear();
+   m_bin_x_curr = 0;
+   m_bin_x_tgt = 0;
+   m_bin_y_curr = 0;
+   m_bin_y_tgt = 0;
+   m_cen_x_curr = 0;
+   m_cen_x_tgt = 0;
+   m_cen_y_curr = 0;
+   m_cen_y_tgt = 0;
+   m_wid_curr = 0;
+   m_wid_tgt = 0;
+   m_hgt_curr = 0;
+   m_hgt_tgt = 0;
+
    setWindowTitle(QString(m_winTitle.c_str()) + QString(" (disconnected)"));
 
    ui.lab_bin_x_title->setEnabled(false);
@@ -235,6 +251,22 @@ void roi::onDisconnect()
 void roi::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void roi::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_camName) return;
+
+   if(ipRecv.getName() == "fsm" ||
+      ipRecv.getName() == "roi_region_bin_x" ||
+      ipRecv.getName() == "roi_region_bin_y" ||
+      ipRecv.getName() == "roi_region_x" ||
+      ipRecv.getName() == "roi_region_y" ||
+      ipRecv.getName() == "roi_region_w" ||
+      ipRecv.getName() == "roi_region_h")
+   {
+      onDisconnect();
+   }
 }
 
 void roi::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/singleMode/singleMode.hpp
+++ b/gui/widgets/singleMode/singleMode.hpp
@@ -42,6 +42,8 @@ class singleMode : public xWidget
 
     void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
+
     void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
     void sendNewGain( double ng );
@@ -124,6 +126,9 @@ void singleMode::onConnect()
 
 void singleMode::onDisconnect()
 {
+    m_appState.clear();
+    m_modeNumber = 0;
+
     std::string tit = m_windowTitle + " (disconnected)";
     setWindowTitle( QString( tit.c_str() ) );
 
@@ -138,6 +143,17 @@ void singleMode::onDisconnect()
 void singleMode::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
     return handleSetProperty( ipRecv );
+}
+
+void singleMode::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_procName )
+        return;
+
+    if( ipRecv.getName() == "fsm" || ipRecv.getName() == "singleModeNo" )
+    {
+        onDisconnect();
+    }
 }
 
 void singleMode::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/stage/stage.hpp
+++ b/gui/widgets/stage/stage.hpp
@@ -54,6 +54,8 @@ public:
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void clear_focus();
@@ -155,10 +157,21 @@ void stage::onConnect()
 
 void stage::onDisconnect()
 {
+   m_appState.clear();
+   m_presets.clear();
+   m_presetCurrent.clear();
+   m_presetTarget.clear();
+   m_setPoint.clear();
+   m_filterWheel = false;
+   m_maxPos = 100;
+   m_position = -1e30;
+   m_position_changed = false;
+
    setWindowTitle(QString(m_winTitle.c_str()) + QString(" (disconnected)"));
 
    ui.stageName->setEnabled(false);
    ui.fsmState->setEnabled(false);
+   ui.setPoint->clear();
    ui.setPoint->setEnabled(false);
    ui.setPointGo->setEnabled(false);
    ui.positionSlider->setEnabled(false);
@@ -180,6 +193,21 @@ void stage::onDisconnect()
 void stage::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void stage::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_stageName) return;
+
+   if(ipRecv.getName() == "fsm" ||
+      ipRecv.getName() == "maxpos" ||
+      ipRecv.getName() == "position" ||
+      ipRecv.getName() == "filter" ||
+      ipRecv.getName() == "presetName" ||
+      ipRecv.getName() == "filterName")
+   {
+      onDisconnect();
+   }
 }
 
 void stage::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/ttm/ttm.hpp
+++ b/gui/widgets/ttm/ttm.hpp
@@ -53,6 +53,8 @@ public:
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void sendNewPos1(double np);
@@ -183,6 +185,15 @@ void ttm::onConnect()
 
 void ttm::onDisconnect()
 {
+   m_appState.clear();
+   m_naxes = 2;
+   m_pos_1 = 0.0;
+   m_pos_2 = 0.0;
+   m_pos_3 = 0.0;
+   m_shmimName.clear();
+   m_flatSet = false;
+   m_testSet = false;
+
    ui.label_device_status->onDisconnect();
 
    ui.pos_1->onDisconnect();
@@ -193,6 +204,25 @@ void ttm::onDisconnect()
 void ttm::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void ttm::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_procName) return;
+
+   if(ipRecv.getName() == "fsm" ||
+      ipRecv.getName() == "pos_1" ||
+      ipRecv.getName() == "pos_2" ||
+      ipRecv.getName() == "pos_3" ||
+      ipRecv.getName() == "sm_shmimName" ||
+      ipRecv.getName() == "flat_shmim" ||
+      ipRecv.getName() == "flat_set" ||
+      ipRecv.getName() == "test" ||
+      ipRecv.getName() == "test_shmim" ||
+      ipRecv.getName() == "test_set")
+   {
+      onDisconnect();
+   }
 }
 
 void ttm::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xWidgets/fsmDisplay.hpp
+++ b/gui/widgets/xWidgets/fsmDisplay.hpp
@@ -68,6 +68,9 @@ class fsmDisplay : public xWidget
     /// Handles defProperty notifications.
     virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] Property which has changed. */ );
 
+    /// Handles delProperty notifications.
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] Property which has been deleted. */ );
+
     /// Handles setProperty notifications.
     virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] Property which has changed. */ );
 
@@ -177,6 +180,17 @@ void fsmDisplay::onDisconnectGUI()
 void fsmDisplay::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
     return handleSetProperty( ipRecv );
+}
+
+void fsmDisplay::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_device )
+        return;
+
+    if( ipRecv.getName() == m_property )
+    {
+        onDisconnect();
+    }
 }
 
 void fsmDisplay::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/xWidgets/gainCtrl.hpp
+++ b/gui/widgets/xWidgets/gainCtrl.hpp
@@ -72,6 +72,8 @@ public:
 
    virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   virtual void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    virtual void updateGUI();
@@ -204,12 +206,27 @@ void gainCtrl::onConnect()
 
 void gainCtrl::onDisconnect()
 {
+   m_current = 0;
+   m_target = 0;
+   m_valChanged = false;
+   m_newSent = false;
+   ui.slider->setValue(0);
    ui.status->onDisconnect();
 }
 
 void gainCtrl::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void gainCtrl::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_device) return;
+
+   if(ipRecv.getName() == m_property)
+   {
+      onDisconnect();
+   }
 }
 
 void gainCtrl::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xWidgets/selectionSw.hpp
+++ b/gui/widgets/xWidgets/selectionSw.hpp
@@ -47,6 +47,8 @@ public:
 
     virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+    virtual void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
     virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
     virtual void showEvent(QShowEvent* event);
@@ -112,6 +114,9 @@ void selectionSw::onDisconnect()
 {
     setWindowTitle(QString(m_title.c_str()) + QString(" (disconnected)"));
 
+    m_value.clear();
+    m_valChanged = false;
+    ui.comboBox->clear();
     ui.current->setText("---");
 
     m_onDisconnected = true;
@@ -120,6 +125,16 @@ void selectionSw::onDisconnect()
 void selectionSw::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
     return handleSetProperty(ipRecv);
+}
+
+void selectionSw::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+    if(ipRecv.getDevice() != m_device) return;
+
+    if(ipRecv.getName() == m_property)
+    {
+        onDisconnect();
+    }
 }
 
 void selectionSw::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xWidgets/stageStatus.hpp
+++ b/gui/widgets/xWidgets/stageStatus.hpp
@@ -32,6 +32,8 @@ class stageStatus : public statusCombo
 
     virtual void subscribe();
 
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
+
     void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
     // void updateGUI();
@@ -120,6 +122,23 @@ void stageStatus::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
 
     statusCombo::handleSetProperty( ipRecv ); //always emit updateGUI
+}
+
+void stageStatus::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_device )
+        return;
+
+    if( ipRecv.getName() == "position" || ipRecv.getName() == "filter" )
+    {
+        m_position = 0;
+        if( m_value == "none" || m_value == "" )
+        {
+            m_valChanged = true;
+        }
+    }
+
+    statusCombo::handleDelProperty( ipRecv );
 }
 
 } // namespace xqt

--- a/gui/widgets/xWidgets/statusCombo.hpp
+++ b/gui/widgets/xWidgets/statusCombo.hpp
@@ -69,6 +69,8 @@ protected:
 
     virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
+
     virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
   public:
@@ -223,6 +225,13 @@ void statusCombo::onConnect()
 
 void statusCombo::onDisconnect()
 {
+    m_fsmState.clear();
+    m_value.clear();
+    m_showVal = false;
+    m_valChanged = false;
+
+    ui.status->clear();
+    ui.status->setPlaceholderText( "" );
     ui.status->setCurrentIndex( -1 );
 
     if( m_ctrlWidget )
@@ -234,6 +243,17 @@ void statusCombo::onDisconnect()
 void statusCombo::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
     return handleSetProperty( ipRecv );
+}
+
+void statusCombo::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_device )
+        return;
+
+    if( ipRecv.getName() == "fsm" || ipRecv.getName() == m_property )
+    {
+        onDisconnect();
+    }
 }
 
 void statusCombo::handleSetProperty( const pcf::IndiProperty &ipRecv )

--- a/gui/widgets/xWidgets/statusDisplay.hpp
+++ b/gui/widgets/xWidgets/statusDisplay.hpp
@@ -71,6 +71,8 @@ public:
 
    virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   virtual void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
 public:
@@ -201,6 +203,10 @@ void statusDisplay::onConnect()
 
 void statusDisplay::onDisconnect()
 {
+   m_fsmState.clear();
+   m_value.clear();
+   m_showVal = false;
+   m_valChanged = false;
    ui.status->setText("---");
    if(m_ctrlWidget) m_ctrlWidget->onDisconnect();
 }
@@ -208,6 +214,16 @@ void statusDisplay::onDisconnect()
 void statusDisplay::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void statusDisplay::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+    if(ipRecv.getDevice() != m_device) return;
+
+    if(ipRecv.getName() == "fsm" || ipRecv.getName() == m_property)
+    {
+        onDisconnect();
+    }
 }
 
 void statusDisplay::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xWidgets/statusEntry.hpp
+++ b/gui/widgets/xWidgets/statusEntry.hpp
@@ -119,6 +119,8 @@ public:
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    /// Set the stretch of the horizontal layout
@@ -357,12 +359,25 @@ void statusEntry::onConnect()
 
 void statusEntry::onDisconnect()
 {
+    m_current.clear();
+    m_target.clear();
+    m_valChanged = false;
     ui.value->setText("---");
 }
 
 void statusEntry::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void statusEntry::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_device) return;
+
+   if(ipRecv.getName() == m_property)
+   {
+      onDisconnect();
+   }
 }
 
 void statusEntry::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xWidgets/toggleSlider.hpp
+++ b/gui/widgets/xWidgets/toggleSlider.hpp
@@ -97,6 +97,8 @@ public:
 
    virtual void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
+   virtual void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+
    virtual void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    //------------------------------------------------------
@@ -267,12 +269,26 @@ void toggleSlider::onConnect()
 
 void toggleSlider::onDisconnect()
 {
+   m_waiting = false;
+   m_status = 0;
+   m_statusChanged = false;
+   m_tgtTimer->stop();
    ui.slider->setSliderPosition(ui.slider->minimum());
 }
 
 void toggleSlider::handleDefProperty( const pcf::IndiProperty & ipRecv)
 {
    return handleSetProperty(ipRecv);
+}
+
+void toggleSlider::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   if(ipRecv.getDevice() != m_device) return;
+
+   if(ipRecv.getName() == m_property)
+   {
+      onDisconnect();
+   }
 }
 
 void toggleSlider::handleSetProperty( const pcf::IndiProperty & ipRecv)

--- a/gui/widgets/xyAlign/xyAlign.hpp
+++ b/gui/widgets/xyAlign/xyAlign.hpp
@@ -55,6 +55,7 @@ public:
    virtual void onDisconnect();
 
    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
 
    void enableButtons();
@@ -147,6 +148,8 @@ void xyAlign::onConnect()
 void xyAlign::onDisconnect()
 {
    m_fsmState = "";
+   m_axis1Pos = 0;
+   m_axis2Pos = 0;
 
    ui.fsmState->setEnabled(false);
 
@@ -175,6 +178,17 @@ void xyAlign::handleDefProperty( const pcf::IndiProperty & ipRecv)
    }
 
    return;
+}
+
+void xyAlign::handleDelProperty( const pcf::IndiProperty & ipRecv)
+{
+   std::string dev = ipRecv.getDevice();
+   if( dev != m_device ) return;
+
+   if( ipRecv.getName() == "fsm" || ipRecv.getName() == m_axis1Property || ipRecv.getName() == m_axis2Property )
+   {
+      onDisconnect();
+   }
 }
 
 void xyAlign::handleSetProperty( const pcf::IndiProperty & ipRecv)


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "our recent work to harden the GUIs against crashes on INDI server connection drops has made significant improvements, but there are still crashes occurring. Two problem areas are pwrGUI and cameraCtrlGUI. Let's look for more problems with INDI client reconnections."

## Summary

This PR hardens MagAO-X GUI behavior during INDI disconnect/reconnect cycles, with an initial focus on `pwrGUI` and `cameraGUI`, then a broader sweep across shared GUI widgets and composite GUIs.

The main goals were:
- eliminate remaining reconnect-time crash paths
- clear stale widget state when INDI properties are deleted during reconnect flapping
- make connect/disconnect GUI callbacks safer with respect to Qt thread usage

## Key Changes

- Queue reconnect `onConnect()` callbacks onto the Qt event loop in the shared INDI manager, matching the existing disconnect behavior.
- Fix a `cameraGUI` null-dereference bug where the `vshift` widget path incorrectly dereferenced the readout-speed widget.
- Add `delProperty` handling across shared xWidgets so cached state is reset when properties disappear.
- Add explicit disconnect/reset handling for `pwr` channel/device state, including pending timers and cached load metadata.
- Extend the same reconnect/deletion cleanup to composite GUIs that cache INDI-backed state.

## Notable Areas Updated

### Shared INDI / widget infrastructure
- `gui/lib/multiIndiManager.hpp`
- `gui/widgets/xWidgets/fsmDisplay.hpp`
- `gui/widgets/xWidgets/statusEntry.hpp`
- `gui/widgets/xWidgets/statusDisplay.hpp`
- `gui/widgets/xWidgets/statusCombo.hpp`
- `gui/widgets/xWidgets/toggleSlider.hpp`
- `gui/widgets/xWidgets/selectionSw.hpp`
- `gui/widgets/xWidgets/gainCtrl.hpp`
- `gui/widgets/xWidgets/stageStatus.hpp`

### Camera / power targets
- `gui/widgets/camera/camera.hpp`
- `gui/widgets/camera/roiStatus.hpp`
- `gui/widgets/camera/shutterStatus.hpp`
- `gui/widgets/pwr/pwr.hpp`
- `gui/widgets/pwr/pwrDevice.hpp`
- `gui/widgets/pwr/pwrChannel.hpp`

### Additional composite GUIs hardened
- `gui/widgets/roi/roi.hpp`
- `gui/widgets/stage/stage.hpp`
- `gui/widgets/dmCtrl/dmCtrl.hpp`
- `gui/widgets/dmMode/dmMode.hpp`
- `gui/widgets/singleMode/singleMode.hpp`
- `gui/widgets/xyAlign/xyAlign.hpp`
- `gui/widgets/coronAlign/coronAlign.hpp`
- `gui/widgets/pupilGuide/pupilGuide.hpp`
- `gui/widgets/offloadCtrl/offloadCtrl.hpp`
- `gui/widgets/ttm/ttm.hpp`

## Testing

- Manual build/test completed by user
- `git diff --check` clean

## Expected Impact

This should significantly reduce GUI crashes caused by:
- INDI server connection drops
- reconnect flapping
- property deletion/redefinition during reconnect
- stale cached widget state surviving partial reconnects

## Follow-up

If we still see reconnect-related GUI crashes after this, the next likely places to inspect are:
- any remaining non-widget INDI subscribers outside `gui/widgets`
- runtime-only races involving delayed queued signals during application shutdown
- cases where property deletion semantics differ from full-device disconnect behavior
