### PR TITLE
rtimv plugin text overlays

### DIFF
--- a/gui/rtimv/plugins/acquisition/acquisition.hpp
+++ b/gui/rtimv/plugins/acquisition/acquisition.hpp
@@ -14,7 +14,7 @@
 class acquisition : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.2")
+    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
     Q_INTERFACES(rtimvOverlayInterface)
 
 protected:

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
@@ -13,7 +13,7 @@
 class cameraStatus : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.2")
+    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
     Q_INTERFACES(rtimvOverlayInterface)
 
 protected:

--- a/gui/rtimv/plugins/dmStatus/dmStatus.hpp
+++ b/gui/rtimv/plugins/dmStatus/dmStatus.hpp
@@ -13,7 +13,7 @@
 class dmStatus : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.2")
+    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
     Q_INTERFACES(rtimvOverlayInterface)
 
 protected:

--- a/gui/rtimv/plugins/indiDictionary/indiDictionary.hpp
+++ b/gui/rtimv/plugins/indiDictionary/indiDictionary.hpp
@@ -21,7 +21,7 @@ class rtimvIndiClient;
 class indiDictionary : public rtimvDictionaryInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.dictionaryInterface/1.2")
+    Q_PLUGIN_METADATA(IID "rtimv.dictionaryInterface/1.4")
     Q_INTERFACES(rtimvDictionaryInterface)
 
 protected:

--- a/gui/rtimv/plugins/pwfsAlignment/pwfsAlignment.hpp
+++ b/gui/rtimv/plugins/pwfsAlignment/pwfsAlignment.hpp
@@ -12,7 +12,7 @@
 class pwfsAlignment : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.2")
+    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
     Q_INTERFACES(rtimvOverlayInterface)
 
 protected:

--- a/gui/rtimv/plugins/warnings/warnings.cpp
+++ b/gui/rtimv/plugins/warnings/warnings.cpp
@@ -1,9 +1,9 @@
 
 #include "warnings.hpp"
 
-#define errPrint(expl) std::cerr << "warnings: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
+#define errPrint( expl ) std::cerr << "warnings: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
 
-warnings::warnings() : rtimvOverlayInterface(), m_blob{'\0'}
+warnings::warnings() : rtimvOverlayInterface(), m_blob{ '\0' }
 {
 }
 
@@ -11,58 +11,58 @@ warnings::~warnings()
 {
 }
 
-int warnings::attachOverlay( rtimvOverlayAccess & roa,
-                             mx::app::appConfigurator & config
-                           )
+int warnings::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &config )
 {
     m_roa = roa;
 
-    config.configUnused(m_deviceName, mx::app::iniFile::makeKey("rules", "device"));
+    config.configUnused( m_deviceName, mx::app::iniFile::makeKey( "rules", "device" ) );
 
-    if(m_deviceName == "")
+    if( m_deviceName == "" )
     {
-        pluginLogInfo("not configured");
+        pluginLogInfo( "not configured" );
         m_enableable = false;
         disableOverlay();
-        return 1; //Tell rtimv to unload me since not configured.
+        return 1; // Tell rtimv to unload me since not configured.
     }
 
-    pluginLogInfo(std::format("enabling for {}", m_deviceName));
+    pluginLogInfo( std::format( "enabling for {}", m_deviceName ) );
 
-    config.configUnused(m_cautionKeys, mx::app::iniFile::makeKey("rules", "cautions"));
-    config.configUnused(m_warningKeys, mx::app::iniFile::makeKey("rules", "warnings"));
-    config.configUnused(m_alertKeys, mx::app::iniFile::makeKey("rules", "alerts"));
+    config.configUnused( m_cautionKeys, mx::app::iniFile::makeKey( "rules", "cautions" ) );
+    config.configUnused( m_warningKeys, mx::app::iniFile::makeKey( "rules", "warnings" ) );
+    config.configUnused( m_alertKeys, mx::app::iniFile::makeKey( "rules", "alerts" ) );
 
-    if(m_cautionKeys.size() == 0 && m_warningKeys.size() == 0 && m_alertKeys.size() == 0)
+    if( m_cautionKeys.size() == 0 && m_warningKeys.size() == 0 && m_alertKeys.size() == 0 )
     {
         m_enableable = false;
         disableOverlay();
         return 1;
     }
 
-    connect(this, SIGNAL(warningLevel(rtimv::warningLevel)), m_roa.m_mainWindowObject, SLOT(borderWarningLevel(rtimv::warningLevel)));
+    connect( this,
+             SIGNAL( warningLevel( rtimv::warningLevel ) ),
+             m_roa.m_mainWindowObject,
+             SLOT( borderWarningLevel( rtimv::warningLevel ) ) );
 
-    if(m_roa.m_dictionary != nullptr)
+    if( m_roa.m_dictionary != nullptr )
     {
-        for(size_t n = 0; n < m_cautionKeys.size(); ++n)
+        for( size_t n = 0; n < m_cautionKeys.size(); ++n )
         {
-            (*m_roa.m_dictionary)[m_deviceName + ".caution." + m_cautionKeys[n]].setBlob(nullptr, 0);
+            ( *m_roa.m_dictionary )[m_deviceName + ".caution." + m_cautionKeys[n]].setBlob( nullptr, 0 );
         }
 
-        for(size_t n = 0; n < m_warningKeys.size(); ++n)
+        for( size_t n = 0; n < m_warningKeys.size(); ++n )
         {
-            (*m_roa.m_dictionary)[m_deviceName + ".warning." + m_warningKeys[n]].setBlob(nullptr, 0);
+            ( *m_roa.m_dictionary )[m_deviceName + ".warning." + m_warningKeys[n]].setBlob( nullptr, 0 );
         }
 
-        for(size_t n = 0; n < m_alertKeys.size(); ++n)
+        for( size_t n = 0; n < m_alertKeys.size(); ++n )
         {
-            (*m_roa.m_dictionary)[m_deviceName + ".alert." + m_alertKeys[n]].setBlob(nullptr, 0);
+            ( *m_roa.m_dictionary )[m_deviceName + ".alert." + m_alertKeys[n]].setBlob( nullptr, 0 );
         }
-
     }
 
     m_enableable = true;
-    m_enabled = true;
+    m_enabled    = true;
     enableOverlay();
 
     return 0;
@@ -70,106 +70,158 @@ int warnings::attachOverlay( rtimvOverlayAccess & roa,
 
 int warnings::updateOverlay()
 {
-    if(!m_enabled) return 0;
+    if( !m_enabled )
+        return 0;
 
-    if(m_roa.m_dictionary == nullptr) return 0;
+    if( m_roa.m_dictionary == nullptr )
+        return 0;
 
-    if(m_roa.m_graphicsView == nullptr) return 0;
+    if( m_roa.m_graphicsView == nullptr )
+        return 0;
 
-    bool caution = false;
+    bool caution = anyOn( m_cautionKeys, ".caution." );
+    bool warn    = anyOn( m_warningKeys, ".warning." );
+    bool alert   = anyOn( m_alertKeys, ".alert." );
 
-    for(size_t n = 0; n < m_cautionKeys.size(); ++n)
+    if( alert )
     {
-        if( ((*m_roa.m_dictionary)[m_deviceName + ".caution." + m_cautionKeys[n]].getBlobStr(m_blob, sizeof(m_blob))) == sizeof(m_blob) )
-        {
-            errPrint("bad string"); //Don't trust this as a string.
-            continue;
-        }
-
-        if(std::string(m_blob) == "on") caution = true;
+        emit warningLevel( rtimv::warningLevel::alert );
     }
-
-    bool warn = false;
-
-    for(size_t n = 0; n < m_warningKeys.size(); ++n)
+    else if( warn )
     {
-        if( ((*m_roa.m_dictionary)[m_deviceName + ".warning." + m_warningKeys[n]].getBlobStr(m_blob, sizeof(m_blob))) == sizeof(m_blob) )
-        {
-            errPrint("bad string"); //Don't trust this as a string.
-            continue;
-        }
-
-        if(std::string(m_blob) == "on") warn = true;
+        emit warningLevel( rtimv::warningLevel::warning );
     }
-
-    bool alert = false;
-
-    for(size_t n = 0; n < m_alertKeys.size(); ++n)
+    else if( caution )
     {
-        if( ((*m_roa.m_dictionary)[m_deviceName + ".alert." + m_alertKeys[n]].getBlobStr(m_blob, sizeof(m_blob))) == sizeof(m_blob) )
-        {
-            errPrint("bad string"); //Don't trust this as a string.
-            continue;
-        }
-
-        if(std::string(m_blob) == "on") alert = true;
-    }
-
-    if(alert)
-    {
-        emit warningLevel(rtimv::warningLevel::alert);
-    }
-    else if(warn)
-    {
-        emit warningLevel(rtimv::warningLevel::warning);
-    }
-    else if(caution)
-    {
-        emit warningLevel(rtimv::warningLevel::caution);
+        emit warningLevel( rtimv::warningLevel::caution );
     }
     else
     {
-        emit warningLevel(rtimv::warningLevel::normal);
+        emit warningLevel( rtimv::warningLevel::normal );
     }
 
     return 0;
 }
 
-void warnings::keyPressEvent( QKeyEvent * ke)
+void warnings::keyPressEvent( QKeyEvent *ke )
 {
-   static_cast<void>(ke);
+    static_cast<void>( ke );
+}
+
+bool warnings::hasTextOverlay()
+{
+    return true;
+}
+
+char warnings::textOverlayKey()
+{
+    return 'w';
+}
+
+std::string warnings::textOverlayTitle()
+{
+    return "warnings";
+}
+
+std::string warnings::textOverlayText()
+{
+    std::string text;
+    text = "                     active warnings                     \n";
+    text += "                  press 'w' to exit warnings            \n";
+    text += "\n";
+
+    appendActive( text, "Alerts", m_alertKeys, ".alert." );
+    appendActive( text, "Warnings", m_warningKeys, ".warning." );
+    appendActive( text, "Cautions", m_cautionKeys, ".caution." );
+
+    return text;
 }
 
 bool warnings::overlayEnabled()
 {
-   return m_enabled;
+    return m_enabled;
 }
 
 void warnings::enableOverlay()
 {
-   if(m_enableable == false) return;
+    if( m_enableable == false )
+        return;
 
-   m_enabled = true;
+    m_enabled = true;
 }
 
 void warnings::disableOverlay()
 {
-   for(size_t n=0; n<m_roa.m_graphicsView->statusTextNo();++n)
-   {
-      m_roa.m_graphicsView->statusTextText(n, "");
-   }
+    for( size_t n = 0; n < m_roa.m_graphicsView->statusTextNo(); ++n )
+    {
+        m_roa.m_graphicsView->statusTextText( n, "" );
+    }
 
-   m_enabled = false;
+    m_enabled = false;
 }
 
 std::vector<std::string> warnings::info()
 {
     std::vector<std::string> vinfo;
-    vinfo.push_back("Warnings overlay: " + m_deviceName);
+    vinfo.push_back( "Warnings overlay: " + m_deviceName );
     /*if(m_deviceName != "")
     {
         vinfo.push_back("                   " + m_deviceName);
     }*/
 
     return vinfo;
+}
+
+bool warnings::keyOn( const std::string &key )
+{
+    if( m_roa.m_dictionary == nullptr )
+        return false;
+
+    if( ( ( *m_roa.m_dictionary )[key].getBlobStr( m_blob, sizeof( m_blob ) ) ) == sizeof( m_blob ) )
+    {
+        errPrint( "bad string" );
+        return false;
+    }
+
+    return std::string( m_blob ) == "on";
+}
+
+bool warnings::anyOn( const std::vector<std::string> &keys, const std::string &prefix )
+{
+    for( size_t n = 0; n < keys.size(); ++n )
+    {
+        if( keyOn( m_deviceName + prefix + keys[n] ) )
+            return true;
+    }
+
+    return false;
+}
+
+void warnings::appendActive( std::string                    &text,
+                             const std::string              &heading,
+                             const std::vector<std::string> &keys,
+                             const std::string              &prefix )
+{
+    bool any = false;
+
+    for( size_t n = 0; n < keys.size(); ++n )
+    {
+        if( !keyOn( m_deviceName + prefix + keys[n] ) )
+            continue;
+
+        if( !any )
+        {
+            text += heading + ":\n";
+            any = true;
+        }
+
+        text += "  " + keys[n] + "\n";
+    }
+
+    if( !any )
+    {
+        text += heading + ": none\n";
+    }
+
+    text += "\n";
 }

--- a/gui/rtimv/plugins/warnings/warnings.cpp
+++ b/gui/rtimv/plugins/warnings/warnings.cpp
@@ -1,3 +1,9 @@
+/** \file warnings.cpp
+ * \brief Defines the warnings rtimv overlay plugin.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
 
 #include "warnings.hpp"
 

--- a/gui/rtimv/plugins/warnings/warnings.hpp
+++ b/gui/rtimv/plugins/warnings/warnings.hpp
@@ -12,15 +12,15 @@
 class warnings : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.2")
-    Q_INTERFACES(rtimvOverlayInterface)
+    Q_PLUGIN_METADATA( IID "rtimv.overlayInterface/1.4" )
+    Q_INTERFACES( rtimvOverlayInterface )
 
-protected:
+  protected:
     rtimvOverlayAccess m_roa;
 
-    bool m_enabled{false};
+    bool m_enabled{ false };
 
-    bool m_enableable{false};
+    bool m_enableable{ false };
 
     std::string m_deviceName;
 
@@ -32,17 +32,24 @@ protected:
 
     char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
 
-public:
+  public:
     warnings();
 
     virtual ~warnings();
 
-    virtual int attachOverlay(rtimvOverlayAccess &,
-                              mx::app::appConfigurator &config);
+    virtual int attachOverlay( rtimvOverlayAccess &, mx::app::appConfigurator &config );
 
     virtual int updateOverlay();
 
-    virtual void keyPressEvent(QKeyEvent *ke);
+    virtual void keyPressEvent( QKeyEvent *ke );
+
+    virtual bool hasTextOverlay();
+
+    virtual char textOverlayKey();
+
+    virtual std::string textOverlayTitle();
+
+    virtual std::string textOverlayText();
 
     virtual bool overlayEnabled();
 
@@ -50,13 +57,22 @@ public:
 
     virtual void disableOverlay();
 
-public:
+  public:
     virtual std::vector<std::string> info();
 
-signals:
+  protected:
+    bool keyOn( const std::string &key );
 
-    void warningLevel(rtimv::warningLevel lvl);
+    bool anyOn( const std::vector<std::string> &keys, const std::string &prefix );
 
+    void appendActive( std::string                    &text,
+                       const std::string              &heading,
+                       const std::vector<std::string> &keys,
+                       const std::string              &prefix );
+
+  signals:
+
+    void warningLevel( rtimv::warningLevel lvl );
 };
 
 #endif // warnings_hpp

--- a/gui/rtimv/plugins/warnings/warnings.hpp
+++ b/gui/rtimv/plugins/warnings/warnings.hpp
@@ -1,14 +1,21 @@
+/** \file warnings.hpp
+ * \brief Declares the warnings rtimv overlay plugin.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #ifndef warnings_hpp
 #define warnings_hpp
 
 #include <rtimv/rtimvInterfaces.hpp>
-#include <rtimv/StretchBox.hpp>
 
 #include <QObject>
 #include <QtPlugin>
 
 #include <iostream>
 
+/// Overlay plugin which monitors dictionary-backed caution, warning, and alert state.
 class warnings : public rtimvOverlayInterface
 {
     Q_OBJECT
@@ -16,63 +23,93 @@ class warnings : public rtimvOverlayInterface
     Q_INTERFACES( rtimvOverlayInterface )
 
   protected:
+    /// Access to selected rtimv GUI and dictionary state.
     rtimvOverlayAccess m_roa;
 
+    /// True when the plugin is currently allowed to update state.
     bool m_enabled{ false };
 
+    /// True when configuration was sufficient to enable this plugin.
     bool m_enableable{ false };
 
+    /// Device prefix used when forming dictionary keys.
     std::string m_deviceName;
 
+    /// Dictionary keys checked at caution severity.
     std::vector<std::string> m_cautionKeys;
 
+    /// Dictionary keys checked at warning severity.
     std::vector<std::string> m_warningKeys;
 
+    /// Dictionary keys checked at alert severity.
     std::vector<std::string> m_alertKeys;
 
     char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
 
   public:
+    /// Construct the warnings plugin.
     warnings();
 
+    /// Destruct the warnings plugin.
     virtual ~warnings();
 
-    virtual int attachOverlay( rtimvOverlayAccess &, mx::app::appConfigurator &config );
+    /// Attach the overlay plugin to rtimv.
+    virtual int
+    attachOverlay( rtimvOverlayAccess & /**< [in] exposed main-window, graphics-view, and dictionary access */,
+                   mx::app::appConfigurator &config /**< [in] configuration source for plugin options */
+    );
 
+    /// Update the warning-border state from the current dictionary values.
     virtual int updateOverlay();
 
-    virtual void keyPressEvent( QKeyEvent *ke );
+    /// Handle key presses passed through by rtimv.
+    virtual void keyPressEvent( QKeyEvent *ke /**< [in] key event to inspect */ );
 
+    /// Report whether this plugin provides a full-screen text overlay.
     virtual bool hasTextOverlay();
 
+    /// Return the key used to toggle the warnings text overlay.
     virtual char textOverlayKey();
 
+    /// Return the short title used in the built-in help listing.
     virtual std::string textOverlayTitle();
 
+    /// Generate the current full-screen warnings text overlay.
     virtual std::string textOverlayText();
 
+    /// Report whether this overlay is currently enabled.
     virtual bool overlayEnabled();
 
+    /// Enable the overlay if configuration allows it.
     virtual void enableOverlay();
 
+    /// Disable the overlay and clear any status text it owns.
     virtual void disableOverlay();
 
   public:
+    /// Return user-visible plugin information for the `i` overlay.
     virtual std::vector<std::string> info();
 
   protected:
-    bool keyOn( const std::string &key );
+    /// Check whether a single dictionary key is currently set to `on`.
+    bool keyOn( const std::string &key /**< [in] fully qualified dictionary key to inspect */ );
 
-    bool anyOn( const std::vector<std::string> &keys, const std::string &prefix );
+    /// Check whether any keys in one severity group are currently active.
+    bool anyOn( const std::vector<std::string> &keys, /**< [in] configured leaf keys for one severity group */
+                const std::string &prefix /**< [in] severity-specific key prefix inserted after the device name */
+    );
 
-    void appendActive( std::string                    &text,
-                       const std::string              &heading,
-                       const std::vector<std::string> &keys,
-                       const std::string              &prefix );
+    /// Append all active keys from one severity group to the overlay text.
+    void
+    appendActive( std::string                    &text,    /**< [in,out] accumulated overlay text */
+                  const std::string              &heading, /**< [in] heading label for the severity group */
+                  const std::vector<std::string> &keys,    /**< [in] configured leaf keys for one severity group */
+                  const std::string &prefix /**< [in] severity-specific key prefix inserted after the device name */
+    );
 
   signals:
-
-    void warningLevel( rtimv::warningLevel lvl );
+    /// Emit the highest currently active warning level.
+    void warningLevel( rtimv::warningLevel lvl /**< [in] highest active warning severity */ );
 };
 
 #endif // warnings_hpp


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "the warnings plugin is here: /home/jrmales/Source/MagAOX/gui/rtimv/plugins. the idea is to have the help text be a list of the active cautions/warnings/alerts when the user hits `w`."

## Summary

Updates the MagAO-X `rtimv` plugin set for the new `rtimv` text-overlay interface and adds a warnings overlay on `w`.

This PR:
- updates MagAO-X `rtimv` plugin IIDs to `1.4` to match the current `rtimv` plugin interfaces
- adds a `w` text overlay to the warnings plugin
- shows the currently active alerts, warnings, and cautions in the shared full-screen overlay
- reuses the same dictionary-backed active-state checks for both the warning border and the overlay text
- improves documentation in the warnings plugin source/header

## Testing

- Verified interactively that the warnings plugin overlay appears on `w`
- Verified the overlay lists active alerts, warnings, and cautions
- Verified the device name is not repeated in the `w` overlay, since it is already available in plugin info

## Notes

- The main `rtimv` support for plugin text overlays landed separately in the `rtimv` repository.
- This branch is intended to pair with that `rtimv` change, since the plugin IIDs now match interface version `1.4`.
