### PR TITLE
w2tcs offloader telem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,11 +79,23 @@ Follow these code style and documentation rules exactly.
   - When a file is touched, update documentation quality across the full changed file, not only in modified lines.
 
 16) Keep This File Current
-  - Add new standing style/documentation instructions to `agent_context.md` as they are introduced.
+  - Add new standing style/documentation instructions to this `AGENTS.md` file as they are introduced.
 
 17) Commit Branch Discipline
   - Do not commit directly to shared/integration branches (e.g. `dev`, `main`, `master`).
   - Always create/switch to a feature branch that follows rule #12 before committing.
+
+18) dev Base-Class Macros
+  - When integrating a `dev::<base-class>` helper into an app, prefer the corresponding interface macros provided by that helper header when they exist.
+  - Examples include `TELEMETER_*` for `dev::telemeter` and `FRAMEGRABBER_*` for `dev::frameGrabber`.
+
+19) Commit Separation
+  - Keep changes separated into clean commits on feature branches.
+  - Make functional changes first.
+  - Keep relevant plan files up to date as implementation progresses when they capture engineering decisions or execution notes for the work.
+  - Commit relevant plan files with the associated code changes when they serve as part of the engineering record for that work.
+  - Follow with documentation-only changes.
+  - Make formatting-only cleanup a separate final commit when needed.
 
 When you finish:
 - Summarize what changed.

--- a/agents/plans/w2tcsoffloader-telem.md
+++ b/agents/plans/w2tcsoffloader-telem.md
@@ -50,6 +50,9 @@ Plan
    - Explicitly zero coefficients at indices `>= m_nModes` so telemetry reflects the same effective command state sent to TCS.
    - Continue updating `m_indiP_zCoeffs` from the same `m_zCoeffs` values so INDI and telemetry remain consistent.
    - After updating the coefficients, call `recordZCoeffs()` so changes are logged promptly instead of waiting only for the max telemeter interval.
+   - During startup after loading the mode cube:
+     - clamp configured `m_nModes` to the number of available modes in the FITS cube
+     - fail with a `LOG_CRITICAL` `text_log` and shutdown if the available mode count exceeds what can be represented by the two-digit INDI element naming scheme (`00` through `99`)
 
 5. Wire the app lifecycle to the telemeter base class.
    - `setupConfig()`
@@ -107,3 +110,4 @@ Notes / Expected Design Decisions
 - Scope:
   - this plan assumes no change to the offload math itself
   - the work is limited to exposing the already computed coefficient vector through telemetry
+  - startup validation now also includes guarding the configured/available mode counts so the INDI naming scheme remains valid

--- a/agents/plans/w2tcsoffloader-telem.md
+++ b/agents/plans/w2tcsoffloader-telem.md
@@ -1,1 +1,109 @@
-Problem Statement: we need to add telemetry functionality to the app `w2tcsOffloader` to record the calculated zernike basis coefficients.  
+Problem Statement: we need to add `dev::telemeter` functionality to the app `w2tcsOffloader` to record the calculated Zernike basis coefficients. Review `AGENTS.md` and document a plan in this document.
+
+Comments on initial plan:
+- be sure to use the TELEMETER macros for the interface calls in step 5.
+- let's make the functional changes first, and have a commit on the new branch, before doing the documentation and a commit, and yet another commit for a formatting cleanup.  This should be the standard practice added to AGENTS.md to keep the changes cleanly separated.
+
+
+Plan
+
+1. Review and mirror the existing telemetry integration pattern used elsewhere in MagAO-X.
+   - Use apps such as `usbtempMon`, `cacaoInterface`, and `t2wOffloader` as the implementation model for:
+     - inheritance from `dev::telemeter<derivedT>`
+     - the `telemeterT` typedef
+     - `checkRecordTimes()`
+     - `recordTelem(...)`
+     - calling telemeter `setupConfig`, `loadConfig`, `appStartup`, `appLogic`, and `appShutdown`
+   - Keep changes scoped to `w2tcsOffloader` and the new logger type needed for the coefficient vector.
+
+2. Add a purpose-built telemetry log type for the coefficient vector.
+   - The existing `logger::telem_offloading` log type is not suitable because it only records:
+     - `num_modes`
+     - `num_average`
+     - `fps`
+   - The requirement here is to record the calculated Zernike basis coefficients themselves, so the best fit is a new flatbuffer-backed logger type modeled after `logger::telem_dmmodes`.
+   - Proposed contents of the new log type:
+     - a `vector<float>` of the offloaded coefficients
+   - Proposed location:
+     - `libMagAOX/logger/types/telem_w2tcsoffloader.hpp`
+     - plus the corresponding flatbuffer schema under `libMagAOX/logger/types/schemas/`
+   - Also update the logger registration/build plumbing consistently with existing logger types:
+     - `libMagAOX/logger/types/telem.cpp`
+     - `libMagAOX/logger/logCodes.dat`
+     - any generated/header include lists if required by the build
+
+3. Integrate `dev::telemeter` into `w2tcsOffloader`.
+   - Update the class declaration in `apps/w2tcsOffloader/w2tcsOffloader.hpp` to:
+     - inherit from `dev::telemeter<w2tcsOffloader>`
+     - add `friend class dev::telemeter<w2tcsOffloader>;`
+     - add `typedef dev::telemeter<w2tcsOffloader> telemeterT;`
+   - Add the standard telemeter interface declarations:
+     - `int checkRecordTimes();`
+     - `int recordTelem( const telem_w2tcsoffloader * );`
+     - `int recordZCoeffs( bool force = false );`
+   - Add any member state needed to suppress redundant telemetry records, for example:
+     - `std::vector<realT> m_zCoeffs;` as the current coefficient values
+     - `std::vector<realT> m_lastZCoeffs;` as the last logged values
+
+4. Make coefficient computation update internal state first, then publish both INDI and telemetry from that state.
+   - In `processImage(...)`, compute coefficients into `m_zCoeffs` instead of writing only to the INDI property.
+   - Explicitly zero coefficients at indices `>= m_nModes` so telemetry reflects the same effective command state sent to TCS.
+   - Continue updating `m_indiP_zCoeffs` from the same `m_zCoeffs` values so INDI and telemetry remain consistent.
+   - After updating the coefficients, call `recordZCoeffs()` so changes are logged promptly instead of waiting only for the max telemeter interval.
+
+5. Wire the app lifecycle to the telemeter base class.
+   - `setupConfig()`
+     - use `TELEMETER_SETUP_CONFIG(config)` in addition to the existing shmim monitor setup
+   - `loadConfigImpl(...)`
+     - use `TELEMETER_LOAD_CONFIG(_config)`
+   - `appStartup()`
+     - use `TELEMETER_APP_STARTUP`
+   - `appLogic()`
+     - use `TELEMETER_APP_LOGIC` in operating states where telemetry logging is valid
+   - `appShutdown()`
+     - use `TELEMETER_APP_SHUTDOWN`
+
+6. Implement the telemetry recording methods in the standard MagAO-X style.
+   - `checkRecordTimes()`
+     - return `telemeterT::checkRecordTimes( telem_w2tcsoffloader() );`
+   - `recordTelem( const telem_w2tcsoffloader * )`
+     - delegate to `recordZCoeffs(true)`
+   - `recordZCoeffs( bool force )`
+     - compare current coefficients against the last logged coefficients
+     - log on any change or when `force == true`
+     - emit a telemetry message containing the coefficient vector
+
+7. Do a documentation/style pass across the touched files.
+   - Keep file-level Doxygen blocks present and aligned with the local style.
+   - Add `///` summaries and inline parameter docs for any new declarations in headers.
+   - Keep declaration grouping stable and avoid introducing non-trivial in-class definitions.
+   - If a lock-lifetime-only scope is introduced, annotate it as `{ //mutex scope`.
+
+8. Run formatting and targeted verification.
+   - Run `clang-format -i` on the touched source/header files.
+   - Build the affected target(s) to catch schema/logger integration issues.
+   - If available, confirm at runtime or in logs that:
+     - telemetry records are produced
+     - coefficient vectors match the INDI values
+     - repeated identical frames do not spam logs except at the configured maximum interval
+
+9. Keep the work separated into clean commits on the feature branch.
+   - Make the functional telemetry changes first and commit them on the new feature branch.
+   - Follow with a documentation-only pass and commit.
+   - If needed, make formatting-only cleanup a separate final commit.
+   - Treat this functional/docs/formatting separation as the preferred standard workflow for similar changes going forward.
+
+Notes / Expected Design Decisions
+
+- Preferred logger shape:
+  - a new vector-valued telemetry type, rather than extending `telem_offloading`
+  - rationale: `telem_offloading` is already used for scalar offloading summary data in other apps, and overloading its meaning would make downstream interpretation ambiguous
+
+- Recording behavior:
+  - immediate record on coefficient change from `processImage(...)`
+  - periodic forced record via `dev::telemeter` max-interval logic
+  - rationale: this matches common MagAO-X patterns and avoids losing long steady-state periods in telemetry
+
+- Scope:
+  - this plan assumes no change to the offload math itself
+  - the work is limited to exposing the already computed coefficient vector through telemetry

--- a/agents/plans/w2tcsoffloader-telem.md
+++ b/agents/plans/w2tcsoffloader-telem.md
@@ -1,0 +1,1 @@
+Problem Statement: we need to add telemetry functionality to the app `w2tcsOffloader` to record the calculated zernike basis coefficients.  

--- a/apps/w2tcsOffloader/w2tcsOffloader.cpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.cpp
@@ -1,16 +1,14 @@
 /** \file w2tcsOffloader.cpp
-  * \brief The MagAO-X Woofer To Telescope Control System (TCS) Offloader
-  *
-  * \ingroup w2tcsOffloader_files
-  */
+ * \brief The MagAO-X Woofer To Telescope Control System (TCS) offloader main program.
+ *
+ * \ingroup w2tcsOffloader_files
+ */
 
 #include "w2tcsOffloader.hpp"
-
-
-int main(int argc, char **argv)
+/// Run the w2tcsOffloader application entry point.
+int main( int argc, char **argv )
 {
-   MagAOX::app::w2tcsOffloader xapp;
+    MagAOX::app::w2tcsOffloader xapp;
 
-   return xapp.main(argc, argv);
-
+    return xapp.main( argc, argv );
 }

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -7,6 +7,7 @@
 #ifndef w2tcsOffloader_hpp
 #define w2tcsOffloader_hpp
 
+#include <format>
 #include <limits>
 
 #include <mx/improc/eigenCube.hpp>
@@ -222,6 +223,19 @@ inline int w2tcsOffloader::appStartup()
     m_zCoeffs.resize( m_wZModes.planes(), 0 );
     m_lastZCoeffs.resize( m_zCoeffs.size(), std::numeric_limits<realT>::max() );
 
+    if( m_nModes > m_zCoeffs.size() )
+    {
+        m_nModes = m_zCoeffs.size();
+    }
+
+    if( m_zCoeffs.size() > 100 )
+    {
+        m_shutdown = true;
+        return log<text_log, -1>( "w2tcsOffloader supports at most 100 offload modes because INDI element names are "
+                                  "formatted with two digits.",
+                                  logPrio::LOG_CRITICAL );
+    }
+
     errc = ff.read( m_wMask, m_wMaskPath );
     if( errc != mx::error_t::noerror )
     {
@@ -241,7 +255,7 @@ inline int w2tcsOffloader::appStartup()
     m_elNames.resize( m_zCoeffs.size() );
     for( size_t n = 0; n < m_zCoeffs.size(); ++n )
     {
-        m_elNames[n] = mx::ioutils::convertToString<size_t, 2, '0'>( n );
+        m_elNames[n] = std::format( "{:02}", n );
 
         indi::addNumberElement<realT>( m_indiP_zCoeffs,
                                        m_elNames[n],

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -62,8 +62,7 @@ protected:
    std::string m_wMaskPath;
    std::vector<std::string> m_elNames;
    std::vector<realT> m_zCoeffs;
-   float m_gain {0.1};
-   int m_nModes {2};
+   unsigned m_nModes {5};
    float m_norm {1.0};
 
    ///@}
@@ -120,16 +119,11 @@ public:
 
 protected:
 
-   pcf::IndiProperty m_indiP_gain;
    pcf::IndiProperty m_indiP_nModes;
    pcf::IndiProperty m_indiP_zCoeffs;
 
-   pcf::IndiProperty m_indiP_zero;
 
-   INDI_NEWCALLBACK_DECL(w2tcsOffloader, m_indiP_gain);
-   INDI_NEWCALLBACK_DECL(w2tcsOffloader, m_indiP_nModes);
-   INDI_NEWCALLBACK_DECL(w2tcsOffloader, m_indiP_zero);
-   INDI_NEWCALLBACK_DECL(w2tcsOffloader, m_indiP_zCoeffs);
+
 };
 
 inline
@@ -145,7 +139,6 @@ void w2tcsOffloader::setupConfig()
 
    config.add("offload.wZModesPath", "", "offload.wZModesPath", argType::Required, "offload", "wZModesPath", false, "string", "The path to the woofer Zernike modes.");
    config.add("offload.wMaskPath", "", "offload.wMaskPath", argType::Required, "offload", "wMaskPath", false, "string", "Path to the woofer Zernike mode mask.");
-   config.add("offload.gain", "", "offload.gain", argType::Required, "offload", "gain", false, "float", "The starting offload gain.  Default is 0.1.");
    config.add("offload.nModes", "", "offload.nModes", argType::Required, "offload", "nModes", false, "int", "Number of modes to offload to the TCS.");
 }
 
@@ -157,7 +150,6 @@ int w2tcsOffloader::loadConfigImpl( mx::app::appConfigurator & _config )
 
    _config(m_wZModesPath, "offload.wZModesPath");
    _config(m_wMaskPath, "offload.wMaskPath");
-   _config(m_gain, "offload.gain");
    _config(m_nModes, "offload.nModes");
 
    return 0;
@@ -189,27 +181,13 @@ int w2tcsOffloader::appStartup(){
 
    m_norm = m_wMask.sum();
 
-   createStandardIndiNumber<unsigned>( m_indiP_gain, "gain", 0, 1, 0, "%0.2f");
-   m_indiP_gain["current"] = m_gain;
-   m_indiP_gain["target"] = m_gain;
-
-   if( registerIndiPropertyNew( m_indiP_gain, INDI_NEWCALLBACK(m_indiP_gain)) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
-
-   createStandardIndiNumber<unsigned>( m_indiP_nModes, "nModes", 1, std::numeric_limits<unsigned>::max(), 1, "%u");
+   createROIndiNumber( m_indiP_nModes, "nModes", "number of modes calculated");
+   indi::addNumberElement<unsigned>( m_indiP_nModes, "current", 0, m_zCoeffs.size(), 1, "%d");
    m_indiP_nModes["current"] = m_nModes;
 
-   if( registerIndiPropertyNew( m_indiP_nModes, INDI_NEWCALLBACK(m_indiP_nModes)) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
+   registerIndiPropertyReadOnly(m_indiP_nModes);
 
-   REG_INDI_NEWPROP(m_indiP_zCoeffs, "zCoeffs", pcf::IndiProperty::Number);
-
+   registerIndiPropertyReadOnly(m_indiP_zCoeffs);
 
    m_elNames.resize(m_zCoeffs.size());
    for(size_t n=0; n < m_zCoeffs.size(); ++n)
@@ -224,14 +202,6 @@ int w2tcsOffloader::appStartup(){
    if(shmimMonitorT::appStartup() < 0)
    {
       return log<software_error,-1>({__FILE__, __LINE__});
-   }
-
-
-   createStandardIndiRequestSw( m_indiP_zero, "zero", "zero loop");
-   if( registerIndiPropertyNew( m_indiP_zero, INDI_NEWCALLBACK(m_indiP_zero)) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
    }
 
    state(stateCodes::OPERATING);
@@ -303,7 +273,7 @@ int w2tcsOffloader::processImage( void * curr_src,
     {
        float coeff;
        coeff = ( Eigen::Map<mx::improc::eigenImage<realT>>((float *)curr_src, shmimMonitorT::m_width, shmimMonitorT::m_height) * m_wZModes.image(i) * m_wMask).sum() / m_norm;
-       m_indiP_zCoeffs[m_elNames[i]] = m_gain * coeff;
+       m_indiP_zCoeffs[m_elNames[i]] = coeff;
     }
     else
     {
@@ -322,84 +292,6 @@ int w2tcsOffloader::processImage( void * curr_src,
    return 0;
 }
 
-// update this: mode coefficients (maybe they shouldn't be settable. How to handle?)
-
-INDI_NEWCALLBACK_DEFN(w2tcsOffloader, m_indiP_gain)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_gain, ipRecv);
-
-    float target;
-
-    if( indiTargetUpdate( m_indiP_gain, target, ipRecv, true) < 0)
-    {
-        log<software_error>({__FILE__,__LINE__});
-        return -1;
-    }
-
-    m_gain = target;
-
-    updateIfChanged(m_indiP_gain, "current", m_gain);
-    updateIfChanged(m_indiP_gain, "target", m_gain);
-
-    log<text_log>("set gain to " + std::to_string(m_gain), logPrio::LOG_NOTICE);
-
-    return 0;
-}
-
-INDI_NEWCALLBACK_DEFN(w2tcsOffloader, m_indiP_nModes)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_nModes, ipRecv);
-
-    unsigned target;
-
-    if( indiTargetUpdate( m_indiP_nModes, target, ipRecv, true) < 0)
-    {
-        log<software_error>({__FILE__,__LINE__});
-        return -1;
-    }
-
-    m_nModes = target;
-
-    updateIfChanged(m_indiP_nModes, "current", m_nModes);
-    updateIfChanged(m_indiP_nModes, "target", m_nModes);
-
-    log<text_log>("set nModes to " + std::to_string(m_nModes), logPrio::LOG_NOTICE);
-
-    return 0;
-}
-
-INDI_NEWCALLBACK_DEFN(w2tcsOffloader, m_indiP_zCoeffs)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_zCoeffs, ipRecv);
-
-
-    for(size_t n=0; n < m_zCoeffs.size(); ++n)
-    {
-        if(ipRecv.find(m_elNames[n]))
-        {
-            realT zcoeff = ipRecv[m_elNames[n]].get<realT>();
-            m_zCoeffs[n] = zcoeff;
-        }
-    }
-    return 0;
-
-
-   return log<software_error,-1>({__FILE__,__LINE__, "invalid indi property name"});
-}
-
-INDI_NEWCALLBACK_DEFN(w2tcsOffloader, m_indiP_zero)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_zero, ipRecv);
-
-    float target;
-
-    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On)
-    {
-        m_woofer.setZero();
-        log<text_log>("set zero", logPrio::LOG_NOTICE);
-    }
-    return 0;
-}
 
 } //namespace app
 } //namespace MagAOX

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -66,11 +66,13 @@ class w2tcsOffloader : public MagAOXApp<true>,
 
     std::string m_wMaskPath; ///< Filesystem path to the mask used for coefficient projection.
 
-    std::vector<std::string> m_elNames; ///< INDI element names corresponding to the coefficient vector, formatted as `00` through `99`.
+    std::vector<std::string>
+        m_elNames; ///< INDI element names corresponding to the coefficient vector, formatted as `00` through `99`.
 
     std::vector<realT> m_zCoeffs; ///< Current coefficient vector sent to INDI and telemetry.
 
-    unsigned m_nModes{ 5 }; ///< Number of low-order modes to retain when offloading, clamped to the loaded cube size at startup.
+    unsigned m_nModes{
+        5 }; ///< Number of low-order modes to retain when offloading, clamped to the loaded cube size at startup.
 
     float m_norm{ 1.0 }; ///< Mask normalization applied to each coefficient measurement.
 

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -1,8 +1,8 @@
 /** \file w2tcsOffloader.hpp
-  * \brief The MagAO-X Woofer To Telescope Control System (TCS) offloading manager
-  *
-  * \ingroup app_files
-  */
+ * \brief The MagAO-X Woofer To Telescope Control System (TCS) offloading manager
+ *
+ * \ingroup app_files
+ */
 
 #ifndef w2tcsOffloader_hpp
 #define w2tcsOffloader_hpp
@@ -21,279 +21,381 @@ namespace app
 {
 
 /** \defgroup w2tcsOffloader Woofer to TCS Offloading
-  * \brief Monitors the averaged woofer shape, fits Zernikes, and sends it to INDI.
-  *
-  * <a href="../handbook/operating/software/apps/w2tcsOffloader.html">Application Documentation</a>
-  *
-  * \ingroup apps
-  *
-  */
+ * \brief Monitors the averaged woofer shape, fits Zernikes, and sends it to INDI.
+ *
+ * <a href="../handbook/operating/software/apps/w2tcsOffloader.html">Application Documentation</a>
+ *
+ * \ingroup apps
+ *
+ */
 
 /** \defgroup w2tcsOffloader_files Woofer to TCS Offloading
-  * \ingroup w2tcsOffloader
-  */
+ * \ingroup w2tcsOffloader
+ */
 
 /** MagAO-X application to control offloading the woofer to the TCS.
-  *
-  * \ingroup w2tcsOffloader
-  *
-  */
-class w2tcsOffloader : public MagAOXApp<true>, public dev::shmimMonitor<w2tcsOffloader>
+ *
+ * \ingroup w2tcsOffloader
+ *
+ */
+class w2tcsOffloader : public MagAOXApp<true>,
+                       public dev::shmimMonitor<w2tcsOffloader>,
+                       public dev::telemeter<w2tcsOffloader>
 {
 
-   //Give the test harness access.
-   friend class w2tcsOffloader_test;
+    // Give the test harness access.
+    friend class w2tcsOffloader_test;
 
-   friend class dev::shmimMonitor<w2tcsOffloader>;
+    friend class dev::shmimMonitor<w2tcsOffloader>;
+    friend class dev::telemeter<w2tcsOffloader>;
 
-   //The base shmimMonitor type
-   typedef dev::shmimMonitor<w2tcsOffloader> shmimMonitorT;
+    // The base helper types.
+    typedef dev::shmimMonitor<w2tcsOffloader> shmimMonitorT;
+    typedef dev::telemeter<w2tcsOffloader>    telemeterT;
 
-   ///Floating point type in which to do all calculations.
-   typedef float realT;
+    /// Floating point type in which to do all calculations.
+    typedef float realT;
 
-protected:
-
-   /** \name Configurable Parameters
+  protected:
+    /** \name Configurable Parameters - Data
      *@{
      */
 
-   std::string m_wZModesPath;
-   std::string m_wMaskPath;
-   std::vector<std::string> m_elNames;
-   std::vector<realT> m_zCoeffs;
-   unsigned m_nModes {5};
-   float m_norm {1.0};
+    std::string m_wZModesPath; ///< Filesystem path to the woofer Zernike basis cube.
 
-   ///@}
+    std::string m_wMaskPath; ///< Filesystem path to the mask used for coefficient projection.
 
-   mx::improc::eigenCube<realT> m_wZModes;
-   mx::improc::eigenImage<realT> m_woofer;
-   mx::improc::eigenImage<realT> m_wMask;
+    std::vector<std::string> m_elNames; ///< INDI element names corresponding to the coefficient vector.
 
-public:
-   /// Default c'tor.
-   w2tcsOffloader();
+    std::vector<realT> m_zCoeffs; ///< Current coefficient vector sent to INDI and telemetry.
 
-   /// D'tor, declared and defined for noexcept.
-   ~w2tcsOffloader() noexcept
-   {}
+    unsigned m_nModes{ 5 }; ///< Number of low-order modes to retain when offloading.
 
-   virtual void setupConfig();
+    float m_norm{ 1.0 }; ///< Mask normalization applied to each coefficient measurement.
 
-   /// Implementation of loadConfig logic, separated for testing.
-   /** This is called by loadConfig().
+    ///@}
+
+    /** \name Offloading State - Data
+     * @{
      */
-   int loadConfigImpl( mx::app::appConfigurator & _config /**< [in] an application configuration from which to load values*/);
+    mx::improc::eigenCube<realT> m_wZModes; ///< Basis cube used to project the incoming woofer image.
 
-   virtual void loadConfig();
+    mx::improc::eigenImage<realT> m_woofer; ///< Copy of the most recently processed woofer image.
 
-   /// Startup function
-   /**
-     *
+    mx::improc::eigenImage<realT> m_wMask; ///< Mask selecting valid pixels for the coefficient projection.
+
+    std::vector<realT> m_lastZCoeffs; ///< Last coefficient vector recorded to telemetry.
+                                      ///@}
+
+  public:
+    /// Default c'tor.
+    w2tcsOffloader();
+
+    /// D'tor, declared and defined for noexcept.
+    ~w2tcsOffloader() noexcept
+    {
+    }
+
+    /// Set up the application configuration.
+    virtual void setupConfig();
+
+    /// Implementation of loadConfig logic, separated for testing.
+    /** This is called by loadConfig().
      */
-   virtual int appStartup();
+    int loadConfigImpl(
+        mx::app::appConfigurator &_config /**< [in] an application configuration from which to load values*/ );
 
-   /// Implementation of the FSM for w2tcsOffloader.
-   /**
+    /// Load the application configuration.
+    virtual void loadConfig();
+
+    /// Startup function.
+    virtual int appStartup();
+
+    /// Implementation of the FSM for w2tcsOffloader.
+    /**
      * \returns 0 on no critical error
      * \returns -1 on an error requiring shutdown
      */
-   virtual int appLogic();
+    virtual int appLogic();
 
-   /// Shutdown the app.
-   /**
-     *
+    /// Shutdown the app.
+    virtual int appShutdown();
+
+    /// Allocate image buffers for a new shared-memory image stream.
+    int allocate( const dev::shmimT &dummy /**< [in] tag to differentiate shmimMonitor parents.*/ );
+
+    /// Process a new woofer image and update offload outputs.
+    int processImage( void              *curr_src, ///< [in] pointer to start of current frame.
+                      const dev::shmimT &dummy     ///< [in] tag to differentiate shmimMonitor parents.
+    );
+
+    /** \name Telemeter Interface
+     * @{
      */
-   virtual int appShutdown();
+    /// Check whether a telemetry record is due.
+    int checkRecordTimes();
 
+    /// Record the current coefficient vector for telemetry.
+    int recordTelem( const logger::telem_w2tcsoffloader * /**< [in] telemetry tag used for overload resolution */ );
 
+    /// Record the current coefficient vector when changed or when forced.
+    int recordZCoeffs( bool force = false /**< [in] set true to record even if unchanged */ );
+    ///@}
 
+  protected:
+    /** \name Offloading State
+     * @{
+     */
+    pcf::IndiProperty m_indiP_nModes; ///< INDI property publishing the number of active offload modes.
 
-   int allocate( const dev::shmimT & dummy /**< [in] tag to differentiate shmimMonitor parents.*/);
-
-   int processImage( void * curr_src,          ///< [in] pointer to start of current frame.
-                     const dev::shmimT & dummy ///< [in] tag to differentiate shmimMonitor parents.
-                   );
-
-
-protected:
-
-   pcf::IndiProperty m_indiP_nModes;
-   pcf::IndiProperty m_indiP_zCoeffs;
-
-
-
+    pcf::IndiProperty m_indiP_zCoeffs; ///< INDI property publishing the current offload coefficients.
+    ///@}
 };
 
-inline
-w2tcsOffloader::w2tcsOffloader() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
+inline w2tcsOffloader::w2tcsOffloader() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
-   return;
+    return;
 }
 
-inline
-void w2tcsOffloader::setupConfig()
+inline void w2tcsOffloader::setupConfig()
 {
-   shmimMonitorT::setupConfig(config);
+    shmimMonitorT::setupConfig( config );
+    TELEMETER_SETUP_CONFIG( config );
 
-   config.add("offload.wZModesPath", "", "offload.wZModesPath", argType::Required, "offload", "wZModesPath", false, "string", "The path to the woofer Zernike modes.");
-   config.add("offload.wMaskPath", "", "offload.wMaskPath", argType::Required, "offload", "wMaskPath", false, "string", "Path to the woofer Zernike mode mask.");
-   config.add("offload.nModes", "", "offload.nModes", argType::Required, "offload", "nModes", false, "int", "Number of modes to offload to the TCS.");
+    config.add( "offload.wZModesPath",
+                "",
+                "offload.wZModesPath",
+                argType::Required,
+                "offload",
+                "wZModesPath",
+                false,
+                "string",
+                "The path to the woofer Zernike modes." );
+    config.add( "offload.wMaskPath",
+                "",
+                "offload.wMaskPath",
+                argType::Required,
+                "offload",
+                "wMaskPath",
+                false,
+                "string",
+                "Path to the woofer Zernike mode mask." );
+    config.add( "offload.nModes",
+                "",
+                "offload.nModes",
+                argType::Required,
+                "offload",
+                "nModes",
+                false,
+                "int",
+                "Number of modes to offload to the TCS." );
 }
 
-inline
-int w2tcsOffloader::loadConfigImpl( mx::app::appConfigurator & _config )
+inline int w2tcsOffloader::loadConfigImpl( mx::app::appConfigurator &_config )
 {
 
-   shmimMonitorT::loadConfig(_config);
+    shmimMonitorT::loadConfig( _config );
+    TELEMETER_LOAD_CONFIG( _config );
 
-   _config(m_wZModesPath, "offload.wZModesPath");
-   _config(m_wMaskPath, "offload.wMaskPath");
-   _config(m_nModes, "offload.nModes");
+    _config( m_wZModesPath, "offload.wZModesPath" );
+    _config( m_wMaskPath, "offload.wMaskPath" );
+    _config( m_nModes, "offload.nModes" );
 
-   return 0;
+    return 0;
 }
 
-inline
-void w2tcsOffloader::loadConfig()
+inline void w2tcsOffloader::loadConfig()
 {
-   loadConfigImpl(config);
+    loadConfigImpl( config );
 }
 
-inline
-int w2tcsOffloader::appStartup(){
-
-   mx::fits::fitsFile<float> ff;
-   mx::error_t errc = ff.read(m_wZModes, m_wZModesPath);
-   if(errc != mx::error_t::noerror)
-   {
-      return log<text_log,-1>("Could not open mode cube file", logPrio::LOG_ERROR);
-   }
-
-   m_zCoeffs.resize(m_wZModes.planes(), 0);
-
-   errc = ff.read(m_wMask, m_wMaskPath);
-   if( errc != mx::error_t::noerror)
-   {
-     return log<text_log,-1>("Could not open mode mask file", logPrio::LOG_ERROR);
-   }
-
-   m_norm = m_wMask.sum();
-
-   createROIndiNumber( m_indiP_nModes, "nModes", "number of modes calculated");
-   indi::addNumberElement<unsigned>( m_indiP_nModes, "current", 0, m_zCoeffs.size(), 1, "%d");
-   m_indiP_nModes["current"] = m_nModes;
-
-   registerIndiPropertyReadOnly(m_indiP_nModes);
-
-   registerIndiPropertyReadOnly(m_indiP_zCoeffs);
-
-   m_elNames.resize(m_zCoeffs.size());
-   for(size_t n=0; n < m_zCoeffs.size(); ++n)
-   {
-      //std::string el = std::to_string(n);
-      m_elNames[n] = mx::ioutils::convertToString<size_t, 2, '0'>(n);
-
-      m_indiP_zCoeffs.add( pcf::IndiElement(m_elNames[n]) );
-      m_indiP_zCoeffs[m_elNames[n]].set(0);
-   }
-
-   if(shmimMonitorT::appStartup() < 0)
-   {
-      return log<software_error,-1>({__FILE__, __LINE__});
-   }
-
-   state(stateCodes::OPERATING);
-
-   return 0;
-}
-
-inline
-int w2tcsOffloader::appLogic()
+inline int w2tcsOffloader::appStartup()
 {
-   if( shmimMonitorT::appLogic() < 0)
-   {
-      return log<software_error,-1>({__FILE__,__LINE__});
-   }
 
-
-   std::unique_lock<std::mutex> lock(m_indiMutex);
-
-   if(shmimMonitorT::updateINDI() < 0)
-   {
-      log<software_error>({__FILE__, __LINE__});
-   }
-
-
-   return 0;
-}
-
-inline
-int w2tcsOffloader::appShutdown()
-{
-   shmimMonitorT::appShutdown();
-
-
-   return 0;
-}
-
-inline
-int w2tcsOffloader::allocate(const dev::shmimT & dummy)
-{
-   static_cast<void>(dummy); //be unused
-
-   //std::unique_lock<std::mutex> lock(m_indiMutex);
-
-   m_woofer.resize(shmimMonitorT::m_width, shmimMonitorT::m_height);
-
-   //state(stateCodes::OPERATING);
-
-   return 0;
-}
-
-inline
-int w2tcsOffloader::processImage( void * curr_src,
-                                const dev::shmimT & dummy
-                              )
-{
-   static_cast<void>(dummy); //be unused (what is this?)
-
-   // Replace this:
-   // project zernikes onto avg image
-   // update INDI properties with coeffs
-
-   for(size_t i=0; i < m_zCoeffs.size(); ++i)
-   {
-    /* update requested nModes and explicitly zero out any
-    modes that shouldn't be offloaded (but might have been
-    previously set)
-    */
-    if(i < m_nModes)
+    mx::fits::fitsFile<float> ff;
+    mx::error_t               errc = ff.read( m_wZModes, m_wZModesPath );
+    if( errc != mx::error_t::noerror )
     {
-       float coeff;
-       coeff = ( Eigen::Map<mx::improc::eigenImage<realT>>((float *)curr_src, shmimMonitorT::m_width, shmimMonitorT::m_height) * m_wZModes.image(i) * m_wMask).sum() / m_norm;
-       m_indiP_zCoeffs[m_elNames[i]] = coeff;
+        return log<text_log, -1>( "Could not open mode cube file", logPrio::LOG_ERROR );
     }
-    else
+
+    m_zCoeffs.resize( m_wZModes.planes(), 0 );
+    m_lastZCoeffs.resize( m_zCoeffs.size(), std::numeric_limits<realT>::max() );
+
+    errc = ff.read( m_wMask, m_wMaskPath );
+    if( errc != mx::error_t::noerror )
     {
-      m_indiP_zCoeffs[m_elNames[i]] = 0.;
+        return log<text_log, -1>( "Could not open mode mask file", logPrio::LOG_ERROR );
     }
-   }
 
-   m_indiP_zCoeffs.setState (pcf::IndiProperty::Ok);
-   m_indiDriver->sendSetProperty (m_indiP_zCoeffs);
+    m_norm = m_wMask.sum();
 
+    createROIndiNumber( m_indiP_nModes, "nModes", "number of modes calculated" );
+    indi::addNumberElement<unsigned>( m_indiP_nModes, "current", 0, m_zCoeffs.size(), 1, "%d" );
+    m_indiP_nModes["current"] = m_nModes;
 
-   // loop over something like this
-   //z0 = (im * basis.image(0)*mask).sum()/norm;
+    registerIndiPropertyReadOnly( m_indiP_nModes );
 
+    createROIndiNumber( m_indiP_zCoeffs, "zCoeffs", "offload coefficients" );
 
-   return 0;
+    m_elNames.resize( m_zCoeffs.size() );
+    for( size_t n = 0; n < m_zCoeffs.size(); ++n )
+    {
+        m_elNames[n] = mx::ioutils::convertToString<size_t, 2, '0'>( n );
+
+        indi::addNumberElement<realT>( m_indiP_zCoeffs,
+                                       m_elNames[n],
+                                       -std::numeric_limits<realT>::max(),
+                                       std::numeric_limits<realT>::max(),
+                                       0,
+                                       "%0.6f" );
+        m_indiP_zCoeffs[m_elNames[n]] = 0;
+    }
+
+    registerIndiPropertyReadOnly( m_indiP_zCoeffs );
+
+    TELEMETER_APP_STARTUP;
+
+    if( shmimMonitorT::appStartup() < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
+
+    state( stateCodes::OPERATING );
+
+    return 0;
 }
 
+inline int w2tcsOffloader::appLogic()
+{
+    if( shmimMonitorT::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
 
-} //namespace app
-} //namespace MagAOX
+    {
+        std::unique_lock<std::mutex> lock( m_indiMutex ); // mutex scope
 
-#endif //w2tcsOffloader_hpp
+        if( shmimMonitorT::updateINDI() < 0 )
+        {
+            log<software_error>( { __FILE__, __LINE__ } );
+        }
+    }
+
+    TELEMETER_APP_LOGIC;
+
+    return 0;
+}
+
+inline int w2tcsOffloader::appShutdown()
+{
+    shmimMonitorT::appShutdown();
+    TELEMETER_APP_SHUTDOWN;
+
+    return 0;
+}
+
+inline int w2tcsOffloader::allocate( const dev::shmimT &dummy )
+{
+    static_cast<void>( dummy ); // be unused
+
+    m_woofer.resize( shmimMonitorT::m_width, shmimMonitorT::m_height );
+
+    return 0;
+}
+
+inline int w2tcsOffloader::processImage( void *curr_src, const dev::shmimT &dummy )
+{
+    static_cast<void>( dummy ); // be unused
+
+    Eigen::Map<mx::improc::eigenImage<realT>> wooferImage(
+        static_cast<realT *>( curr_src ), shmimMonitorT::m_width, shmimMonitorT::m_height );
+
+    {
+        std::unique_lock<std::mutex> lock( m_indiMutex ); // mutex scope
+
+        m_woofer = wooferImage;
+
+        for( size_t i = 0; i < m_zCoeffs.size(); ++i )
+        {
+            if( i < m_nModes )
+            {
+                m_zCoeffs[i] = ( wooferImage * m_wZModes.image( i ) * m_wMask ).sum() / m_norm;
+            }
+            else
+            {
+                m_zCoeffs[i] = 0;
+            }
+
+            m_indiP_zCoeffs[m_elNames[i]] = m_zCoeffs[i];
+        }
+
+        m_indiP_zCoeffs.setState( pcf::IndiProperty::Ok );
+
+        if( m_indiDriver )
+        {
+            m_indiDriver->sendSetProperty( m_indiP_zCoeffs );
+        }
+    }
+
+    recordZCoeffs();
+
+    return 0;
+}
+
+inline int w2tcsOffloader::checkRecordTimes()
+{
+    return telemeterT::checkRecordTimes( logger::telem_w2tcsoffloader() );
+}
+
+inline int w2tcsOffloader::recordTelem( const logger::telem_w2tcsoffloader * )
+{
+    return recordZCoeffs( true );
+}
+
+inline int w2tcsOffloader::recordZCoeffs( bool force )
+{
+    std::vector<float> coeffs;
+    bool               changed{ false };
+
+    {
+        std::unique_lock<std::mutex> lock( m_indiMutex ); // mutex scope
+
+        if( m_lastZCoeffs.size() != m_zCoeffs.size() )
+        {
+            m_lastZCoeffs.resize( m_zCoeffs.size(), std::numeric_limits<realT>::max() );
+        }
+
+        coeffs.resize( m_zCoeffs.size() );
+
+        for( size_t n = 0; n < m_zCoeffs.size(); ++n )
+        {
+            coeffs[n] = m_zCoeffs[n];
+
+            if( m_lastZCoeffs[n] != m_zCoeffs[n] )
+            {
+                changed = true;
+            }
+        }
+
+        if( force || changed )
+        {
+            for( size_t n = 0; n < m_lastZCoeffs.size(); ++n )
+            {
+                m_lastZCoeffs[n] = m_zCoeffs[n];
+            }
+        }
+    }
+
+    if( force || changed )
+    {
+        telem<logger::telem_w2tcsoffloader>( logger::telem_w2tcsoffloader::messageT( coeffs ) );
+    }
+
+    return 0;
+}
+
+} // namespace app
+} // namespace MagAOX
+
+#endif // w2tcsOffloader_hpp

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -66,11 +66,11 @@ class w2tcsOffloader : public MagAOXApp<true>,
 
     std::string m_wMaskPath; ///< Filesystem path to the mask used for coefficient projection.
 
-    std::vector<std::string> m_elNames; ///< INDI element names corresponding to the coefficient vector.
+    std::vector<std::string> m_elNames; ///< INDI element names corresponding to the coefficient vector, formatted as `00` through `99`.
 
     std::vector<realT> m_zCoeffs; ///< Current coefficient vector sent to INDI and telemetry.
 
-    unsigned m_nModes{ 5 }; ///< Number of low-order modes to retain when offloading.
+    unsigned m_nModes{ 5 }; ///< Number of low-order modes to retain when offloading, clamped to the loaded cube size at startup.
 
     float m_norm{ 1.0 }; ///< Mask normalization applied to each coefficient measurement.
 
@@ -109,7 +109,7 @@ class w2tcsOffloader : public MagAOXApp<true>,
     /// Load the application configuration.
     virtual void loadConfig();
 
-    /// Start the application.
+    /// Start the application and validate the loaded mode cube against the configured mode count.
     virtual int appStartup();
 
     /// Implementation of the FSM for w2tcsOffloader.
@@ -125,7 +125,7 @@ class w2tcsOffloader : public MagAOXApp<true>,
     /// Allocate image buffers for a new shared-memory image stream.
     int allocate( const dev::shmimT &dummy /**< [in] tag to differentiate shmimMonitor parents.*/ );
 
-    /// Process a new woofer image and update offload outputs.
+    /// Process a new woofer image and update offload outputs using the currently allowed mode count.
     int processImage( void              *curr_src, ///< [in] pointer to start of current frame.
                       const dev::shmimT &dummy     ///< [in] tag to differentiate shmimMonitor parents.
     );

--- a/apps/w2tcsOffloader/w2tcsOffloader.hpp
+++ b/apps/w2tcsOffloader/w2tcsOffloader.hpp
@@ -1,5 +1,5 @@
 /** \file w2tcsOffloader.hpp
- * \brief The MagAO-X Woofer To Telescope Control System (TCS) offloading manager
+ * \brief The MagAO-X Woofer To Telescope Control System (TCS) offloading manager.
  *
  * \ingroup app_files
  */
@@ -88,10 +88,10 @@ class w2tcsOffloader : public MagAOXApp<true>,
                                       ///@}
 
   public:
-    /// Default c'tor.
+    /// Default constructor.
     w2tcsOffloader();
 
-    /// D'tor, declared and defined for noexcept.
+    /// Destructor, declared and defined for noexcept.
     ~w2tcsOffloader() noexcept
     {
     }
@@ -108,7 +108,7 @@ class w2tcsOffloader : public MagAOXApp<true>,
     /// Load the application configuration.
     virtual void loadConfig();
 
-    /// Startup function.
+    /// Start the application.
     virtual int appStartup();
 
     /// Implementation of the FSM for w2tcsOffloader.
@@ -118,7 +118,7 @@ class w2tcsOffloader : public MagAOXApp<true>,
      */
     virtual int appLogic();
 
-    /// Shutdown the app.
+    /// Shut down the application.
     virtual int appShutdown();
 
     /// Allocate image buffers for a new shared-memory image stream.
@@ -132,13 +132,13 @@ class w2tcsOffloader : public MagAOXApp<true>,
     /** \name Telemeter Interface
      * @{
      */
-    /// Check whether a telemetry record is due.
+    /// Check whether the telemetry max-interval requires a record.
     int checkRecordTimes();
 
-    /// Record the current coefficient vector for telemetry.
+    /// Record the current coefficient vector for telemetry when requested by the telemeter.
     int recordTelem( const logger::telem_w2tcsoffloader * /**< [in] telemetry tag used for overload resolution */ );
 
-    /// Record the current coefficient vector when changed or when forced.
+    /// Record the current coefficient vector when it changes or when forced.
     int recordZCoeffs( bool force = false /**< [in] set true to record even if unchanged */ );
     ///@}
 

--- a/libMagAOX/Makefile
+++ b/libMagAOX/Makefile
@@ -94,6 +94,7 @@ INCLUDEDEPS= \
 	logger/types/telem_telvane.hpp \
 	logger/types/telem_temps.hpp \
 	logger/types/telem_usage.hpp \
+	logger/types/telem_w2tcsoffloader.hpp \
 	logger/types/telem_zaber.hpp \
 	logger/types/text_log.hpp \
 	logger/types/ttmmod_params.hpp \

--- a/libMagAOX/logger/logCodes.dat
+++ b/libMagAOX/logger/logCodes.dat
@@ -81,6 +81,7 @@ telem_dmmodes            20910    telem_dmmodes
 telem_loopgain           20915    telem_loopgain
 telem_blockgains         20920    telem_blockgains
 telem_offloading         20923    telem_offloading
+telem_w2tcsoffloader     20924    telem_w2tcsoffloader
 
 telem_pi335              20930    telem_pi335
 

--- a/libMagAOX/logger/types/schemas/telem_w2tcsoffloader.fbs
+++ b/libMagAOX/logger/types/schemas/telem_w2tcsoffloader.fbs
@@ -1,0 +1,8 @@
+namespace MagAOX.logger;
+
+table Telem_w2tcsoffloader_fb
+{
+   coeffs:[float];
+}
+
+root_type Telem_w2tcsoffloader_fb;

--- a/libMagAOX/logger/types/telem.cpp
+++ b/libMagAOX/logger/types/telem.cpp
@@ -28,6 +28,7 @@ timespec telem_fxngen::lastRecord = {0,0};
 timespec telem_loopgain::lastRecord = {0,0};
 timespec telem_observer::lastRecord = {0,0};
 timespec telem_offloading::lastRecord = {0,0};
+timespec telem_w2tcsoffloader::lastRecord = {0,0};
 timespec telem_pi335::lastRecord = {0,0};
 timespec telem_pico::lastRecord = {0,0};
 timespec telem_position::lastRecord = {0,0};
@@ -52,4 +53,3 @@ timespec telem_zaber::lastRecord = {0,0};
 
 } //namespace logger
 } //namespace MagAOX
-

--- a/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
+++ b/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
@@ -1,0 +1,121 @@
+/** \file telem_w2tcsoffloader.hpp
+ * \brief The MagAO-X logger telem_w2tcsoffloader log type.
+ *
+ * \ingroup logger_types_files
+ *
+ */
+#ifndef logger_types_telem_w2tcsoffloader_hpp
+#define logger_types_telem_w2tcsoffloader_hpp
+
+#include "generated/telem_w2tcsoffloader_generated.h"
+#include "flatbuffer_log.hpp"
+
+namespace MagAOX
+{
+namespace logger
+{
+
+/// Log entry recording the woofer-to-TCS Zernike coefficients.
+/** \ingroup logger_types
+ */
+struct telem_w2tcsoffloader : public flatbuffer_log
+{
+    /// The event code.
+    static const flatlogs::eventCodeT eventCode = eventCodes::TELEM_W2TCSOFFLOADER;
+
+    /// The default level.
+    static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
+
+    static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
+
+    /// The type of the input message.
+    struct messageT : public fbMessage
+    {
+        /// Construct from components.
+        explicit messageT( const std::vector<float> &coeffs /**< [in] the offloaded Zernike coefficients */ )
+        {
+            auto coeffVec = builder.CreateVector( coeffs );
+            auto fp       = CreateTelem_w2tcsoffloader_fb( builder, coeffVec );
+
+            builder.Finish( fp );
+        }
+    };
+
+    static bool verify( flatlogs::bufferPtrT &logBuff, ///< [in] Buffer containing the flatbuffer serialized message.
+                        flatlogs::msgLenT     len      ///< [in] length of msgBuffer.
+    )
+    {
+        auto verifier = flatbuffers::Verifier( static_cast<uint8_t *>( flatlogs::logHeader::messageBuffer( logBuff ) ),
+                                               static_cast<size_t>( len ) );
+        return VerifyTelem_w2tcsoffloader_fbBuffer( verifier );
+    }
+
+    /// Get the message formatted for human consumption.
+    static std::string msgString( void *msgBuffer, /**< [in] Buffer containing the flatbuffer serialized message. */
+                                  flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer. */
+    )
+    {
+        static_cast<void>( len );
+
+        auto fbs = GetTelem_w2tcsoffloader_fb( msgBuffer );
+
+        std::string msg = "[w2tcsoffloader coeffs] ";
+
+        if( fbs->coeffs() != nullptr )
+        {
+            for( flatbuffers::Vector<float>::const_iterator it = fbs->coeffs()->begin(); it != fbs->coeffs()->end();
+                 ++it )
+            {
+                msg += std::to_string( *it );
+                msg += " ";
+            }
+        }
+
+        return msg;
+    }
+
+    static std::vector<float> coeffs( void *msgBuffer )
+    {
+        std::vector<float> coeffVec;
+        auto               fbs = GetTelem_w2tcsoffloader_fb( msgBuffer );
+
+        if( fbs->coeffs() != nullptr )
+        {
+            for( flatbuffers::Vector<float>::const_iterator it = fbs->coeffs()->begin(); it != fbs->coeffs()->end();
+                 ++it )
+            {
+                coeffVec.push_back( *it );
+            }
+        }
+
+        return coeffVec;
+    }
+
+    /// Get the logMetaDetail for a member by name.
+    /**
+     * \returns a logMetaDetail filled in with the appropriate details
+     * \returns an empty logMetaDetail if member not recognized
+     */
+    static logMetaDetail getAccessor( const std::string &member /**< [in] the name of the member */ )
+    {
+        if( member == "coeffs" )
+        {
+            return logMetaDetail( { "COEFFS",
+                                    logMeta::valTypes::Vector_Float,
+                                    logMeta::metaTypes::Continuous,
+                                    reinterpret_cast<void *>( &coeffs ),
+                                    false } );
+        }
+        else
+        {
+            std::cerr << "No member " << member << " in telem_w2tcsoffloader\n";
+            return logMetaDetail();
+        }
+    }
+
+}; // struct telem_w2tcsoffloader
+
+} // namespace logger
+} // namespace MagAOX
+
+#endif // logger_types_telem_w2tcsoffloader_hpp

--- a/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
+++ b/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
@@ -15,7 +15,7 @@ namespace MagAOX
 namespace logger
 {
 
-/// Log entry recording the woofer-to-TCS Zernike coefficients.
+/// Log entry recording the woofer-to-TCS Zernike coefficient vector.
 /** \ingroup logger_types
  */
 struct telem_w2tcsoffloader : public flatbuffer_log

--- a/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
+++ b/libMagAOX/logger/types/telem_w2tcsoffloader.hpp
@@ -74,6 +74,7 @@ struct telem_w2tcsoffloader : public flatbuffer_log
         return msg;
     }
 
+    /// Recover the coefficient vector from a serialized message.
     static std::vector<float> coeffs( void *msgBuffer )
     {
         std::vector<float> coeffVec;


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to the prompt: "please see agents/plans/w2tcsoffloader-telem.md"

## Summary

This PR adds telemetry support to `w2tcsOffloader` for the calculated Zernike offload coefficients and records the associated engineering plan alongside the implementation.

## What Changed

- integrated `dev::telemeter` into `w2tcsOffloader`
- added a new logger type, `telem_w2tcsoffloader`, to record the coefficient vector
- updated `w2tcsOffloader` to:
  - maintain the computed coefficient vector in app state
  - publish INDI from that shared state
  - emit telemetry immediately on coefficient changes
  - continue emitting periodic telemetry through the telemeter max-interval path
- added startup guards so:
  - configured `m_nModes` is clamped to the number of available modes in the loaded FITS cube
  - the app logs `LOG_CRITICAL` and shuts down if the loaded cube contains more than 100 modes, since the current INDI element naming scheme only supports `00` through `99`
- replaced the deprecated `mx::ioutils::convertToString` usage with `std::format`
- updated the plan document to keep the engineering record aligned with the implementation
- followed up with documentation-only and formatting-only cleanup commits

## Verification

- regenerated logger outputs with the new schema
- built `w2tcsOffloader` successfully
- tested the telemetry path and startup guard behavior in the target environment

## Notes

- this PR intentionally keeps the existing two-digit INDI element naming convention
- supporting more than 100 modes in the future will require a coordinated naming-scheme change for downstream consumers
