### PR TITLE
Jrmales/tcsi telem always

### DIFF
--- a/agents/plans/tcsi-telemetry.md
+++ b/agents/plans/tcsi-telemetry.md
@@ -1,0 +1,227 @@
+Prompt: add telemetry to `tcsInterface` for the offloading control parameters `m_offlTT_enabled`, `m_offlTT_gain`, `m_offlTT_thresh`, and the corresponding focus parameters `m_offlF_enabled`, `m_offlF_gain`, `m_offlF_thresh`. Also add `labMode` as separate telemetry. Work on branch `jrmales/tcsi-telem-always`.
+
+## Analysis
+
+The `apps/tcsInterface` app already maintains all of the requested state in memory and exposes it through INDI properties:
+
+- `m_labMode`
+- `m_offlTT_enabled`
+- `m_offlTT_gain`
+- `m_offlTT_thresh`
+- `m_offlF_enabled`
+- `m_offlF_gain`
+- `m_offlF_thresh`
+
+What is missing is telemetry plumbing for those values.
+
+The existing `tcsInterface` telemeter interface only covers:
+
+- `telem_telpos`
+- `telem_teldata`
+- `telem_telvane`
+- `telem_telenv`
+- `telem_telcat`
+- `telem_telsee`
+
+So this work is not just a small change in `tcsInterface`. It also requires adding one or more logger telemetry types in `libMagAOX`, wiring them into the telemeter cadence, and emitting records when values change.
+
+## Design Choice
+
+The request calls for:
+
+- separate tip/tilt control telemetry
+- separate focus control telemetry
+- `labMode` as a separate telemetry record
+
+The implementation should therefore use three telemetry log types:
+
+1. one for tip/tilt offload control state
+2. one for focus offload control state
+3. one dedicated to `labMode`
+
+Recommended names:
+
+- `telem_tcsi_tiptilt`
+- `telem_tcsi_focus`
+- `telem_tcsi_labmode`
+
+Tip/tilt and focus should remain distinct log types because they are operationally different controls and are used differently downstream.
+
+To minimize duplicated logger code, the tip/tilt and focus log types can share:
+
+- the same underlying flatbuffer schema shape
+- the same helper or base-log implementation pattern
+
+This should follow the same general idea as paired logger types such as `text_log` and `user_log`: separate log identities and event codes, but shared structure where practical.
+
+`labMode` should remain its own log type because it is a separate application status rather than an offload-control parameter.
+
+## Scope
+
+### 1. Add logger types in `libMagAOX`
+
+Create new telemetry definitions for:
+
+- `telem_tcsi_tiptilt`
+- `telem_tcsi_focus`
+- `telem_tcsi_labmode`
+
+For each new telemetry type:
+
+- add a flatbuffer schema under `libMagAOX/logger/types/schemas`
+- add the corresponding logger type header under `libMagAOX/logger/types`
+- add the header to `libMagAOX/Makefile`
+- add a code entry to `libMagAOX/logger/logCodes.dat`
+- add a `lastRecord` initialization entry to `libMagAOX/logger/types/telem.cpp`
+
+The tip/tilt record should include:
+
+- `enabled`
+- `gain`
+- `thresh`
+
+The focus record should include:
+
+- `enabled`
+- `gain`
+- `thresh`
+
+The tip/tilt and focus payloads should share the same schema shape so the two log types can reuse the same underlying field layout and basic logger implementation.
+
+The lab-mode record should include:
+
+- `labMode`
+
+### 2. Extend `tcsInterface` telemeter declarations
+
+In `apps/tcsInterface/tcsInterface.hpp`:
+
+- add `recordTelem( const telem_tcsi_tiptilt * )`
+- add `recordTelem( const telem_tcsi_focus * )`
+- add `recordTelem( const telem_tcsi_labmode * )`
+- add helper functions to write the records, e.g.:
+  - `recordTcsiTipTilt( bool force = false )`
+  - `recordTcsiFocus( bool force = false )`
+  - `recordTcsiLabMode( bool force = false )`
+
+Update `checkRecordTimes()` so the new telemetry types participate in the normal telemetry cadence.
+
+This is important because MagAO-X telemetry should still be written on the configured interval even when values do not change.
+
+### 3. Emit telemetry on change
+
+Implement the new `record...()` helpers with the same pattern as the existing `recordTel...()` methods:
+
+- keep static last-recorded values
+- emit a telemetry record when any tracked value changes
+- also emit when `force == true`
+
+For tip/tilt control, track:
+
+- `m_offlTT_enabled`
+- `m_offlTT_gain`
+- `m_offlTT_thresh`
+
+For focus control, track:
+
+- `m_offlF_enabled`
+- `m_offlF_gain`
+- `m_offlF_thresh`
+
+For lab mode, track:
+
+- `m_labMode`
+
+### 4. Call record helpers at the right mutation points
+
+After the helper methods exist, add record calls where these values can change:
+
+- after config load establishes initial values
+- in the `m_indiP_labMode` callback
+- in the `m_indiP_offlTTenable` callback
+- in the `m_indiP_offlTTgain` callback
+- in the `m_indiP_offlTTthresh` callback
+- in the `m_indiP_offlFenable` callback
+- in the `m_indiP_offlFgain` callback
+- in the `m_indiP_offlFthresh` callback
+
+This ensures:
+
+- immediate telemetry on user-visible control changes
+- periodic telemetry through the telemeter framework
+
+No additional record calls are needed for:
+
+- `m_offlTT_dump`
+- `m_offlTT_avgInt`
+- `m_offlF_dump`
+- `m_offlF_avgInt`
+
+unless the requirements are later expanded.
+
+### 5. Keep changes minimal and style-consistent
+
+While touching `tcsInterface.hpp`:
+
+- preserve existing behavior
+- keep declaration ordering stable
+- add any required Doxygen comments to new declarations
+- follow existing naming conventions
+
+For the new logger headers:
+
+- include standard top-of-file Doxygen blocks
+- match existing logger type structure and accessor style
+
+## Verification Plan
+
+### 1. Build verification
+
+Rebuild the logger and app code paths affected by the new telemetry:
+
+- `libMagAOX`
+- `apps/tcsInterface`
+
+This confirms:
+
+- schema generation is correct
+- new log-code registration is valid
+- the new telemetry types are visible to the app
+
+### 2. Test coverage
+
+Update or add tests in `apps/tcsInterface/tests/tcsInterface_test.cpp` to cover at least:
+
+- `labMode` callback changes the internal state and can trigger telemetry recording path
+- offload TT enable/gain/thresh callbacks change the internal state cleanly
+- offload F enable/gain/thresh callbacks change the internal state cleanly
+
+If tip/tilt and focus are factored through a shared schema or common helper/base log, include at least a compile-level check that both `telem_tcsi_tiptilt` and `telem_tcsi_focus` instantiate and expose the correct accessors independently.
+
+If direct log-capture tests are too heavy for the current test harness, document that limitation and at minimum verify the record-helper methods compile and are callable through the telemeter interface.
+
+### 3. Runtime/manual verification
+
+Manual verification should confirm:
+
+1. `labMode` writes a telemetry record on startup and when toggled.
+2. TT offload telemetry writes on startup and whenever enable/gain/thresh changes.
+3. Focus offload telemetry writes on startup and whenever enable/gain/thresh changes.
+4. The telemeter interval still forces records even when values remain unchanged.
+
+## Execution Order
+
+1. Create branch `jrmales/tcsi-telem-always` if not already active.
+2. Add `libMagAOX` logger schemas and type headers.
+3. Register the new telemetry types in `logCodes.dat`, `telem.cpp`, and `libMagAOX/Makefile`.
+4. Extend `tcsInterface` telemeter declarations and implementations.
+5. Add change-triggered record calls in the relevant callbacks and startup/config paths.
+6. Update tests.
+7. Build and verify.
+
+## Risks and Notes
+
+- The main ambiguity is naming of the new telemetry types. The recommendation above uses `telem_tcsi_tiptilt`, `telem_tcsi_focus`, and `telem_tcsi_labmode` for clarity and to avoid colliding with existing generic telemetry names.
+- If the logger framework does not support literal inheritance between log-type structs cleanly, the practical fallback is to share the schema and duplicate only the thin type wrappers and event-code declarations.
+- Because `tcsInterface` is implemented largely in the header, the documentation pass should cover the full touched regions in that file, not only the inserted lines.
+- This plan intentionally keeps telemetry limited to the values explicitly requested and does not broaden scope to dump or averaging controls.

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -351,13 +351,23 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
      */
     void offloadThreadExec();
 
-    int doTToffload( float TT_0, float TT_1 );
+    /// Apply tip/tilt offload controls to an averaged request vector.
+    int doTToffload( float TT_0, /**< [in] averaged tip request */
+                     float TT_1  /**< [in] averaged tilt request */
+    );
 
-    int sendTToffload( float TT_0, float TT_1 );
+    /// Send a tip/tilt offload command to the selected target.
+    int sendTToffload( float TT_0, /**< [in] tip offload command */
+                       float TT_1  /**< [in] tilt offload command */
+    );
 
-    int doFoffload( float F_0 );
+    /// Apply focus offload controls to an averaged request value.
+    int doFoffload( float F_0 /**< [in] averaged focus request */
+    );
 
-    int sendFoffload( float F_0 );
+    /// Send a focus offload command to the telescope.
+    int sendFoffload( float F_0 /**< [in] focus offload command */
+    );
 
     pcf::IndiProperty
         m_indiP_offloadCoeffs; ///< Property used to report the latest woofer modal coefficients for offloading
@@ -370,11 +380,20 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
     /// Protects the offload request ring and its queue-state indices across producer and consumer threads.
     std::mutex m_offloadMutex;
 
+    /// Ring buffer of modal offload requests indexed by mode and request slot.
     std::vector<std::vector<float>> m_offloadRequests;
-    size_t                          m_firstRequest{ 0 };
-    size_t                          m_lastRequest{ std::numeric_limits<size_t>::max() };
-    size_t                          m_nRequests{ 0 };
-    size_t                          m_last_nRequests{ 0 };
+
+    /// Index of the oldest valid request in the offload ring.
+    size_t m_firstRequest{ 0 };
+
+    /// Index of the newest valid request in the offload ring.
+    size_t m_lastRequest{ std::numeric_limits<size_t>::max() };
+
+    /// Number of valid requests currently stored in the offload ring.
+    size_t m_nRequests{ 0 };
+
+    /// Request count last processed by the offload thread.
+    size_t m_last_nRequests{ 0 };
 
     // The TT control matrix -- LAb
     float m_lab_offlTT_C_00{ 0.17 };

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -52,6 +52,7 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
      * @{
      */
 
+    /// Tracks whether the app is operating in lab mode rather than on-sky mode.
     bool m_labMode{ true };
 
     pcf::IndiProperty m_indiP_labMode;
@@ -228,31 +229,62 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
     /** \name Telemeter Interface
      * @{
      */
+    /// Check whether any telemetry records are due.
     int checkRecordTimes();
 
+    /// Record telescope-position telemetry on a forced telemeter update.
     int recordTelem( const telem_telpos * );
 
+    /// Record telescope-status telemetry on a forced telemeter update.
     int recordTelem( const telem_teldata * );
 
+    /// Record vane-position telemetry on a forced telemeter update.
     int recordTelem( const telem_telvane * );
 
+    /// Record telescope-environment telemetry on a forced telemeter update.
     int recordTelem( const telem_telenv * );
 
+    /// Record catalog telemetry on a forced telemeter update.
     int recordTelem( const telem_telcat * );
 
+    /// Record seeing telemetry on a forced telemeter update.
     int recordTelem( const telem_telsee * );
 
+    /// Record tip/tilt offload-control telemetry on a forced telemeter update.
+    int recordTelem( const telem_tcsi_tiptilt * );
+
+    /// Record focus offload-control telemetry on a forced telemeter update.
+    int recordTelem( const telem_tcsi_focus * );
+
+    /// Record lab-mode telemetry on a forced telemeter update.
+    int recordTelem( const telem_tcsi_labmode * );
+
+    /// Record telescope-position telemetry when values change.
     int recordTelPos( bool force = false );
 
+    /// Record telescope-status telemetry when values change.
     int recordTelData( bool force = false );
 
+    /// Record vane-position telemetry when values change.
     int recordTelVane( bool force = false );
 
+    /// Record telescope-environment telemetry when values change.
     int recordTelEnv( bool force = false );
 
+    /// Record catalog telemetry when values change.
     int recordTelCat( bool force = false );
 
+    /// Record seeing telemetry when values change.
     int recordTelSee( bool force = false );
+
+    /// Record tip/tilt offload-control telemetry when values change.
+    int recordTcsiTipTilt( bool force = false );
+
+    /// Record focus offload-control telemetry when values change.
+    int recordTcsiFocus( bool force = false );
+
+    /// Record lab-mode telemetry when values change.
+    int recordTcsiLabMode( bool force = false );
 
     ///@}
 
@@ -348,10 +380,14 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
     float m_offlTT_C_10{ 0 };
     float m_offlTT_C_11{ -0.25 };
 
-    bool  m_offlTT_enabled{ false };
-    bool  m_offlTT_dump{ false };
+    /// Tracks whether tip/tilt offloading is currently enabled.
+    bool m_offlTT_enabled{ false };
+    bool m_offlTT_dump{ false };
+    /// The number of recent requests included in each tip/tilt offload average.
     float m_offlTT_avgInt{ 1.0 };
+    /// The operator-set gain applied to tip/tilt offload requests.
     float m_offlTT_gain{ 0.1 };
+    /// The deadband threshold applied to tip/tilt offload requests.
     float m_offlTT_thresh{ 0.1 };
 
     pcf::IndiProperty m_indiP_offlTTenable;
@@ -372,10 +408,14 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
     // The Focus control constant
     float m_offlCFocus_00{ 1 };
 
-    bool  m_offlF_enabled{ false };
-    bool  m_offlF_dump{ false };
+    /// Tracks whether focus offloading is currently enabled.
+    bool m_offlF_enabled{ false };
+    bool m_offlF_dump{ false };
+    /// The number of recent requests included in each focus offload average.
     float m_offlF_avgInt{ 1.0 };
+    /// The operator-set gain applied to focus offload requests.
     float m_offlF_gain{ 0.1 };
+    /// The deadband threshold applied to focus offload requests.
     float m_offlF_thresh{ 0.1 };
 
     pcf::IndiProperty m_indiP_offlFenable;
@@ -1183,6 +1223,10 @@ inline int tcsInterface::appStartup()
 
     // Register to receive the coeff updates from Kyle
     REG_INDI_SETPROP( m_indiP_offloadCoeffs, "w2tcsOffloader", "zCoeffs" );
+
+    recordTcsiTipTilt( true );
+    recordTcsiFocus( true );
+    recordTcsiLabMode( true );
 
     state( stateCodes::NOTCONNECTED );
 
@@ -2536,8 +2580,15 @@ inline int tcsInterface::updateINDI()
 
 inline int tcsInterface::checkRecordTimes()
 {
-    return telemeter<tcsInterface>::checkRecordTimes(
-        telem_telpos(), telem_teldata(), telem_telvane(), telem_telenv(), telem_telcat(), telem_telsee() );
+    return telemeter<tcsInterface>::checkRecordTimes( telem_telpos(),
+                                                      telem_teldata(),
+                                                      telem_telvane(),
+                                                      telem_telenv(),
+                                                      telem_telcat(),
+                                                      telem_telsee(),
+                                                      telem_tcsi_tiptilt(),
+                                                      telem_tcsi_focus(),
+                                                      telem_tcsi_labmode() );
 }
 
 inline int tcsInterface::recordTelem( const telem_telpos * )
@@ -2573,6 +2624,24 @@ inline int tcsInterface::recordTelem( const telem_telcat * )
 inline int tcsInterface::recordTelem( const telem_telsee * )
 {
     recordTelSee( true );
+    return 0;
+}
+
+inline int tcsInterface::recordTelem( const telem_tcsi_tiptilt * )
+{
+    recordTcsiTipTilt( true );
+    return 0;
+}
+
+inline int tcsInterface::recordTelem( const telem_tcsi_focus * )
+{
+    recordTcsiFocus( true );
+    return 0;
+}
+
+inline int tcsInterface::recordTelem( const telem_tcsi_labmode * )
+{
+    recordTcsiLabMode( true );
     return 0;
 }
 
@@ -2784,6 +2853,62 @@ inline int tcsInterface::recordTelSee( bool force )
 
         last_mag2_time      = m_mag2_time;
         last_mag2_fwhm_corr = m_mag2_fwhm_corr;
+    }
+
+    return 0;
+}
+
+inline int tcsInterface::recordTcsiTipTilt( bool force )
+{
+    static bool  lastEnabled = !m_offlTT_enabled;
+    static float lastAvgInt  = std::numeric_limits<float>::quiet_NaN();
+    static float lastGain    = std::numeric_limits<float>::quiet_NaN();
+    static float lastThresh  = std::numeric_limits<float>::quiet_NaN();
+
+    if( force || lastEnabled != m_offlTT_enabled || lastAvgInt != m_offlTT_avgInt || lastGain != m_offlTT_gain ||
+        lastThresh != m_offlTT_thresh )
+    {
+        telem<telem_tcsi_tiptilt>( { m_offlTT_enabled, m_offlTT_avgInt, m_offlTT_gain, m_offlTT_thresh } );
+
+        lastEnabled = m_offlTT_enabled;
+        lastAvgInt  = m_offlTT_avgInt;
+        lastGain    = m_offlTT_gain;
+        lastThresh  = m_offlTT_thresh;
+    }
+
+    return 0;
+}
+
+inline int tcsInterface::recordTcsiFocus( bool force )
+{
+    static bool  lastEnabled = !m_offlF_enabled;
+    static float lastAvgInt  = std::numeric_limits<float>::quiet_NaN();
+    static float lastGain    = std::numeric_limits<float>::quiet_NaN();
+    static float lastThresh  = std::numeric_limits<float>::quiet_NaN();
+
+    if( force || lastEnabled != m_offlF_enabled || lastAvgInt != m_offlF_avgInt || lastGain != m_offlF_gain ||
+        lastThresh != m_offlF_thresh )
+    {
+        telem<telem_tcsi_focus>( { m_offlF_enabled, m_offlF_avgInt, m_offlF_gain, m_offlF_thresh } );
+
+        lastEnabled = m_offlF_enabled;
+        lastAvgInt  = m_offlF_avgInt;
+        lastGain    = m_offlF_gain;
+        lastThresh  = m_offlF_thresh;
+    }
+
+    return 0;
+}
+
+inline int tcsInterface::recordTcsiLabMode( bool force )
+{
+    static bool lastLabMode = !m_labMode;
+
+    if( force || lastLabMode != m_labMode )
+    {
+        telem<telem_tcsi_labmode>( { m_labMode } );
+
+        lastLabMode = m_labMode;
     }
 
     return 0;
@@ -3144,6 +3269,8 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_labMode )( const pcf::IndiProperty 
         updateSwitchIfChanged( m_indiP_labMode, "toggle", pcf::IndiElement::Off, INDI_OK );
     }
 
+    recordTcsiLabMode();
+
     return 0;
 }
 
@@ -3276,12 +3403,14 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTenable )( const pcf::IndiProp
         updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::On, INDI_OK );
 
         m_offlTT_enabled = true;
+        recordTcsiTipTilt();
     }
     else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off && m_offlTT_enabled == true )
     {
         updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
 
         m_offlTT_enabled = false;
+        recordTcsiTipTilt();
     }
 
     return 0;
@@ -3317,6 +3446,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTavgInt )( const pcf::IndiProp
     }
 
     m_offlTT_avgInt = target;
+    recordTcsiTipTilt();
 
     return 0;
 }
@@ -3334,6 +3464,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTgain )( const pcf::IndiProper
     }
 
     m_offlTT_gain = target;
+    recordTcsiTipTilt();
 
     return 0;
 }
@@ -3351,6 +3482,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTthresh )( const pcf::IndiProp
     }
 
     m_offlTT_thresh = target;
+    recordTcsiTipTilt();
 
     return 0;
 }
@@ -3367,12 +3499,14 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFenable )( const pcf::IndiPrope
         updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::On, INDI_OK );
 
         m_offlF_enabled = true;
+        recordTcsiFocus();
     }
     else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off && m_offlF_enabled == true )
     {
         updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
 
         m_offlF_enabled = false;
+        recordTcsiFocus();
     }
 
     return 0;
@@ -3408,6 +3542,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFavgInt )( const pcf::IndiPrope
     }
 
     m_offlF_avgInt = target;
+    recordTcsiFocus();
 
     return 0;
 }
@@ -3425,6 +3560,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFgain )( const pcf::IndiPropert
     }
 
     m_offlF_gain = target;
+    recordTcsiFocus();
 
     return 0;
 }
@@ -3444,6 +3580,7 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFthresh )( const pcf::IndiPrope
     }
 
     m_offlF_thresh = target;
+    recordTcsiFocus();
 
     return 0;
 }

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -7,6 +7,7 @@
 #ifndef tcsInterface_hpp
 #define tcsInterface_hpp
 
+#include <atomic>
 #include <cmath>
 #include <iostream>
 
@@ -288,7 +289,8 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
 
     ///@}
 
-    int               m_loopState{ 0 };
+    /// Tracks the current loop state shared between the INDI callback and the offload thread.
+    std::atomic<int>  m_loopState{ 0 };
     pcf::IndiProperty m_indiP_loopState; ///< Property used to report the loop state
 
     INDI_SETCALLBACK_DECL( tcsInterface, m_indiP_loopState );
@@ -3017,11 +3019,13 @@ void tcsInterface::offloadThreadExec()
 
     while( shutdown() == 0 )
     {
+        int loopState = m_loopState.load();
+
         // Check if loop open
-        if( m_loopState == 0 )
+        if( loopState == 0 )
         {
             // If this is new, then reset the averaging buffer
-            if( m_loopState != last_loopState )
+            if( loopState != last_loopState )
             {
                 { // mutex scope
                     std::lock_guard<std::mutex> lock( m_offloadMutex );
@@ -3034,20 +3038,20 @@ void tcsInterface::offloadThreadExec()
                 sincelast_F  = 0;
             }
             sleep( 1 );
-            last_loopState = m_loopState;
+            last_loopState = loopState;
             continue;
         }
 
         // Check if loop paused
-        if( m_loopState == 1 )
+        if( loopState == 1 )
         {
-            if( m_loopState != last_loopState )
+            if( loopState != last_loopState )
             {
                 sincelast_TT = 0;
                 sincelast_F  = 0;
             }
             sleep( 1 );
-            last_loopState = m_loopState;
+            last_loopState = loopState;
             continue;
         }
 
@@ -3135,7 +3139,7 @@ void tcsInterface::offloadThreadExec()
                 sincelast_F = 0;
             }
         }
-        last_loopState = m_loopState;
+        last_loopState = loopState;
 
         sleep( 1 );
     }
@@ -3347,11 +3351,11 @@ INDI_SETCALLBACK_DEFN( tcsInterface, m_indiP_loopState )( const pcf::IndiPropert
 
     if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
     {
-        m_loopState = 2;
+        m_loopState.store( 2 );
     }
     else
     {
-        m_loopState = 0;
+        m_loopState.store( 0 );
     }
 
     return 0;
@@ -3361,7 +3365,7 @@ INDI_SETCALLBACK_DEFN( tcsInterface, m_indiP_offloadCoeffs )( const pcf::IndiPro
 {
     INDI_VALIDATE_CALLBACK_PROPS( m_indiP_offloadCoeffs, ipRecv );
 
-    if( m_loopState != 2 )
+    if( m_loopState.load() != 2 )
         return 0;
 
     { // mutex scope

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -3076,7 +3076,7 @@ void tcsInterface::offloadThreadExec()
             avg_TT_1 /= navg;
 
             ++sincelast_TT;
-            if( sincelast_TT > m_offlTT_avgInt )
+            if( sincelast_TT >= m_offlTT_avgInt )
             {
                 doTToffload( avg_TT_0, avg_TT_1 );
                 sincelast_TT = 0;
@@ -3106,7 +3106,7 @@ void tcsInterface::offloadThreadExec()
             avg_F_0 /= navg;
 
             ++sincelast_F;
-            if( sincelast_F > m_offlF_avgInt )
+            if( sincelast_F >= m_offlF_avgInt )
             {
                 doFoffload( avg_F_0 );
                 sincelast_F = 0;

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -362,6 +362,9 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
 
     INDI_SETCALLBACK_DECL( tcsInterface, m_indiP_offloadCoeffs );
 
+    /// Protects the offload request ring and its queue-state indices across producer and consumer threads.
+    std::mutex m_offloadMutex;
+
     std::vector<std::vector<float>> m_offloadRequests;
     size_t                          m_firstRequest{ 0 };
     size_t                          m_lastRequest{ std::numeric_limits<size_t>::max() };
@@ -3020,12 +3023,15 @@ void tcsInterface::offloadThreadExec()
             // If this is new, then reset the averaging buffer
             if( m_loopState != last_loopState )
             {
-                m_firstRequest   = 0;
-                m_lastRequest    = std::numeric_limits<size_t>::max();
-                m_nRequests      = 0;
-                m_last_nRequests = 0;
-                sincelast_TT     = 0;
-                sincelast_F      = 0;
+                { // mutex scope
+                    std::lock_guard<std::mutex> lock( m_offloadMutex );
+                    m_firstRequest   = 0;
+                    m_lastRequest    = std::numeric_limits<size_t>::max();
+                    m_nRequests      = 0;
+                    m_last_nRequests = 0;
+                }
+                sincelast_TT = 0;
+                sincelast_F  = 0;
             }
             sleep( 1 );
             last_loopState = m_loopState;
@@ -3047,40 +3053,73 @@ void tcsInterface::offloadThreadExec()
 
         // Ok loop closed
 
-        if( m_nRequests == 0 )
-            continue; // this really should mutexed instead
+        bool haveNewRequests = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadMutex );
+            haveNewRequests = ( m_nRequests > 0 && m_last_nRequests != m_nRequests );
+        }
 
         // If we got a new offload request, process it
-        if( m_last_nRequests != m_nRequests )
+        if( haveNewRequests )
         {
             // std::cerr << m_firstRequest << " " << m_lastRequest << " " << m_nRequests << std::endl;
 
             ///\todo offloading: These sections ought to be separate functions for clarity
-            /* --- TT --- */
-            avg_TT_0 = 0;
-            avg_TT_1 = 0;
+            { // mutex scope
+                std::lock_guard<std::mutex> lock( m_offloadMutex );
 
-            int navg = 0;
+                /* --- TT --- */
+                avg_TT_0 = 0;
+                avg_TT_1 = 0;
 
-            size_t i = m_lastRequest;
+                int navg = 0;
 
-            for( size_t n = 0; n < m_offlTT_avgInt; ++n )
-            {
-                avg_TT_0 += m_offloadRequests[0][i];
-                avg_TT_1 += m_offloadRequests[1][i];
-                ++navg;
+                size_t i = m_lastRequest;
 
-                if( i == m_firstRequest )
-                    break;
+                for( size_t n = 0; n < m_offlTT_avgInt; ++n )
+                {
+                    avg_TT_0 += m_offloadRequests[0][i];
+                    avg_TT_1 += m_offloadRequests[1][i];
+                    ++navg;
 
-                if( i == 0 )
-                    i = m_offloadRequests[0].size() - 1;
-                else
-                    --i;
+                    if( i == m_firstRequest )
+                        break;
+
+                    if( i == 0 )
+                        i = m_offloadRequests[0].size() - 1;
+                    else
+                        --i;
+                }
+
+                avg_TT_0 /= navg;
+                avg_TT_1 /= navg;
+
+                /* --- Focus --- */
+                avg_F_0 = 0;
+
+                navg = 0;
+
+                i = m_lastRequest;
+
+                for( size_t n = 0; n < m_offlF_avgInt; ++n )
+                {
+                    avg_F_0 += m_offloadRequests[2][i];
+                    ++navg;
+
+                    if( i == m_firstRequest )
+                        break;
+
+                    if( i == 0 )
+                        i = m_offloadRequests[0].size() - 1;
+                    else
+                        --i;
+                }
+
+                avg_F_0 /= navg;
+
+                m_last_nRequests = m_nRequests;
             }
-
-            avg_TT_0 /= navg;
-            avg_TT_1 /= navg;
 
             ++sincelast_TT;
             if( sincelast_TT >= m_offlTT_avgInt )
@@ -3089,37 +3128,12 @@ void tcsInterface::offloadThreadExec()
                 sincelast_TT = 0;
             }
 
-            /* --- Focus --- */
-            avg_F_0 = 0;
-
-            navg = 0;
-
-            i = m_lastRequest;
-
-            for( size_t n = 0; n < m_offlF_avgInt; ++n )
-            {
-                avg_F_0 += m_offloadRequests[2][i];
-                ++navg;
-
-                if( i == m_firstRequest )
-                    break;
-
-                if( i == 0 )
-                    i = m_offloadRequests[0].size() - 1;
-                else
-                    --i;
-            }
-
-            avg_F_0 /= navg;
-
             ++sincelast_F;
             if( sincelast_F >= m_offlF_avgInt )
             {
                 doFoffload( avg_F_0 );
                 sincelast_F = 0;
             }
-
-            m_last_nRequests = m_nRequests;
         }
         last_loopState = m_loopState;
 
@@ -3350,45 +3364,49 @@ INDI_SETCALLBACK_DEFN( tcsInterface, m_indiP_offloadCoeffs )( const pcf::IndiPro
     if( m_loopState != 2 )
         return 0;
 
-    size_t nextReq = m_lastRequest + 1;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadMutex );
 
-    if( nextReq >= m_offloadRequests[0].size() )
-        nextReq = 0;
+        size_t nextReq = m_lastRequest + 1;
 
-    // Tip-Tilt
-    float tt0 = ipRecv["00"].get<float>();
-    float tt1 = ipRecv["01"].get<float>();
+        if( nextReq >= m_offloadRequests[0].size() )
+            nextReq = 0;
 
-    if( m_labMode )
-    {
-        m_offloadRequests[0][nextReq] = m_lab_offlTT_C_00 * tt0 + m_lab_offlTT_C_01 * tt1;
-        m_offloadRequests[1][nextReq] = m_lab_offlTT_C_10 * tt0 + m_lab_offlTT_C_11 * tt1;
+        // Tip-Tilt
+        float tt0 = ipRecv["00"].get<float>();
+        float tt1 = ipRecv["01"].get<float>();
+
+        if( m_labMode )
+        {
+            m_offloadRequests[0][nextReq] = m_lab_offlTT_C_00 * tt0 + m_lab_offlTT_C_01 * tt1;
+            m_offloadRequests[1][nextReq] = m_lab_offlTT_C_10 * tt0 + m_lab_offlTT_C_11 * tt1;
+        }
+        else
+        {
+            m_offloadRequests[0][nextReq] = m_offlTT_C_00 * tt0 + m_offlTT_C_01 * tt1;
+            m_offloadRequests[1][nextReq] = m_offlTT_C_10 * tt0 + m_offlTT_C_11 * tt1;
+        }
+
+        // Focus
+        float f0 = ipRecv["02"].get<float>();
+
+        m_offloadRequests[2][nextReq] = m_offlCFocus_00 * f0;
+
+        // Coma
+        float c0 = ipRecv["03"].get<float>();
+        float c1 = ipRecv["04"].get<float>();
+
+        m_offloadRequests[3][nextReq] = m_offlCComa_00 * c0 + m_offlCComa_01 * c1;
+        m_offloadRequests[4][nextReq] = m_offlCComa_10 * c0 + m_offlCComa_11 * c1;
+
+        // Now update circ buffer
+        m_lastRequest = nextReq;
+        ++m_nRequests;
+        if( m_nRequests > m_offloadRequests[0].size() )
+            ++m_firstRequest;
+        if( m_firstRequest >= m_offloadRequests[0].size() )
+            m_firstRequest = 0;
     }
-    else
-    {
-        m_offloadRequests[0][nextReq] = m_offlTT_C_00 * tt0 + m_offlTT_C_01 * tt1;
-        m_offloadRequests[1][nextReq] = m_offlTT_C_10 * tt0 + m_offlTT_C_11 * tt1;
-    }
-
-    // Focus
-    float f0 = ipRecv["02"].get<float>();
-
-    m_offloadRequests[2][nextReq] = m_offlCFocus_00 * f0;
-
-    // Coma
-    float c0 = ipRecv["03"].get<float>();
-    float c1 = ipRecv["04"].get<float>();
-
-    m_offloadRequests[3][nextReq] = m_offlCComa_00 * c0 + m_offlCComa_01 * c1;
-    m_offloadRequests[4][nextReq] = m_offlCComa_10 * c0 + m_offlCComa_11 * c1;
-
-    // Now update circ buffer
-    m_lastRequest = nextReq;
-    ++m_nRequests;
-    if( m_nRequests > m_offloadRequests[0].size() )
-        ++m_firstRequest;
-    if( m_firstRequest >= m_offloadRequests[0].size() )
-        m_firstRequest = 0;
     return 0;
 }
 

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -836,8 +836,27 @@ inline void tcsInterface::loadConfig()
 
 inline int tcsInterface::appStartup()
 {
+    bool  labMode;
+    float offlTTAvgInt;
+    float offlTTGain;
+    float offlTTThresh;
+    float offlFAvgInt;
+    float offlFGain;
+    float offlFThresh;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        labMode      = m_labMode;
+        offlTTAvgInt = m_offlTT_avgInt;
+        offlTTGain   = m_offlTT_gain;
+        offlTTThresh = m_offlTT_thresh;
+        offlFAvgInt  = m_offlF_avgInt;
+        offlFGain    = m_offlF_gain;
+        offlFThresh  = m_offlF_thresh;
+    }
+
     CREATE_REG_INDI_NEW_TOGGLESWITCH( m_indiP_labMode, "labMode" );
-    if( m_labMode )
+    if( labMode )
     {
         m_indiP_labMode["toggle"].setSwitchState( pcf::IndiElement::On );
         log<text_log>( "lab mode ON", logPrio::LOG_NOTICE );
@@ -1141,8 +1160,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlTTavgInt, "offlTT_avgInt", 0, 3600, 1, "%d" );
-    m_indiP_offlTTavgInt["current"].set( m_offlTT_avgInt );
-    m_indiP_offlTTavgInt["target"].set( m_offlTT_avgInt );
+    m_indiP_offlTTavgInt["current"].set( offlTTAvgInt );
+    m_indiP_offlTTavgInt["target"].set( offlTTAvgInt );
     if( registerIndiPropertyNew( m_indiP_offlTTavgInt, st_newCallBack_m_indiP_offlTTavgInt ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -1150,8 +1169,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlTTgain, "offlTT_gain", 0.0, 1.0, 0.0, "%0.2f" );
-    m_indiP_offlTTgain["current"].set( m_offlTT_gain );
-    m_indiP_offlTTgain["target"].set( m_offlTT_gain );
+    m_indiP_offlTTgain["current"].set( offlTTGain );
+    m_indiP_offlTTgain["target"].set( offlTTGain );
     if( registerIndiPropertyNew( m_indiP_offlTTgain, st_newCallBack_m_indiP_offlTTgain ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -1159,8 +1178,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlTTthresh, "offlTT_thresh", 0.0, 1.0, 0.0, "%0.2f" );
-    m_indiP_offlTTthresh["current"].set( m_offlTT_thresh );
-    m_indiP_offlTTthresh["target"].set( m_offlTT_thresh );
+    m_indiP_offlTTthresh["current"].set( offlTTThresh );
+    m_indiP_offlTTthresh["target"].set( offlTTThresh );
     if( registerIndiPropertyNew( m_indiP_offlTTthresh, st_newCallBack_m_indiP_offlTTthresh ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -1182,8 +1201,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlFavgInt, "offlF_avgInt", 0, 3600, 1, "%d" );
-    m_indiP_offlFavgInt["current"].set( m_offlF_avgInt );
-    m_indiP_offlFavgInt["target"].set( m_offlF_avgInt );
+    m_indiP_offlFavgInt["current"].set( offlFAvgInt );
+    m_indiP_offlFavgInt["target"].set( offlFAvgInt );
     if( registerIndiPropertyNew( m_indiP_offlFavgInt, st_newCallBack_m_indiP_offlFavgInt ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -1191,8 +1210,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlFgain, "offlF_gain", 0.0, 1.0, 0.0, "%0.2f" );
-    m_indiP_offlFgain["current"].set( m_offlF_gain );
-    m_indiP_offlFgain["target"].set( m_offlF_gain );
+    m_indiP_offlFgain["current"].set( offlFGain );
+    m_indiP_offlFgain["target"].set( offlFGain );
     if( registerIndiPropertyNew( m_indiP_offlFgain, st_newCallBack_m_indiP_offlFgain ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -1200,8 +1219,8 @@ inline int tcsInterface::appStartup()
     }
 
     createStandardIndiNumber( m_indiP_offlFthresh, "offlF_thresh", 0.0, 1.0, 0.0, "%0.2f" );
-    m_indiP_offlFthresh["current"].set( m_offlF_thresh );
-    m_indiP_offlFthresh["target"].set( m_offlF_thresh );
+    m_indiP_offlFthresh["current"].set( offlFThresh );
+    m_indiP_offlFthresh["target"].set( offlFThresh );
     if( registerIndiPropertyNew( m_indiP_offlFthresh, st_newCallBack_m_indiP_offlFthresh ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
@@ -2523,9 +2542,34 @@ inline int tcsInterface::updateINDI()
 
     //--- Offloading ---//
 
+    bool  offlTTDump;
+    bool  offlTTEnabled;
+    float offlTTAvgInt;
+    float offlTTGain;
+    float offlTTThresh;
+    bool  offlFDump;
+    bool  offlFEnabled;
+    float offlFAvgInt;
+    float offlFGain;
+    float offlFThresh;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        offlTTDump    = m_offlTT_dump;
+        offlTTEnabled = m_offlTT_enabled;
+        offlTTAvgInt  = m_offlTT_avgInt;
+        offlTTGain    = m_offlTT_gain;
+        offlTTThresh  = m_offlTT_thresh;
+        offlFDump     = m_offlF_dump;
+        offlFEnabled  = m_offlF_enabled;
+        offlFAvgInt   = m_offlF_avgInt;
+        offlFGain     = m_offlF_gain;
+        offlFThresh   = m_offlF_thresh;
+    }
+
     try
     {
-        if( m_offlTT_dump )
+        if( offlTTDump )
         {
             updateSwitchIfChanged( m_indiP_offlTTdump, "request", pcf::IndiElement::On, INDI_OK );
         }
@@ -2534,7 +2578,7 @@ inline int tcsInterface::updateINDI()
             updateSwitchIfChanged( m_indiP_offlTTdump, "request", pcf::IndiElement::Off, INDI_IDLE );
         }
 
-        if( m_offlTT_enabled )
+        if( offlTTEnabled )
         {
             updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::On, INDI_OK );
         }
@@ -2543,9 +2587,9 @@ inline int tcsInterface::updateINDI()
             updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
         }
 
-        updateIfChanged( m_indiP_offlTTavgInt, "current", m_offlTT_avgInt );
-        updateIfChanged( m_indiP_offlTTgain, "current", m_offlTT_gain );
-        updateIfChanged( m_indiP_offlTTthresh, "current", m_offlTT_thresh );
+        updateIfChanged( m_indiP_offlTTavgInt, "current", offlTTAvgInt );
+        updateIfChanged( m_indiP_offlTTgain, "current", offlTTGain );
+        updateIfChanged( m_indiP_offlTTthresh, "current", offlTTThresh );
     }
     catch( ... )
     {
@@ -2555,7 +2599,7 @@ inline int tcsInterface::updateINDI()
 
     try
     {
-        if( m_offlF_dump )
+        if( offlFDump )
         {
             updateSwitchIfChanged( m_indiP_offlFdump, "request", pcf::IndiElement::On, INDI_OK );
         }
@@ -2564,7 +2608,7 @@ inline int tcsInterface::updateINDI()
             updateSwitchIfChanged( m_indiP_offlFdump, "request", pcf::IndiElement::Off, INDI_IDLE );
         }
 
-        if( m_offlF_enabled )
+        if( offlFEnabled )
         {
             updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::On, INDI_OK );
         }
@@ -2573,9 +2617,9 @@ inline int tcsInterface::updateINDI()
             updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
         }
 
-        updateIfChanged( m_indiP_offlFavgInt, "current", m_offlF_avgInt );
-        updateIfChanged( m_indiP_offlFgain, "current", m_offlF_gain );
-        updateIfChanged( m_indiP_offlFthresh, "current", m_offlF_thresh );
+        updateIfChanged( m_indiP_offlFavgInt, "current", offlFAvgInt );
+        updateIfChanged( m_indiP_offlFgain, "current", offlFGain );
+        updateIfChanged( m_indiP_offlFthresh, "current", offlFThresh );
     }
     catch( ... )
     {

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -1603,7 +1603,7 @@ inline int tcsInterface::getTelTime()
     if( pdat.size() != 3 )
     {
         state( stateCodes::ERROR );
-        log<text_log>( "Error getting telescope position (datetime): TCS response wrong size, returned " +
+        log<text_log>( "Error getting telescope time (datetime): TCS response wrong size, returned " +
                            std::to_string( pdat.size() ) + " values",
                        logPrio::LOG_WARNING );
         return -1;

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -3024,6 +3024,8 @@ void tcsInterface::offloadThreadExec()
                 m_lastRequest    = std::numeric_limits<size_t>::max();
                 m_nRequests      = 0;
                 m_last_nRequests = 0;
+                sincelast_TT     = 0;
+                sincelast_F      = 0;
             }
             sleep( 1 );
             last_loopState = m_loopState;
@@ -3033,6 +3035,11 @@ void tcsInterface::offloadThreadExec()
         // Check if loop paused
         if( m_loopState == 1 )
         {
+            if( m_loopState != last_loopState )
+            {
+                sincelast_TT = 0;
+                sincelast_F  = 0;
+            }
             sleep( 1 );
             last_loopState = m_loopState;
             continue;
@@ -3040,7 +3047,7 @@ void tcsInterface::offloadThreadExec()
 
         // Ok loop closed
 
-        if( m_firstRequest == m_lastRequest )
+        if( m_nRequests == 0 )
             continue; // this really should mutexed instead
 
         // If we got a new offload request, process it

--- a/apps/tcsInterface/tcsInterface.hpp
+++ b/apps/tcsInterface/tcsInterface.hpp
@@ -364,6 +364,9 @@ class tcsInterface : public MagAOXApp<true>, public dev::ioDevice, public dev::t
 
     INDI_SETCALLBACK_DECL( tcsInterface, m_indiP_offloadCoeffs );
 
+    /// Protects shared offload control parameters accessed by callbacks and the offload thread.
+    std::mutex m_offloadCtrlMutex;
+
     /// Protects the offload request ring and its queue-state indices across producer and consumer threads.
     std::mutex m_offloadMutex;
 
@@ -2865,20 +2868,32 @@ inline int tcsInterface::recordTelSee( bool force )
 
 inline int tcsInterface::recordTcsiTipTilt( bool force )
 {
-    static bool  lastEnabled = !m_offlTT_enabled;
+    bool  enabled;
+    float avgInt;
+    float gain;
+    float thresh;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        enabled = m_offlTT_enabled;
+        avgInt  = m_offlTT_avgInt;
+        gain    = m_offlTT_gain;
+        thresh  = m_offlTT_thresh;
+    }
+
+    static bool  lastEnabled = !enabled;
     static float lastAvgInt  = std::numeric_limits<float>::quiet_NaN();
     static float lastGain    = std::numeric_limits<float>::quiet_NaN();
     static float lastThresh  = std::numeric_limits<float>::quiet_NaN();
 
-    if( force || lastEnabled != m_offlTT_enabled || lastAvgInt != m_offlTT_avgInt || lastGain != m_offlTT_gain ||
-        lastThresh != m_offlTT_thresh )
+    if( force || lastEnabled != enabled || lastAvgInt != avgInt || lastGain != gain || lastThresh != thresh )
     {
-        telem<telem_tcsi_tiptilt>( { m_offlTT_enabled, m_offlTT_avgInt, m_offlTT_gain, m_offlTT_thresh } );
+        telem<telem_tcsi_tiptilt>( { enabled, avgInt, gain, thresh } );
 
-        lastEnabled = m_offlTT_enabled;
-        lastAvgInt  = m_offlTT_avgInt;
-        lastGain    = m_offlTT_gain;
-        lastThresh  = m_offlTT_thresh;
+        lastEnabled = enabled;
+        lastAvgInt  = avgInt;
+        lastGain    = gain;
+        lastThresh  = thresh;
     }
 
     return 0;
@@ -2886,20 +2901,32 @@ inline int tcsInterface::recordTcsiTipTilt( bool force )
 
 inline int tcsInterface::recordTcsiFocus( bool force )
 {
-    static bool  lastEnabled = !m_offlF_enabled;
+    bool  enabled;
+    float avgInt;
+    float gain;
+    float thresh;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        enabled = m_offlF_enabled;
+        avgInt  = m_offlF_avgInt;
+        gain    = m_offlF_gain;
+        thresh  = m_offlF_thresh;
+    }
+
+    static bool  lastEnabled = !enabled;
     static float lastAvgInt  = std::numeric_limits<float>::quiet_NaN();
     static float lastGain    = std::numeric_limits<float>::quiet_NaN();
     static float lastThresh  = std::numeric_limits<float>::quiet_NaN();
 
-    if( force || lastEnabled != m_offlF_enabled || lastAvgInt != m_offlF_avgInt || lastGain != m_offlF_gain ||
-        lastThresh != m_offlF_thresh )
+    if( force || lastEnabled != enabled || lastAvgInt != avgInt || lastGain != gain || lastThresh != thresh )
     {
-        telem<telem_tcsi_focus>( { m_offlF_enabled, m_offlF_avgInt, m_offlF_gain, m_offlF_thresh } );
+        telem<telem_tcsi_focus>( { enabled, avgInt, gain, thresh } );
 
-        lastEnabled = m_offlF_enabled;
-        lastAvgInt  = m_offlF_avgInt;
-        lastGain    = m_offlF_gain;
-        lastThresh  = m_offlF_thresh;
+        lastEnabled = enabled;
+        lastAvgInt  = avgInt;
+        lastGain    = gain;
+        lastThresh  = thresh;
     }
 
     return 0;
@@ -2907,13 +2934,20 @@ inline int tcsInterface::recordTcsiFocus( bool force )
 
 inline int tcsInterface::recordTcsiLabMode( bool force )
 {
-    static bool lastLabMode = !m_labMode;
+    bool labMode;
 
-    if( force || lastLabMode != m_labMode )
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        labMode = m_labMode;
+    }
+
+    static bool lastLabMode = !labMode;
+
+    if( force || lastLabMode != labMode )
     {
-        telem<telem_tcsi_labmode>( { m_labMode } );
+        telem<telem_tcsi_labmode>( { labMode } );
 
-        lastLabMode = m_labMode;
+        lastLabMode = labMode;
     }
 
     return 0;
@@ -3019,7 +3053,15 @@ void tcsInterface::offloadThreadExec()
 
     while( shutdown() == 0 )
     {
-        int loopState = m_loopState.load();
+        int   loopState = m_loopState.load();
+        float offlTTAvgInt;
+        float offlFAvgInt;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            offlTTAvgInt = m_offlTT_avgInt;
+            offlFAvgInt  = m_offlF_avgInt;
+        }
 
         // Check if loop open
         if( loopState == 0 )
@@ -3081,7 +3123,7 @@ void tcsInterface::offloadThreadExec()
 
                 size_t i = m_lastRequest;
 
-                for( size_t n = 0; n < m_offlTT_avgInt; ++n )
+                for( size_t n = 0; n < offlTTAvgInt; ++n )
                 {
                     avg_TT_0 += m_offloadRequests[0][i];
                     avg_TT_1 += m_offloadRequests[1][i];
@@ -3106,7 +3148,7 @@ void tcsInterface::offloadThreadExec()
 
                 i = m_lastRequest;
 
-                for( size_t n = 0; n < m_offlF_avgInt; ++n )
+                for( size_t n = 0; n < offlFAvgInt; ++n )
                 {
                     avg_F_0 += m_offloadRequests[2][i];
                     ++navg;
@@ -3126,14 +3168,14 @@ void tcsInterface::offloadThreadExec()
             }
 
             ++sincelast_TT;
-            if( sincelast_TT >= m_offlTT_avgInt )
+            if( sincelast_TT >= offlTTAvgInt )
             {
                 doTToffload( avg_TT_0, avg_TT_1 );
                 sincelast_TT = 0;
             }
 
             ++sincelast_F;
-            if( sincelast_F >= m_offlF_avgInt )
+            if( sincelast_F >= offlFAvgInt )
             {
                 doFoffload( avg_F_0 );
                 sincelast_F = 0;
@@ -3149,32 +3191,50 @@ void tcsInterface::offloadThreadExec()
 
 int tcsInterface::doTToffload( float tt_0, float tt_1 )
 {
-    if( m_offlTT_dump )
+    bool  offlTTDump;
+    float offlTTGain;
+    float offlTTThresh;
+    bool  offlTTEnabled;
+    bool  labMode;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        offlTTDump    = m_offlTT_dump;
+        offlTTGain    = m_offlTT_gain;
+        offlTTThresh  = m_offlTT_thresh;
+        offlTTEnabled = m_offlTT_enabled;
+        labMode       = m_labMode;
+    }
+
+    if( offlTTDump )
     {
         log<text_log>( "[OFFL] TT dumping: " + std::to_string( tt_0 ) + " " + std::to_string( tt_1 ) );
         sendTToffload( tt_0, tt_1 );
-        m_offlTT_dump = false;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            m_offlTT_dump = false;
+        }
     }
     else
     {
-        tt_0 *= m_offlTT_gain;
-        tt_1 *= m_offlTT_gain;
+        tt_0 *= offlTTGain;
+        tt_1 *= offlTTGain;
 
-        if( fabs( tt_0 ) < m_offlTT_thresh )
+        if( fabs( tt_0 ) < offlTTThresh )
             tt_0 = 0;
-        if( fabs( tt_1 ) < m_offlTT_thresh )
+        if( fabs( tt_1 ) < offlTTThresh )
             tt_1 = 0;
 
         if( tt_0 == 0 && tt_1 == 0 )
         {
             // Do nothing
         }
-        else if( m_offlTT_enabled )
+        else if( offlTTEnabled )
         {
             log<text_log>( "[OFFL] TT offloading: " + std::to_string( tt_0 ) + " " + std::to_string( tt_1 ) );
             sendTToffload( tt_0, tt_1 );
         }
-        else if( !m_labMode )
+        else if( !labMode )
         {
             log<text_log>( "TT offload above threshold but TT offloading disabled", logPrio::LOG_WARNING );
         }
@@ -3185,8 +3245,14 @@ int tcsInterface::doTToffload( float tt_0, float tt_1 )
 
 int tcsInterface::sendTToffload( float tt_0, float tt_1 )
 {
+    bool labMode;
 
-    if( m_labMode ) // If labMode we send offloads to the modulator
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        labMode = m_labMode;
+    }
+
+    if( labMode ) // If labMode we send offloads to the modulator
     {
         pcf::IndiProperty ip( pcf::IndiProperty::Number );
         ip.setDevice( "modwfs" );
@@ -3214,28 +3280,46 @@ int tcsInterface::sendTToffload( float tt_0, float tt_1 )
 
 int tcsInterface::doFoffload( float F_0 )
 {
-    if( m_offlF_dump )
+    bool  offlFDump;
+    float offlFGain;
+    float offlFThresh;
+    bool  offlFEnabled;
+    bool  labMode;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        offlFDump    = m_offlF_dump;
+        offlFGain    = m_offlF_gain;
+        offlFThresh  = m_offlF_thresh;
+        offlFEnabled = m_offlF_enabled;
+        labMode      = m_labMode;
+    }
+
+    if( offlFDump )
     {
         log<text_log>( "[OFFL] Focus dumping: " + std::to_string( F_0 ) );
         sendFoffload( F_0 );
-        m_offlF_dump = false;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            m_offlF_dump = false;
+        }
     }
     else
     {
-        F_0 *= m_offlF_gain;
+        F_0 *= offlFGain;
 
-        if( fabs( F_0 ) < m_offlF_thresh )
+        if( fabs( F_0 ) < offlFThresh )
             F_0 = 0;
 
         if( F_0 == 0 )
         {
         }
-        else if( m_offlF_enabled )
+        else if( offlFEnabled )
         {
             log<text_log>( "[OFFL] Focus sending: " + std::to_string( F_0 ) );
             sendFoffload( F_0 );
         }
-        else if( !m_labMode )
+        else if( !labMode )
         {
 
             log<text_log>( "Focus offload above threshold but Focus offloading disabled", logPrio::LOG_WARNING );
@@ -3276,14 +3360,23 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_labMode )( const pcf::IndiProperty 
         labMode = false;
     }
 
-    if( m_labMode == labMode )
+    bool changed = false;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        if( m_labMode != labMode )
+        {
+            m_labMode = labMode;
+            changed   = true;
+        }
+    }
+
+    if( !changed )
     {
         return 0;
     }
 
-    m_labMode = labMode;
-
-    if( m_labMode )
+    if( labMode )
     {
         log<text_log>( "lab mode ON", logPrio::LOG_NOTICE );
         updateSwitchIfChanged( m_indiP_labMode, "toggle", pcf::IndiElement::On, INDI_OK );
@@ -3368,6 +3461,43 @@ INDI_SETCALLBACK_DEFN( tcsInterface, m_indiP_offloadCoeffs )( const pcf::IndiPro
     if( m_loopState.load() != 2 )
         return 0;
 
+    // Tip-Tilt
+    float tt0 = ipRecv["00"].get<float>();
+    float tt1 = ipRecv["01"].get<float>();
+
+    bool  labMode;
+    float labOfflTTC00;
+    float labOfflTTC01;
+    float labOfflTTC10;
+    float labOfflTTC11;
+    float offlTTC00;
+    float offlTTC01;
+    float offlTTC10;
+    float offlTTC11;
+    float offlCFocus00;
+    float offlCComa00;
+    float offlCComa01;
+    float offlCComa10;
+    float offlCComa11;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        labMode      = m_labMode;
+        labOfflTTC00 = m_lab_offlTT_C_00;
+        labOfflTTC01 = m_lab_offlTT_C_01;
+        labOfflTTC10 = m_lab_offlTT_C_10;
+        labOfflTTC11 = m_lab_offlTT_C_11;
+        offlTTC00    = m_offlTT_C_00;
+        offlTTC01    = m_offlTT_C_01;
+        offlTTC10    = m_offlTT_C_10;
+        offlTTC11    = m_offlTT_C_11;
+        offlCFocus00 = m_offlCFocus_00;
+        offlCComa00  = m_offlCComa_00;
+        offlCComa01  = m_offlCComa_01;
+        offlCComa10  = m_offlCComa_10;
+        offlCComa11  = m_offlCComa_11;
+    }
+
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_offloadMutex );
 
@@ -3376,32 +3506,28 @@ INDI_SETCALLBACK_DEFN( tcsInterface, m_indiP_offloadCoeffs )( const pcf::IndiPro
         if( nextReq >= m_offloadRequests[0].size() )
             nextReq = 0;
 
-        // Tip-Tilt
-        float tt0 = ipRecv["00"].get<float>();
-        float tt1 = ipRecv["01"].get<float>();
-
-        if( m_labMode )
+        if( labMode )
         {
-            m_offloadRequests[0][nextReq] = m_lab_offlTT_C_00 * tt0 + m_lab_offlTT_C_01 * tt1;
-            m_offloadRequests[1][nextReq] = m_lab_offlTT_C_10 * tt0 + m_lab_offlTT_C_11 * tt1;
+            m_offloadRequests[0][nextReq] = labOfflTTC00 * tt0 + labOfflTTC01 * tt1;
+            m_offloadRequests[1][nextReq] = labOfflTTC10 * tt0 + labOfflTTC11 * tt1;
         }
         else
         {
-            m_offloadRequests[0][nextReq] = m_offlTT_C_00 * tt0 + m_offlTT_C_01 * tt1;
-            m_offloadRequests[1][nextReq] = m_offlTT_C_10 * tt0 + m_offlTT_C_11 * tt1;
+            m_offloadRequests[0][nextReq] = offlTTC00 * tt0 + offlTTC01 * tt1;
+            m_offloadRequests[1][nextReq] = offlTTC10 * tt0 + offlTTC11 * tt1;
         }
 
         // Focus
         float f0 = ipRecv["02"].get<float>();
 
-        m_offloadRequests[2][nextReq] = m_offlCFocus_00 * f0;
+        m_offloadRequests[2][nextReq] = offlCFocus00 * f0;
 
         // Coma
         float c0 = ipRecv["03"].get<float>();
         float c1 = ipRecv["04"].get<float>();
 
-        m_offloadRequests[3][nextReq] = m_offlCComa_00 * c0 + m_offlCComa_01 * c1;
-        m_offloadRequests[4][nextReq] = m_offlCComa_10 * c0 + m_offlCComa_11 * c1;
+        m_offloadRequests[3][nextReq] = offlCComa00 * c0 + offlCComa01 * c1;
+        m_offloadRequests[4][nextReq] = offlCComa10 * c0 + offlCComa11 * c1;
 
         // Now update circ buffer
         m_lastRequest = nextReq;
@@ -3427,19 +3553,39 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTenable )( const pcf::IndiProp
     if( !ipRecv.find( "toggle" ) )
         return 0;
 
-    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_offlTT_enabled == false )
-    {
-        updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::On, INDI_OK );
+    bool changed = false;
 
-        m_offlTT_enabled = true;
-        recordTcsiTipTilt();
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            if( m_offlTT_enabled == false )
+            {
+                m_offlTT_enabled = true;
+                changed          = true;
+            }
+        }
+        if( changed )
+        {
+            updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::On, INDI_OK );
+            recordTcsiTipTilt();
+        }
     }
-    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off && m_offlTT_enabled == true )
+    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
     {
-        updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
-
-        m_offlTT_enabled = false;
-        recordTcsiTipTilt();
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            if( m_offlTT_enabled == true )
+            {
+                m_offlTT_enabled = false;
+                changed          = true;
+            }
+        }
+        if( changed )
+        {
+            updateSwitchIfChanged( m_indiP_offlTTenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
+            recordTcsiTipTilt();
+        }
     }
 
     return 0;
@@ -3456,7 +3602,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTdump )( const pcf::IndiProper
     {
         updateSwitchIfChanged( m_indiP_offlTTdump, "request", pcf::IndiElement::On, INDI_OK );
 
-        m_offlTT_dump = true;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            m_offlTT_dump = true;
+        }
     }
 
     return 0;
@@ -3474,7 +3623,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTavgInt )( const pcf::IndiProp
         return -1;
     }
 
-    m_offlTT_avgInt = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlTT_avgInt = target;
+    }
     recordTcsiTipTilt();
 
     return 0;
@@ -3492,7 +3644,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTgain )( const pcf::IndiProper
         return -1;
     }
 
-    m_offlTT_gain = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlTT_gain = target;
+    }
     recordTcsiTipTilt();
 
     return 0;
@@ -3510,7 +3665,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlTTthresh )( const pcf::IndiProp
         return -1;
     }
 
-    m_offlTT_thresh = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlTT_thresh = target;
+    }
     recordTcsiTipTilt();
 
     return 0;
@@ -3523,19 +3681,39 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFenable )( const pcf::IndiPrope
     if( !ipRecv.find( "toggle" ) )
         return 0;
 
-    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_offlF_enabled == false )
-    {
-        updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::On, INDI_OK );
+    bool changed = false;
 
-        m_offlF_enabled = true;
-        recordTcsiFocus();
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            if( m_offlF_enabled == false )
+            {
+                m_offlF_enabled = true;
+                changed         = true;
+            }
+        }
+        if( changed )
+        {
+            updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::On, INDI_OK );
+            recordTcsiFocus();
+        }
     }
-    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off && m_offlF_enabled == true )
+    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
     {
-        updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
-
-        m_offlF_enabled = false;
-        recordTcsiFocus();
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            if( m_offlF_enabled == true )
+            {
+                m_offlF_enabled = false;
+                changed         = true;
+            }
+        }
+        if( changed )
+        {
+            updateSwitchIfChanged( m_indiP_offlFenable, "toggle", pcf::IndiElement::Off, INDI_IDLE );
+            recordTcsiFocus();
+        }
     }
 
     return 0;
@@ -3552,7 +3730,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFdump )( const pcf::IndiPropert
     {
         updateSwitchIfChanged( m_indiP_offlFdump, "request", pcf::IndiElement::On, INDI_OK );
 
-        m_offlF_dump = true;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+            m_offlF_dump = true;
+        }
     }
 
     return 0;
@@ -3570,7 +3751,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFavgInt )( const pcf::IndiPrope
         return -1;
     }
 
-    m_offlF_avgInt = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlF_avgInt = target;
+    }
     recordTcsiFocus();
 
     return 0;
@@ -3588,7 +3772,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFgain )( const pcf::IndiPropert
         return -1;
     }
 
-    m_offlF_gain = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlF_gain = target;
+    }
     recordTcsiFocus();
 
     return 0;
@@ -3608,7 +3795,10 @@ INDI_NEWCALLBACK_DEFN( tcsInterface, m_indiP_offlFthresh )( const pcf::IndiPrope
         return -1;
     }
 
-    m_offlF_thresh = target;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_offloadCtrlMutex );
+        m_offlF_thresh = target;
+    }
     recordTcsiFocus();
 
     return 0;

--- a/apps/tcsInterface/tests/tcsInterface_test.cpp
+++ b/apps/tcsInterface/tests/tcsInterface_test.cpp
@@ -1,11 +1,9 @@
 /** \file tcsInterface_test.cpp
-  * \brief Catch2 tests for the tcsInterface app.
-  * \author Jared R. Males (jaredmales@gmail.com)
-  *
-  * History:
-  */
-
-
+ * \brief Catch2 tests for the tcsInterface app.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * History:
+ */
 
 #include "../../../tests/catch2/catch.hpp"
 #include "../../tests/testMacrosINDI.hpp"
@@ -20,56 +18,56 @@ namespace TCSITEST
 class tcsInterface_test : public tcsInterface
 {
 
-public:
-    tcsInterface_test(const std::string device)
+  public:
+    tcsInterface_test( const std::string device )
     {
         m_configName = device;
 
-        XWCTEST_SETUP_INDI_NEW_PROP(pyrNudge);
-        XWCTEST_SETUP_INDI_NEW_PROP(acqFromGuider);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlTTenable);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlTTdump);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlTTavgInt);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlTTgain);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlTTthresh);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlFenable);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlFdump);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlFavgInt);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlFgain);
-        XWCTEST_SETUP_INDI_NEW_PROP(offlFthresh);
-        //XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_teldata, tcsi, zd);
+        XWCTEST_SETUP_INDI_NEW_PROP( pyrNudge );
+        XWCTEST_SETUP_INDI_NEW_PROP( acqFromGuider );
+        XWCTEST_SETUP_INDI_NEW_PROP( labMode );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlTTenable );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlTTdump );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlTTavgInt );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlTTgain );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlTTthresh );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlFenable );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlFdump );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlFavgInt );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlFgain );
+        XWCTEST_SETUP_INDI_NEW_PROP( offlFthresh );
+        // XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_teldata, tcsi, zd);
     }
 };
 
-
 SCENARIO( "INDI Callbacks", "[tcsInterface]" )
 {
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, pyrNudge);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, acqFromGuider);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTenable);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTdump);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTavgInt);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTgain);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTthresh);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFenable);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFdump);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFavgInt);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFgain);
-    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFthresh);
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, pyrNudge );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, acqFromGuider );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, labMode );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTenable );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTdump );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTavgInt );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTgain );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlTTthresh );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFenable );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFdump );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFavgInt );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFgain );
+    XWCTEST_INDI_NEW_CALLBACK( tcsInterface, offlFthresh );
 
-    //XWCTEST_INDI_SET_CALLBACK( tcsInterface, m_indiP_teldata, tcsi, zd);
-
+    // XWCTEST_INDI_SET_CALLBACK( tcsInterface, m_indiP_teldata, tcsi, zd);
 }
 
 SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
 {
-    GIVEN("A valid x:m:s string")
+    GIVEN( "A valid x:m:s string" )
     {
         int rv;
 
-        WHEN("Positive, double digit integers")
+        WHEN( "Positive, double digit integers" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12:20:50";
 
@@ -77,17 +75,17 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == 0);
-            REQUIRE_THAT(x, Catch::Matchers::WithinAbs(12, 1e-10));
-            REQUIRE_THAT(m, Catch::Matchers::WithinAbs(20, 1e-10));
-            REQUIRE_THAT(s, Catch::Matchers::WithinAbs(50, 1e-10));
+            REQUIRE( rv == 0 );
+            REQUIRE_THAT( x, Catch::Matchers::WithinAbs( 12, 1e-10 ) );
+            REQUIRE_THAT( m, Catch::Matchers::WithinAbs( 20, 1e-10 ) );
+            REQUIRE_THAT( s, Catch::Matchers::WithinAbs( 50, 1e-10 ) );
         }
 
-        WHEN("Negative, double digit integers")
+        WHEN( "Negative, double digit integers" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "-22:30:48";
 
@@ -95,17 +93,17 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == 0);
-            REQUIRE_THAT(x, Catch::Matchers::WithinAbs(-22, 1e-10));
-            REQUIRE_THAT(m, Catch::Matchers::WithinAbs(-30, 1e-10));
-            REQUIRE_THAT(s, Catch::Matchers::WithinAbs(-48, 1e-10));
+            REQUIRE( rv == 0 );
+            REQUIRE_THAT( x, Catch::Matchers::WithinAbs( -22, 1e-10 ) );
+            REQUIRE_THAT( m, Catch::Matchers::WithinAbs( -30, 1e-10 ) );
+            REQUIRE_THAT( s, Catch::Matchers::WithinAbs( -48, 1e-10 ) );
         }
 
-        WHEN("Positive, double digit, decimal seconds")
+        WHEN( "Positive, double digit, decimal seconds" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12:20:50.267849";
 
@@ -113,17 +111,17 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == 0);
-            REQUIRE_THAT(x, Catch::Matchers::WithinAbs(12, 1e-10));
-            REQUIRE_THAT(m, Catch::Matchers::WithinAbs(20, 1e-10));
-            REQUIRE_THAT(s, Catch::Matchers::WithinAbs(50.267849, 1e-10));
+            REQUIRE( rv == 0 );
+            REQUIRE_THAT( x, Catch::Matchers::WithinAbs( 12, 1e-10 ) );
+            REQUIRE_THAT( m, Catch::Matchers::WithinAbs( 20, 1e-10 ) );
+            REQUIRE_THAT( s, Catch::Matchers::WithinAbs( 50.267849, 1e-10 ) );
         }
 
-        WHEN("Negative, double digit integers")
+        WHEN( "Negative, double digit integers" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "-22:30:48.8771819";
 
@@ -131,22 +129,22 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == 0);
-            REQUIRE_THAT(x, Catch::Matchers::WithinAbs(-22, 1e-10));
-            REQUIRE_THAT(m, Catch::Matchers::WithinAbs(-30, 1e-10));
-            REQUIRE_THAT(s, Catch::Matchers::WithinAbs(-48.8771819, 1e-10));
-     }
-   }
+            REQUIRE( rv == 0 );
+            REQUIRE_THAT( x, Catch::Matchers::WithinAbs( -22, 1e-10 ) );
+            REQUIRE_THAT( m, Catch::Matchers::WithinAbs( -30, 1e-10 ) );
+            REQUIRE_THAT( s, Catch::Matchers::WithinAbs( -48.8771819, 1e-10 ) );
+        }
+    }
 
-    GIVEN("Invalid x:m:s strings")
+    GIVEN( "Invalid x:m:s strings" )
     {
         int rv;
 
-        WHEN("empty")
+        WHEN( "empty" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "";
 
@@ -154,14 +152,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("no :")
+        WHEN( "no :" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12-20-50";
 
@@ -169,14 +167,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("only one :")
+        WHEN( "only one :" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12:20-50";
 
@@ -184,14 +182,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("two :, but one at beginning")
+        WHEN( "two :, but one at beginning" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = ":12:20";
 
@@ -199,14 +197,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("two :, but no m")
+        WHEN( "two :, but no m" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12::20";
 
@@ -214,14 +212,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("two :, but one at end")
+        WHEN( "two :, but one at end" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "12:20:";
 
@@ -229,14 +227,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid x")
+        WHEN( "invalid x" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "x:20:80";
 
@@ -244,14 +242,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid -x")
+        WHEN( "invalid -x" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "-x:20:80";
 
@@ -259,14 +257,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid m")
+        WHEN( "invalid m" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "20:m:80";
 
@@ -274,14 +272,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid -m")
+        WHEN( "invalid -m" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "-12:m:80";
 
@@ -289,14 +287,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid s")
+        WHEN( "invalid s" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "20:23:s.ssy";
 
@@ -304,14 +302,14 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
 
-        WHEN("invalid -s")
+        WHEN( "invalid -s" )
         {
-            tcsInterface_test tit("tcsi");
+            tcsInterface_test tit( "tcsi" );
 
             std::string tstr = "-12:23:s.sye";
 
@@ -319,11 +317,11 @@ SCENARIO( "Parsing times in x:m:s format", "[tcsInterface]" )
             double m;
             double s;
 
-            rv = tit.parse_xms(x, m, s, tstr);
+            rv = tit.parse_xms( x, m, s, tstr );
 
-            REQUIRE(rv == -1);
+            REQUIRE( rv == -1 );
         }
     }
 }
 
-} //namespace tcsInterface_test
+} // namespace TCSITEST

--- a/libMagAOX/Makefile
+++ b/libMagAOX/Makefile
@@ -89,6 +89,10 @@ INCLUDEDEPS= \
 	logger/types/telem_telcat.hpp \
 	logger/types/telem_teldata.hpp \
 	logger/types/telem_telenv.hpp \
+	logger/types/telem_tcsi_focus.hpp \
+	logger/types/telem_tcsi_labmode.hpp \
+	logger/types/telem_tcsi_offload.hpp \
+	logger/types/telem_tcsi_tiptilt.hpp \
 	logger/types/telem_telpos.hpp \
 	logger/types/telem_telsee.hpp \
 	logger/types/telem_telvane.hpp \

--- a/libMagAOX/logger/logCodes.dat
+++ b/libMagAOX/logger/logCodes.dat
@@ -47,6 +47,9 @@ telem_telvane            20002    telem_telvane
 telem_telenv             20003    telem_telenv
 telem_telcat             20004    telem_telcat
 telem_telsee             20005    telem_telsee
+telem_tcsi_tiptilt       20006    telem_tcsi_offload
+telem_tcsi_focus         20007    telem_tcsi_offload
+telem_tcsi_labmode       20008    telem_tcsi_labmode
 
 telem_stage              20050    telem_stage
 telem_zaber              20055    telem_zaber

--- a/libMagAOX/logger/types/schemas/telem_tcsi_labmode.fbs
+++ b/libMagAOX/logger/types/schemas/telem_tcsi_labmode.fbs
@@ -1,0 +1,8 @@
+namespace MagAOX.logger;
+
+table Telem_tcsi_labmode_fb
+{
+   labMode:bool;
+}
+
+root_type Telem_tcsi_labmode_fb;

--- a/libMagAOX/logger/types/schemas/telem_tcsi_offload.fbs
+++ b/libMagAOX/logger/types/schemas/telem_tcsi_offload.fbs
@@ -1,0 +1,11 @@
+namespace MagAOX.logger;
+
+table Telem_tcsi_offload_fb
+{
+   enabled:bool;
+   avgInt:float;
+   gain:float;
+   thresh:float;
+}
+
+root_type Telem_tcsi_offload_fb;

--- a/libMagAOX/logger/types/telem.cpp
+++ b/libMagAOX/logger/types/telem.cpp
@@ -42,6 +42,9 @@ timespec telem_stage::lastRecord = {0,0};
 timespec telem_stdcam::lastRecord = {0,0};
 timespec telem_telcat::lastRecord = {0,0};
 timespec telem_teldata::lastRecord = {0,0};
+timespec telem_tcsi_focus::lastRecord = {0,0};
+timespec telem_tcsi_labmode::lastRecord = {0,0};
+timespec telem_tcsi_tiptilt::lastRecord = {0,0};
 timespec telem_telenv::lastRecord = {0,0};
 timespec telem_telpos::lastRecord = {0,0};
 timespec telem_telsee::lastRecord = {0,0};
@@ -52,4 +55,3 @@ timespec telem_zaber::lastRecord = {0,0};
 
 } //namespace logger
 } //namespace MagAOX
-

--- a/libMagAOX/logger/types/telem_tcsi_focus.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_focus.hpp
@@ -26,6 +26,14 @@ struct telem_tcsi_focus : public telem_tcsi_offload
     /// The default level
     static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
 
+    /// Format the message for human consumption.
+    static std::string msgString( void *msgBuffer,      /**< [in] Buffer containing the flatbuffer serialized message.*/
+                                  flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer.*/
+    )
+    {
+        return formatMsgString( "tcsi_focus", msgBuffer, len );
+    }
+
     static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
 };
 

--- a/libMagAOX/logger/types/telem_tcsi_focus.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_focus.hpp
@@ -1,0 +1,35 @@
+/** \file telem_tcsi_focus.hpp
+ * \brief The MagAO-X logger telem_tcsi_focus log type.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup logger_types_files
+ *
+ */
+#ifndef logger_types_telem_tcsi_focus_hpp
+#define logger_types_telem_tcsi_focus_hpp
+
+#include "telem_tcsi_offload.hpp"
+
+namespace MagAOX
+{
+namespace logger
+{
+
+/// Focus offload-control telemetry.
+/** \ingroup logger_types
+ */
+struct telem_tcsi_focus : public telem_tcsi_offload
+{
+    /// The event code
+    static const flatlogs::eventCodeT eventCode = eventCodes::TELEM_TCSI_FOCUS;
+
+    /// The default level
+    static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
+
+    static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
+};
+
+} // namespace logger
+} // namespace MagAOX
+
+#endif // logger_types_telem_tcsi_focus_hpp

--- a/libMagAOX/logger/types/telem_tcsi_labmode.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_labmode.hpp
@@ -1,0 +1,101 @@
+/** \file telem_tcsi_labmode.hpp
+ * \brief The MagAO-X logger type for tcsInterface lab-mode telemetry.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup logger_types_files
+ *
+ */
+#ifndef logger_types_telem_tcsi_labmode_hpp
+#define logger_types_telem_tcsi_labmode_hpp
+
+#include "generated/telem_tcsi_labmode_generated.h"
+#include "flatbuffer_log.hpp"
+
+namespace MagAOX
+{
+namespace logger
+{
+
+/// tcsInterface lab-mode telemetry.
+/** \ingroup logger_types
+ */
+struct telem_tcsi_labmode : public flatbuffer_log
+{
+    /// The event code
+    static const flatlogs::eventCodeT eventCode = eventCodes::TELEM_TCSI_LABMODE;
+
+    /// The default level
+    static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
+
+    static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
+
+    /// The type of the input message
+    struct messageT : public fbMessage
+    {
+        /// Construct from components.
+        messageT( const bool &labMode ///< [in] whether tcsInterface is in lab mode
+        )
+        {
+            auto fp = CreateTelem_tcsi_labmode_fb( builder, labMode );
+            builder.Finish( fp );
+        }
+    };
+
+    static bool verify( flatlogs::bufferPtrT &logBuff, ///< [in] Buffer containing the flatbuffer serialized message.
+                        flatlogs::msgLenT     len      ///< [in] length of msgBuffer.
+    )
+    {
+        auto verifier = flatbuffers::Verifier( static_cast<uint8_t *>( flatlogs::logHeader::messageBuffer( logBuff ) ),
+                                               static_cast<size_t>( len ) );
+        return VerifyTelem_tcsi_labmode_fbBuffer( verifier );
+    }
+
+    /// Format the message for human consumption.
+    static std::string msgString( void *msgBuffer,      /**< [in] Buffer containing the flatbuffer serialized message.*/
+                                  flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer.*/
+    )
+    {
+        static_cast<void>( len );
+
+        auto fbs = GetTelem_tcsi_labmode_fb( msgBuffer );
+
+        std::string msg = "[tcsi_labmode] ";
+        msg += "labMode: ";
+        msg += std::to_string( fbs->labMode() );
+
+        return msg;
+    }
+
+    /// Access the lab-mode state.
+    static bool labMode( void *msgBuffer /**< [in] Buffer containing the flatbuffer serialized message.*/ )
+    {
+        auto fbs = GetTelem_tcsi_labmode_fb( msgBuffer );
+        return fbs->labMode();
+    }
+
+    /// Get the logMetaDetail for a member by name.
+    /**
+     * \returns the a logMetaDetail filled in with the appropriate details
+     * \returns an empty logMetaDetail if member not recognized
+     */
+    static logMetaDetail getAccessor( const std::string &member /**< [in] the name of the member */ )
+    {
+        if( member == "labMode" )
+        {
+            return logMetaDetail( { "LABMODE",
+                                    logMeta::valTypes::Bool,
+                                    logMeta::metaTypes::State,
+                                    reinterpret_cast<void *>( &labMode ) } );
+        }
+        else
+        {
+            std::cerr << "No member " << member << " in telem_tcsi_labmode\n";
+            return logMetaDetail();
+        }
+    }
+};
+
+} // namespace logger
+} // namespace MagAOX
+
+#endif // logger_types_telem_tcsi_labmode_hpp

--- a/libMagAOX/logger/types/telem_tcsi_offload.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_offload.hpp
@@ -25,6 +25,35 @@ namespace logger
  */
 struct telem_tcsi_offload : public flatbuffer_log
 {
+  protected:
+    /// Format a shared offload-control message body with a caller-supplied label.
+    static std::string
+    formatMsgString( const char       *label,     /**< [in] Label identifying the telemetry type. */
+                     void             *msgBuffer, /**< [in] Buffer containing the flatbuffer serialized message. */
+                     flatlogs::msgLenT len        /**< [in] [unused] length of msgBuffer. */
+    )
+    {
+        static_cast<void>( len );
+
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+
+        std::string msg = "[";
+        msg += label;
+        msg += "] ";
+
+        msg += "enabled: ";
+        msg += std::to_string( fbs->enabled() );
+        msg += " avgInt: ";
+        msg += std::to_string( fbs->avgInt() );
+        msg += " gain: ";
+        msg += std::to_string( fbs->gain() );
+        msg += " thresh: ";
+        msg += std::to_string( fbs->thresh() );
+
+        return msg;
+    }
+
+  public:
     /// The type of the input message
     struct messageT : public fbMessage
     {
@@ -54,22 +83,7 @@ struct telem_tcsi_offload : public flatbuffer_log
                                   flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer.*/
     )
     {
-        static_cast<void>( len );
-
-        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
-
-        std::string msg = "[tcsi_offload] ";
-
-        msg += "enabled: ";
-        msg += std::to_string( fbs->enabled() );
-        msg += " avgInt: ";
-        msg += std::to_string( fbs->avgInt() );
-        msg += " gain: ";
-        msg += std::to_string( fbs->gain() );
-        msg += " thresh: ";
-        msg += std::to_string( fbs->thresh() );
-
-        return msg;
+        return formatMsgString( "tcsi_offload", msgBuffer, len );
     }
 
     /// Access the enabled state.

--- a/libMagAOX/logger/types/telem_tcsi_offload.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_offload.hpp
@@ -1,0 +1,147 @@
+/** \file telem_tcsi_offload.hpp
+ * \brief Shared MagAO-X logger type for tcsInterface offload-control telemetry.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup logger_types_files
+ *
+ */
+#ifndef logger_types_telem_tcsi_offload_hpp
+#define logger_types_telem_tcsi_offload_hpp
+
+#include "generated/telem_tcsi_offload_generated.h"
+#include "flatbuffer_log.hpp"
+
+namespace MagAOX
+{
+namespace logger
+{
+
+/// Shared base class for tcsInterface offload-control telemetry.
+/** This provides the common payload and accessors for both tip/tilt and focus
+ * offload-control telemetry records. It is not intended to be used directly as
+ * a logged type.
+ *
+ * \ingroup logger_types_basic
+ */
+struct telem_tcsi_offload : public flatbuffer_log
+{
+    /// The type of the input message
+    struct messageT : public fbMessage
+    {
+        /// Construct from components.
+        messageT( const bool  &enabled, ///< [in] whether the offload path is enabled
+                  const float &avgInt,  ///< [in] the current averaging interval
+                  const float &gain,    ///< [in] the current offload gain
+                  const float &thresh   ///< [in] the current offload threshold
+        )
+        {
+            auto fp = CreateTelem_tcsi_offload_fb( builder, enabled, avgInt, gain, thresh );
+            builder.Finish( fp );
+        }
+    };
+
+    static bool verify( flatlogs::bufferPtrT &logBuff, ///< [in] Buffer containing the flatbuffer serialized message.
+                        flatlogs::msgLenT     len      ///< [in] length of msgBuffer.
+    )
+    {
+        auto verifier = flatbuffers::Verifier( static_cast<uint8_t *>( flatlogs::logHeader::messageBuffer( logBuff ) ),
+                                               static_cast<size_t>( len ) );
+        return VerifyTelem_tcsi_offload_fbBuffer( verifier );
+    }
+
+    /// Format the message for human consumption.
+    static std::string msgString( void *msgBuffer,      /**< [in] Buffer containing the flatbuffer serialized message.*/
+                                  flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer.*/
+    )
+    {
+        static_cast<void>( len );
+
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+
+        std::string msg = "[tcsi_offload] ";
+
+        msg += "enabled: ";
+        msg += std::to_string( fbs->enabled() );
+        msg += " avgInt: ";
+        msg += std::to_string( fbs->avgInt() );
+        msg += " gain: ";
+        msg += std::to_string( fbs->gain() );
+        msg += " thresh: ";
+        msg += std::to_string( fbs->thresh() );
+
+        return msg;
+    }
+
+    /// Access the enabled state.
+    static bool enabled( void *msgBuffer /**< [in] Buffer containing the flatbuffer serialized message.*/ )
+    {
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+        return fbs->enabled();
+    }
+
+    /// Access the offload gain.
+    static float gain( void *msgBuffer /**< [in] Buffer containing the flatbuffer serialized message.*/ )
+    {
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+        return fbs->gain();
+    }
+
+    /// Access the offload averaging interval.
+    static float avgInt( void *msgBuffer /**< [in] Buffer containing the flatbuffer serialized message.*/ )
+    {
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+        return fbs->avgInt();
+    }
+
+    /// Access the offload threshold.
+    static float thresh( void *msgBuffer /**< [in] Buffer containing the flatbuffer serialized message.*/ )
+    {
+        auto fbs = GetTelem_tcsi_offload_fb( msgBuffer );
+        return fbs->thresh();
+    }
+
+    /// Get the logMetaDetail for a member by name.
+    /**
+     * \returns the a logMetaDetail filled in with the appropriate details
+     * \returns an empty logMetaDetail if member not recognized
+     */
+    static logMetaDetail getAccessor( const std::string &member /**< [in] the name of the member */ )
+    {
+        if( member == "enabled" )
+        {
+            return logMetaDetail( { "ENABLED",
+                                    logMeta::valTypes::Bool,
+                                    logMeta::metaTypes::State,
+                                    reinterpret_cast<void *>( &enabled ) } );
+        }
+        else if( member == "avgInt" )
+        {
+            return logMetaDetail( { "AVGINT",
+                                    logMeta::valTypes::Float,
+                                    logMeta::metaTypes::State,
+                                    reinterpret_cast<void *>( &avgInt ) } );
+        }
+        else if( member == "gain" )
+        {
+            return logMetaDetail(
+                { "GAIN", logMeta::valTypes::Float, logMeta::metaTypes::State, reinterpret_cast<void *>( &gain ) } );
+        }
+        else if( member == "thresh" )
+        {
+            return logMetaDetail( { "THRESH",
+                                    logMeta::valTypes::Float,
+                                    logMeta::metaTypes::State,
+                                    reinterpret_cast<void *>( &thresh ) } );
+        }
+        else
+        {
+            std::cerr << "No member " << member << " in telem_tcsi_offload\n";
+            return logMetaDetail();
+        }
+    }
+};
+
+} // namespace logger
+} // namespace MagAOX
+
+#endif // logger_types_telem_tcsi_offload_hpp

--- a/libMagAOX/logger/types/telem_tcsi_tiptilt.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_tiptilt.hpp
@@ -26,6 +26,14 @@ struct telem_tcsi_tiptilt : public telem_tcsi_offload
     /// The default level
     static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
 
+    /// Format the message for human consumption.
+    static std::string msgString( void *msgBuffer,      /**< [in] Buffer containing the flatbuffer serialized message.*/
+                                  flatlogs::msgLenT len /**< [in] [unused] length of msgBuffer.*/
+    )
+    {
+        return formatMsgString( "tcsi_tiptilt", msgBuffer, len );
+    }
+
     static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
 };
 

--- a/libMagAOX/logger/types/telem_tcsi_tiptilt.hpp
+++ b/libMagAOX/logger/types/telem_tcsi_tiptilt.hpp
@@ -1,0 +1,35 @@
+/** \file telem_tcsi_tiptilt.hpp
+ * \brief The MagAO-X logger telem_tcsi_tiptilt log type.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup logger_types_files
+ *
+ */
+#ifndef logger_types_telem_tcsi_tiptilt_hpp
+#define logger_types_telem_tcsi_tiptilt_hpp
+
+#include "telem_tcsi_offload.hpp"
+
+namespace MagAOX
+{
+namespace logger
+{
+
+/// Tip/tilt offload-control telemetry.
+/** \ingroup logger_types
+ */
+struct telem_tcsi_tiptilt : public telem_tcsi_offload
+{
+    /// The event code
+    static const flatlogs::eventCodeT eventCode = eventCodes::TELEM_TCSI_TIPTILT;
+
+    /// The default level
+    static const flatlogs::logPrioT defaultLevel = flatlogs::logPrio::LOG_TELEM;
+
+    static timespec lastRecord; ///< The time of the last time this log was recorded. Used by the telemetry system.
+};
+
+} // namespace logger
+} // namespace MagAOX
+
+#endif // logger_types_telem_tcsi_tiptilt_hpp


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "implement tcsInterface offload telemetry, fix the offload cadence/queue/thread-safety issues, and clean up any remaining AGENTS.md compliance items."

## Summary

This PR adds telemetry for `tcsInterface` offload control state, fixes several correctness issues in the offload path, and hardens the shared-state handoff between callbacks and the offload thread.

It also includes the implementation plan document and a small documentation-only cleanup for the offload helper declarations and queue state.

## What Changed

- Added separate telemetry log types for:
  - `telem_tcsi_tiptilt`
  - `telem_tcsi_focus`
  - `telem_tcsi_labmode`
- Added shared offload telemetry schema/payload support including:
  - `enabled`
  - `avgInt`
  - `gain`
  - `thresh`
- Wired `tcsInterface` to emit TT/focus/labMode telemetry on change and on forced telemeter updates.
- Added the `tcsi` telemetry implementation plan document.

- Fixed an off-by-one bug in offload cadence:
  - offload triggers now use `>=` instead of `>`
  - confirmed on sky that cadence is no longer skipping every other offload when `avgInt == 1`

- Fixed offload queue state handling:
  - a single queued request is no longer ignored
  - cadence counters reset when loop-state transitions invalidate prior averaging cadence

- Hardened concurrency:
  - synchronized the offload request queue between producer/consumer threads
  - made `m_loopState` atomic
  - synchronized offload control-state reads/writes used by callbacks, the offload thread, startup, and INDI updates

- Clarified offload log messages:
  - TT logs now format as `tcsi_tiptilt`
  - focus logs now format as `tcsi_focus`

- Improved declaration/member documentation in `tcsInterface.hpp` for the offload helper and queue-state additions.

## Validation

- `libMagAOX` built successfully during development.
- `tcsInterface` built successfully in a regular terminal.
- On-sky testing confirmed:
  - telemetry is working
  - the offload cadence no longer skips due to the previous off-by-one bug

## Affected Files

- [`apps/tcsInterface/tcsInterface.hpp`](/home/jrmales/Source/MagAOX/apps/tcsInterface/tcsInterface.hpp)
- [`apps/tcsInterface/tests/tcsInterface_test.cpp`](/home/jrmales/Source/MagAOX/apps/tcsInterface/tests/tcsInterface_test.cpp)
- [`agents/plans/tcsi-telemetry.md`](/home/jrmales/Source/MagAOX/agents/plans/tcsi-telemetry.md)
- [`libMagAOX/Makefile`](/home/jrmales/Source/MagAOX/libMagAOX/Makefile)
- [`libMagAOX/logger/logCodes.dat`](/home/jrmales/Source/MagAOX/libMagAOX/logger/logCodes.dat)
- [`libMagAOX/logger/types/telem.cpp`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/telem.cpp)
- [`libMagAOX/logger/types/schemas/telem_tcsi_offload.fbs`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/schemas/telem_tcsi_offload.fbs)
- [`libMagAOX/logger/types/schemas/telem_tcsi_labmode.fbs`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/schemas/telem_tcsi_labmode.fbs)
- [`libMagAOX/logger/types/telem_tcsi_offload.hpp`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/telem_tcsi_offload.hpp)
- [`libMagAOX/logger/types/telem_tcsi_tiptilt.hpp`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/telem_tcsi_tiptilt.hpp)
- [`libMagAOX/logger/types/telem_tcsi_focus.hpp`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/telem_tcsi_focus.hpp)
- [`libMagAOX/logger/types/telem_tcsi_labmode.hpp`](/home/jrmales/Source/MagAOX/libMagAOX/logger/types/telem_tcsi_labmode.hpp)

## Follow-up

- The logger-type headers still use the existing subsystem pattern of inline definitions in headers. I left that consistent with neighboring logger types rather than forcing a local refactor.

## Testing

- tested on sky