### PR TITLE
Add config-driven PVCAM fan control via stdCamera

### DIFF
--- a/agents/plans/pvcam-stdcamera-fan-ctrl.md
+++ b/agents/plans/pvcam-stdcamera-fan-ctrl.md
@@ -1,0 +1,221 @@
+## Problem Statement
+
+Implement fan speed control in `apps/pvcamCtrl` using the PVCAM fan-speed setpoint interface described in:
+
+`/home/jrmales/Documents/MyPapers/Projects/MagAOX/Electronics/Cameras/Teledyne/PVCAM_User_Manual/_ex__fan_speed_and_temperature.xhtml`
+
+The requested behavior is:
+
+- Add a new optional fan-speed interface to `dev::stdCamera`.
+- Expose the control through an INDI one-of-many switch with the four PVCAM fan levels:
+  - `high`
+  - `medium`
+  - `low`
+  - `off`
+- Include the fan state in `stdCamera` telemetry.
+- Integrate the feature in `pvcamCtrl` with minimal behavioral change outside the new control.
+
+## What I Checked
+
+- `libMagAOX/app/dev/stdCamera.hpp`
+  - Existing optional camera features follow a consistent pattern:
+    - compile-time `c_stdCamera_*` flag in the derived app
+    - config values loaded before `appStartup()`
+    - `m_*` state in `stdCamera`
+    - INDI property creation in `appStartup()`
+    - callback dispatch in `newCallBack_stdCamera()`
+    - `updateINDI()` publishing
+    - `recordCamera()` telemetry packing
+- `apps/pvcamCtrl/pvcamCtrl.hpp`
+  - `pvcamCtrl` already uses `stdCamera` readout-speed support, which is the closest analogue for a fan-speed selection switch.
+  - `setupConfig()` and `loadConfig()` happen before `STDCAMERA_APP_STARTUP`, so config is the right place to decide whether to expose the fan interface and how many speeds to advertise.
+- PVCAM manual
+  - `PARAM_FAN_SPEED_SETPOINT` is the relevant parameter.
+  - The documented enum values are `FAN_SPEED_HIGH`, `FAN_SPEED_MEDIUM`, `FAN_SPEED_LOW`, and `FAN_SPEED_OFF`.
+  - The parameter is documented as "Sets and gets the desired fan speed."
+- `libMagAOX/logger/types/schemas/telem_stdcam.fbs` and `libMagAOX/logger/types/telem_stdcam.hpp`
+  - `telem_stdcam` does not currently include any fan field.
+
+## Recommended Design
+
+### 1. Extend `dev::stdCamera` with an optional fan-speed interface
+
+Add a new optional feature in `libMagAOX/app/dev/stdCamera.hpp` following the existing readout-speed pattern.
+
+Recommended interface pieces:
+
+- New compile-time flag in derived apps:
+  - `static constexpr bool c_stdCamera_fanSpeed = true/false;`
+- New config-backed state in `stdCamera`:
+  - `bool m_fanSpeedControlEnabled{ false };`
+  - `std::string m_defaultFanSpeed;`
+- New `stdCamera` state:
+  - `std::vector<std::string> m_fanSpeedNames;`
+  - `std::vector<std::string> m_fanSpeedNameLabels;`
+  - `std::string m_fanSpeedName;`
+  - `std::string m_fanSpeedNameSet;`
+  - `pcf::IndiProperty m_indiP_fanSpeed;`
+- New derived-app interface:
+  - `int setFanSpeed();`
+
+Implementation should mirror `readoutSpeed`, but its exposure should be config-driven:
+
+- in `setupConfig()`, add config entries only when `c_stdCamera_fanSpeed == true`
+- in `loadConfig()`, load whether fan control is enabled and how many speeds should be exposed
+- only create the INDI switch in `appStartup()` when config says the interface is enabled
+- create a one-of-many INDI switch named something like `fan_speed`
+- on callback, determine the selected element and store it in `m_fanSpeedNameSet`
+- call `derived().setFanSpeed()`
+- in `updateINDI()`, publish `m_fanSpeedName` through `indi::updateSelectionSwitchIfChanged()`
+- in `recordCamera()`, include the current fan setting and trigger telemetry when it changes
+
+Recommended config keys:
+
+- `camera.fanSpeedControl`
+  - bool
+  - whether the app should expose fan speed control at all
+- `camera.defaultFanSpeed`
+  - string
+  - the default fan speed to apply at startup or power-on
+  - valid values should be `high`, `medium`, `low`, or `off`
+  - invalid values should hard-fail config load
+
+The exposed choices should always be the full PVCAM set:
+
+- `high`
+- `medium`
+- `low`
+- `off`
+
+This keeps the exposure decision in config instead of runtime hardware probing, while avoiding per-deployment variation in the number of advertised speeds.
+
+### 2. Add fan-speed telemetry to `telem_stdcam`
+
+Update:
+
+- `libMagAOX/logger/types/schemas/telem_stdcam.fbs`
+- `libMagAOX/logger/types/telem_stdcam.hpp`
+
+Recommended payload shape:
+
+- add a single string field for the active fan setting
+
+Rationale:
+
+- `stdCamera` currently tracks human-readable selection names for similar controls.
+- PVCAM documents `PARAM_FAN_SPEED_SETPOINT` as the desired fan speed, so a named state is the most natural fit.
+- This keeps telemetry changes small and avoids tying `telem_stdcam` to PVCAM-specific integer enum values.
+
+After changing the schema, regenerate the corresponding FlatBuffer-generated header if that is part of the normal workflow in this tree.
+
+### 3. Implement the PVCAM mapping in `pvcamCtrl`
+
+Update `apps/pvcamCtrl/pvcamCtrl.hpp` to:
+
+- enable the new interface with `c_stdCamera_fanSpeed = true`
+- declare and document `setFanSpeed()`
+- use `stdCamera` config for enable/default behavior
+- initialize the fan speed names and labels before `appStartup()` to the full four-speed PVCAM set
+- initialize the current/set values in `powerOnDefaults()`
+- optionally read back the current fan setpoint after connect to synchronize status, but not to decide whether the interface exists
+- call `pl_set_param( m_handle, PARAM_FAN_SPEED_SETPOINT, ... )` in `setFanSpeed()`
+
+Recommended canonical PVCAM mapping:
+
+- `high` -> `FAN_SPEED_HIGH`
+- `medium` -> `FAN_SPEED_MEDIUM`
+- `low` -> `FAN_SPEED_LOW`
+- `off` -> `FAN_SPEED_OFF`
+
+Recommended hook points:
+
+- `loadConfigImpl()`
+  - rely on `stdCamera` to load `camera.fanSpeedControl` and `camera.defaultFanSpeed`
+  - populate `m_fanSpeedNames` and `m_fanSpeedNameLabels` with all four fan speeds
+- `powerOnDefaults()`
+  - restore `m_fanSpeedName` and `m_fanSpeedNameSet` from `m_defaultFanSpeed`
+- `connect()`
+  - optionally read `ATTR_CURRENT` to synchronize telemetry and INDI status
+- `setFanSpeed()`
+  - validate the requested string
+  - map it to the PVCAM enum value
+  - set the parameter
+  - update `m_fanSpeedName`
+  - force a telemetry record
+
+## Configuration Model
+
+The interface should be controlled at two levels:
+
+- compile time
+  - `c_stdCamera_fanSpeed` says the app knows how to implement fan control
+- config time
+  - config says whether the feature should be exposed for this deployment
+  - config says which of the four levels is the default
+
+Under this model:
+
+- `stdCamera` does not need runtime capability discovery logic for deciding whether to create the property
+- `pvcamCtrl` does not need runtime checks to decide whether fan control exists
+- the user is responsible for matching config to hardware
+- runtime PVCAM failures should still be logged normally, but they are operational failures, not feature-discovery logic
+
+This is closer to how the current `stdCamera` options are structured and keeps the interface deterministic across startup.
+
+## Concrete Implementation Steps
+
+1. Extend `stdCamera.hpp`
+   - add the new compile-time flag documentation
+   - add config entries for fan-control enable/default
+   - add config-backed enabled/default member state
+   - add fan-speed member data and INDI property
+   - add creation, callback, dispatch, and update helpers
+   - gate property creation and updates on both compile-time support and config enable
+   - hard-fail `loadConfig()` if `camera.defaultFanSpeed` is not one of `high`, `medium`, `low`, or `off`
+   - add fan-speed state to `recordCamera()`
+
+2. Extend `telem_stdcam`
+   - add a fan-speed field to the FlatBuffer schema
+   - update `messageT`, formatting, and metadata accessors in `telem_stdcam.hpp`
+   - regenerate generated FlatBuffer code if required
+
+3. Update `pvcamCtrl`
+   - enable the feature flag
+   - document and declare `setFanSpeed()`
+   - build names/labels from the fixed four-speed PVCAM set before `STDCAMERA_APP_STARTUP`
+   - optionally synchronize current state in `connect()`
+   - implement the PVCAM enum mapping and setter
+
+4. Verify behavior
+   - app starts with fan control hidden when config disables it
+   - app starts with all four fan-speed choices when enabled
+   - app starts with the configured default selected
+   - selecting each exposed INDI fan level updates internal state
+   - `pl_set_param(PARAM_FAN_SPEED_SETPOINT, ...)` is called with the expected PVCAM enum
+   - telemetry changes when fan level changes
+   - misconfigured hardware fails in a clear logged way
+
+## Validation Notes
+
+- The closest existing code path to model after is readout-speed selection in `stdCamera`.
+- The main difference from the previous draft is that exposure is decided by config, not by runtime capability probing.
+- Because this is a potential safety issue, invalid `camera.defaultFanSpeed` should be treated as a fatal configuration error, not silently corrected.
+- Telemetry verification should include both:
+  - forced records after a set operation
+  - change-driven records during steady-state operation
+- If the generated FlatBuffer headers are committed in this repo, they should be updated in the same functional change.
+
+## Affected Files
+
+Expected primary touch points:
+
+- `agents/plans/pvcam-stdcamera-fan-ctrl.md`
+- `libMagAOX/app/dev/stdCamera.hpp`
+- `libMagAOX/logger/types/schemas/telem_stdcam.fbs`
+- `libMagAOX/logger/types/telem_stdcam.hpp`
+- generated FlatBuffer output for `telem_stdcam`, if tracked
+- `apps/pvcamCtrl/pvcamCtrl.hpp`
+
+## Follow-Up Questions
+
+- None at the planning level. The remaining implementation detail is to make the hard-fail path in `stdCamera::loadConfig()` produce a clear configuration error message naming the invalid value.

--- a/apps/andorCtrl/andorCtrl.hpp
+++ b/apps/andorCtrl/andorCtrl.hpp
@@ -403,6 +403,7 @@ public:
    static constexpr bool c_stdCamera_readoutSpeed = true; ///< app::dev config to tell stdCamera to expose readout speed controls
 
    static constexpr bool c_stdCamera_vShiftSpeed = true; ///< app:dev config to tell stdCamera to expose vertical shift speed control
+   static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
    static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls
 

--- a/apps/baslerCtrl/baslerCtrl.hpp
+++ b/apps/baslerCtrl/baslerCtrl.hpp
@@ -80,6 +80,8 @@ class baslerCtrl : public MagAOXApp<>,
 
     static constexpr bool c_stdCamera_vShiftSpeed =
         false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
+    static constexpr bool c_stdCamera_fanSpeed =
+        false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
     static constexpr bool c_stdCamera_emGain =
         false; ///< app::dev config to tell stdCamera to not expose EM gain controls

--- a/apps/cameraSim/cameraSim.hpp
+++ b/apps/cameraSim/cameraSim.hpp
@@ -69,6 +69,8 @@ class cameraSim : public MagAOXApp<>,
 
     static constexpr bool c_stdCamera_vShiftSpeed =
         true; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
+    static constexpr bool c_stdCamera_fanSpeed =
+        false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
     static constexpr bool c_stdCamera_emGain =
         true; ///< app::dev config to tell stdCamera to not expose EM gain controls

--- a/apps/ocam2KCtrl/ocam2KCtrl.hpp
+++ b/apps/ocam2KCtrl/ocam2KCtrl.hpp
@@ -65,6 +65,7 @@ public:
     static constexpr bool c_stdCamera_readoutSpeed = false; ///< app::dev config to tell stdCamera not to expose readout speed controls
 
     static constexpr bool c_stdCamera_vShiftSpeed = false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
+    static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
     static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls
 

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -155,6 +155,7 @@ public:
    static constexpr bool c_stdCamera_readoutSpeed = true; ///< app::dev config to tell stdCamera to expose readout speed controls
 
    static constexpr bool c_stdCamera_vShiftSpeed = true; ///< app:dev config to tell stdCamera to expose vertical shift speed control
+   static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
    static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls
 

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -640,7 +640,11 @@ int pvcamCtrl::setFanSpeed()
     if( m_fanSpeedName != priorFanSpeed )
     {
         log<text_log>( "fan speed changed from '" + priorFanSpeed + "' to '" + m_fanSpeedName + "'",
-                       logPrio::LOG_INFO );
+                       logPrio::LOG_NOTICE );
+    }
+    else
+    {
+        log<text_log>( "fan speed set to '" + m_fanSpeedName + "'", logPrio::LOG_NOTICE );
     }
 
     recordCamera( true );

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -296,6 +296,10 @@ class pvcamCtrl : public MagAOXApp<true>,
 
     void dumpEnum( uns32 paramID, const std::string &paramMnem );
 
+    /// Get the current fan speed from the camera.
+    int getFanSpeed();
+
+    /// Get the current detector temperature and set point from the camera.
     int getTemp();
 
     static void st_endOfFrameCallback( FRAME_INFO *finfo, void *pvcamCtrlInst );
@@ -507,6 +511,14 @@ int pvcamCtrl::appLogic()
     if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
     {
         if( getTemp() != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return 0;
+            log<software_error>( { __FILE__, __LINE__ } );
+            return 0;
+        }
+
+        if( m_fanSpeedControlEnabled && getFanSpeed() != 0 )
         {
             if( powerState() != 1 || powerStateTarget() != 1 )
                 return 0;
@@ -1189,6 +1201,11 @@ int pvcamCtrl::connect()
 
         fillSpeedTable();
 
+        if( m_fanSpeedControlEnabled && getFanSpeed() < 0 )
+        {
+            return log<software_error, -1>( { __FILE__, __LINE__, "could not get fan speed" } );
+        }
+
         if( m_fanSpeedControlEnabled && setFanSpeed() < 0 )
         {
             return log<software_error, -1>( { __FILE__, __LINE__, "could not set fan speed" } );
@@ -1459,6 +1476,64 @@ int pvcamCtrl::getTemp()
         m_tempControlStatus    = true;
         m_tempControlOnTarget  = true;
         m_tempControlStatusStr = "LOCKED";
+    }
+
+    return 0;
+}
+
+int pvcamCtrl::getFanSpeed()
+{
+    if( state() == stateCodes::OPERATING || !m_fanSpeedControlEnabled )
+    {
+        return 0;
+    }
+
+    rs_bool isAvailable;
+    if( !pl_get_param( m_handle, PARAM_FAN_SPEED_SETPOINT, ATTR_AVAIL, static_cast<void *>( &isAvailable ) ) )
+    {
+        if( powerState() != 1 || powerStateTarget() != 1 )
+            return 0;
+        log_pvcam_software_error( "pl_get_param", "PARAM_FAN_SPEED_SETPOINT ATTR_AVAIL" );
+        state( stateCodes::ERROR );
+        return -1;
+    }
+
+    if( !isAvailable )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "PARAM_FAN_SPEED_SETPOINT not available while fan control is enabled" } );
+    }
+
+    int32 fanSpeed;
+    if( !pl_get_param( m_handle, PARAM_FAN_SPEED_SETPOINT, ATTR_CURRENT, static_cast<void *>( &fanSpeed ) ) )
+    {
+        if( powerState() != 1 || powerStateTarget() != 1 )
+            return 0;
+        log_pvcam_software_error( "pl_get_param", "PARAM_FAN_SPEED_SETPOINT ATTR_CURRENT" );
+        state( stateCodes::ERROR );
+        return -1;
+    }
+
+    if( fanSpeed == FAN_SPEED_HIGH )
+    {
+        m_fanSpeedName = "high";
+    }
+    else if( fanSpeed == FAN_SPEED_MEDIUM )
+    {
+        m_fanSpeedName = "medium";
+    }
+    else if( fanSpeed == FAN_SPEED_LOW )
+    {
+        m_fanSpeedName = "low";
+    }
+    else if( fanSpeed == FAN_SPEED_OFF )
+    {
+        m_fanSpeedName = "off";
+    }
+    else
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "unknown PVCAM fan-speed value: " + std::to_string( fanSpeed ) } );
     }
 
     return 0;

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -604,6 +604,8 @@ int pvcamCtrl::setVShiftSpeed()
 
 int pvcamCtrl::setFanSpeed()
 {
+    std::string priorFanSpeed = m_fanSpeedName;
+
     int32 fanSpeed = FAN_SPEED_HIGH;
 
     if( m_fanSpeedNameSet == "high" )
@@ -634,6 +636,13 @@ int pvcamCtrl::setFanSpeed()
     }
 
     m_fanSpeedName = m_fanSpeedNameSet;
+
+    if( m_fanSpeedName != priorFanSpeed )
+    {
+        log<text_log>( "fan speed changed from '" + priorFanSpeed + "' to '" + m_fanSpeedName + "'",
+                       logPrio::LOG_INFO );
+    }
+
     recordCamera( true );
 
     return 0;

--- a/apps/pvcamCtrl/pvcamCtrl.hpp
+++ b/apps/pvcamCtrl/pvcamCtrl.hpp
@@ -107,6 +107,9 @@ class pvcamCtrl : public MagAOXApp<true>,
     static constexpr bool c_stdCamera_vShiftSpeed =
         false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
 
+    static constexpr bool c_stdCamera_fanSpeed =
+        true; ///< app::dev config to tell stdCamera to expose fan-speed control
+
     static constexpr bool c_stdCamera_emGain =
         false; ///< app::dev config to tell stdCamera not to expose EM gain controls
 
@@ -255,6 +258,9 @@ class pvcamCtrl : public MagAOXApp<true>,
     int setTempSetPt();
     int setReadoutSpeed();
     int setVShiftSpeed();
+    /// Set the fan speed according to the configured stdCamera target.
+    int setFanSpeed();
+
     int setEMGain();
     int setExpTime();
     int setFPS();
@@ -319,7 +325,7 @@ pvcamCtrl::pvcamCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 
     m_default_x     = 1599.5;
     m_default_y     = 1599.5;
-    m_default_w     = 512; //we make this smaller by default
+    m_default_w     = 512; // we make this smaller by default
     m_default_h     = 512;
     m_default_bin_x = 1;
     m_default_bin_y = 1;
@@ -329,13 +335,18 @@ pvcamCtrl::pvcamCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
     m_full_w = 3200;
     m_full_h = 3200;
 
-
     m_defaultReadoutSpeed    = "dynamic_range";
     m_readoutSpeedNames      = { "sensitivity", "speed", "dynamic_range", "sub_electron" };
     m_readoutSpeedNameLabels = { "Sensitivity", "Speed", "Dynamic Range", "Sub-Electron" };
 
+    m_defaultFanSpeed    = "high";
+    m_fanSpeedNames      = { "high", "medium", "low", "off" };
+    m_fanSpeedNameLabels = { "High", "Medium", "Low", "Off" };
+
     m_readoutSpeedName    = m_defaultReadoutSpeed;
     m_readoutSpeedNameSet = m_defaultReadoutSpeed;
+    m_fanSpeedName        = m_defaultFanSpeed;
+    m_fanSpeedNameSet     = m_defaultFanSpeed;
 
     return;
 }
@@ -555,6 +566,17 @@ int pvcamCtrl::powerOnDefaults()
     m_readoutSpeedName    = m_defaultReadoutSpeed;
     m_readoutSpeedNameSet = m_defaultReadoutSpeed;
 
+    if( m_fanSpeedControlEnabled )
+    {
+        m_fanSpeedName    = m_defaultFanSpeed;
+        m_fanSpeedNameSet = m_defaultFanSpeed;
+    }
+    else
+    {
+        m_fanSpeedName.clear();
+        m_fanSpeedNameSet.clear();
+    }
+
     return 0;
 }
 
@@ -577,6 +599,43 @@ int pvcamCtrl::setReadoutSpeed()
 
 int pvcamCtrl::setVShiftSpeed()
 {
+    return 0;
+}
+
+int pvcamCtrl::setFanSpeed()
+{
+    int32 fanSpeed = FAN_SPEED_HIGH;
+
+    if( m_fanSpeedNameSet == "high" )
+    {
+        fanSpeed = FAN_SPEED_HIGH;
+    }
+    else if( m_fanSpeedNameSet == "medium" )
+    {
+        fanSpeed = FAN_SPEED_MEDIUM;
+    }
+    else if( m_fanSpeedNameSet == "low" )
+    {
+        fanSpeed = FAN_SPEED_LOW;
+    }
+    else if( m_fanSpeedNameSet == "off" )
+    {
+        fanSpeed = FAN_SPEED_OFF;
+    }
+    else
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "invalid fan-speed target: " + m_fanSpeedNameSet } );
+    }
+
+    if( pl_set_param( m_handle, PARAM_FAN_SPEED_SETPOINT, static_cast<void *>( &fanSpeed ) ) == false )
+    {
+        log_pvcam_software_error( "pl_set_param", "PARAM_FAN_SPEED_SETPOINT" );
+        return -1;
+    }
+
+    m_fanSpeedName = m_fanSpeedNameSet;
+    recordCamera( true );
+
     return 0;
 }
 
@@ -1116,6 +1175,11 @@ int pvcamCtrl::connect()
         }
 
         fillSpeedTable();
+
+        if( m_fanSpeedControlEnabled && setFanSpeed() < 0 )
+        {
+            return log<software_error, -1>( { __FILE__, __LINE__, "could not set fan speed" } );
+        }
     }
     else
     {

--- a/apps/qhyCtrl/qhyCtrl.hpp
+++ b/apps/qhyCtrl/qhyCtrl.hpp
@@ -118,6 +118,7 @@ public:
    static constexpr bool c_stdCamera_readoutSpeed = false; ///< app::dev config to tell stdCamera not to  expose readout speed controls
 
    static constexpr bool c_stdCamera_vShiftSpeed = false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
+   static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
    static constexpr bool c_stdCamera_emGain = false; ///< app::dev config to tell stdCamera to not expose EM gain controls
 

--- a/apps/zylaCtrl/zylaCtrl.hpp
+++ b/apps/zylaCtrl/zylaCtrl.hpp
@@ -63,6 +63,7 @@ public:
    static constexpr bool c_stdCamera_readoutSpeed = false; ///< app::dev config to tell stdCamera to expose readout speed controls
 
    static constexpr bool c_stdCamera_vShiftSpeed = false; ///< app:dev config to tell stdCamera to expose vertical shift speed control
+   static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
    static constexpr bool c_stdCamera_emGain = false; ///< app::dev config to tell stdCamera to expose EM gain controls
 

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -142,6 +142,29 @@ int loadCameraConfig( cameraConfigMap &ccmap, ///< [out] the map in which to pla
  *          is also exposed, and \ref m_defaultVShiftSpeed will be set accordingly.  derivedT can set a sensible default
  *          on constuction.
  *
+ *     - Fan Speed:
+ *
+ *        - A static configuration variable must be defined in derivedT as
+ *          \code
+ *              static constexpr bool c_stdCamera_fanSpeed = true; //or: false
+ *          \endcode
+ *          which determines whether or not fan-speed controls are supported by the app.
+ *
+ *        - If true, then the implementation should populate \ref m_fanSpeedNames and
+ *          \ref m_fanSpeedNameLabels (vectors of strings) on construction to the allowed values.
+ *
+ *        - If true then the following interface must be defined:
+ *          \code
+ *              int setFanSpeed(); // configures camera according to m_fanSpeedNameSet
+ *          \endcode
+ *          function must be defined which sets the camera according to \ref m_fanSpeedNameSet.
+ *          The implementation must also manage \ref m_fanSpeedName, keeping it up to date.
+ *
+ *        - The configuration settings "camera.fanSpeedControl" and "camera.defaultFanSpeed"
+ *          are also exposed. The former determines whether the INDI control is published, and the latter
+ *          sets the default fan speed applied after power-on. The value of \ref m_defaultFanSpeed must
+ *          be one of `high`, `medium`, `low`, or `off`.
+ *
  *     - Exposure Time:
  *        - A static configuration variable must be defined in derivedT as
  *          \code
@@ -300,8 +323,10 @@ class stdCamera
 
     float m_startupTemp{ -999 }; ///< The temperature to set after a power-on.  Set to <= -999 to not use [default].
 
-    std::string m_defaultReadoutSpeed; ///< The default readout speed of the camera.
-    std::string m_defaultVShiftSpeed;  ///< The default readout speed of the camera.
+    std::string m_defaultReadoutSpeed;             ///< The default readout speed of the camera.
+    std::string m_defaultVShiftSpeed;              ///< The default readout speed of the camera.
+    bool        m_fanSpeedControlEnabled{ false }; ///< Whether or not fan-speed control is published through INDI.
+    std::string m_defaultFanSpeed;                 ///< The default fan speed to apply after power on.
 
     ///@}
 
@@ -357,6 +382,20 @@ class stdCamera
     pcf::IndiProperty m_indiP_vShiftSpeed;
 
     pcf::IndiProperty m_indiP_emGain;
+
+    ///@}
+
+    /** \name Fan Speed Control
+     * @{
+     */
+
+    std::vector<std::string> m_fanSpeedNames;      ///< The selectable fan-speed names.
+    std::vector<std::string> m_fanSpeedNameLabels; ///< User-facing labels for the fan-speed names.
+
+    std::string m_fanSpeedName;    ///< The current fan-speed name.
+    std::string m_fanSpeedNameSet; ///< The requested fan-speed name to be applied by derivedT.
+
+    pcf::IndiProperty m_indiP_fanSpeed; ///< Property used to control the selected fan speed.
 
     ///@}
 
@@ -554,6 +593,10 @@ class stdCamera
 
     int createVShiftSpeed( const mx::meta::trueFalseT<false> &f );
 
+    int createFanSpeed( const mx::meta::trueFalseT<true> &t );
+
+    int createFanSpeed( const mx::meta::trueFalseT<false> &f );
+
   public:
     /// Startup function
     /**
@@ -731,6 +774,26 @@ class stdCamera
      * \returns -1 on error.
      */
     int newCallBack_vShiftSpeed(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
+
+    /// Interface to setFanSpeed when the derivedT has fan-speed control
+    /** Tag-dispatch resolution of c_stdCamera_fanSpeed==true will call this function.
+     * Calls derivedT::setFanSpeed.
+     */
+    int setFanSpeed( const mx::meta::trueFalseT<true> &t );
+
+    /// Interface to setFanSpeed when the derivedT does not have fan-speed control
+    /** Tag-dispatch resolution of c_stdCamera_fanSpeed==false will call this function.
+     * Just returns 0.
+     */
+    int setFanSpeed( const mx::meta::trueFalseT<false> &f );
+
+    /// Callback to process a NEW fan-speed request
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    int newCallBack_fanSpeed(
         const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
     /// Interface to setEMGain when the derivedT has EM Gain
@@ -1095,6 +1158,29 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     "The default vertical shift speed." );
     }
 
+    if( derivedT::c_stdCamera_fanSpeed )
+    {
+        config.add( "camera.fanSpeedControl",
+                    "",
+                    "camera.fanSpeedControl",
+                    argType::Required,
+                    "camera",
+                    "fanSpeedControl",
+                    false,
+                    "bool",
+                    "Whether or not fan-speed control is exposed." );
+
+        config.add( "camera.defaultFanSpeed",
+                    "",
+                    "camera.defaultFanSpeed",
+                    argType::Required,
+                    "camera",
+                    "defaultFanSpeed",
+                    false,
+                    "string",
+                    "The default fan speed. Must be one of high, medium, low, or off." );
+    }
+
     if( derivedT::c_stdCamera_emGain )
     {
         config.add( "camera.maxEMGain",
@@ -1203,6 +1289,22 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
     if( derivedT::c_stdCamera_vShiftSpeed )
     {
         config( m_defaultVShiftSpeed, "camera.defaultVShiftSpeed" );
+    }
+
+    if( derivedT::c_stdCamera_fanSpeed )
+    {
+        config( m_fanSpeedControlEnabled, "camera.fanSpeedControl" );
+        config( m_defaultFanSpeed, "camera.defaultFanSpeed" );
+
+        if( m_defaultFanSpeed != "high" && m_defaultFanSpeed != "medium" && m_defaultFanSpeed != "low" &&
+            m_defaultFanSpeed != "off" )
+        {
+            return derivedT::template log<software_critical, -1>(
+                { __FILE__,
+                  __LINE__,
+                  "invalid camera.defaultFanSpeed: '" + m_defaultFanSpeed +
+                      "'. Must be one of high, medium, low, or off." } );
+        }
     }
 
     if( derivedT::c_stdCamera_emGain )
@@ -1365,6 +1467,34 @@ int stdCamera<derivedT>::createVShiftSpeed( const mx::meta::trueFalseT<0> &f )
 }
 
 template <class derivedT>
+int stdCamera<derivedT>::createFanSpeed( const mx::meta::trueFalseT<true> &t )
+{
+    static_cast<void>( t );
+
+    derived().createStandardIndiSelectionSw( m_indiP_fanSpeed, "fan_speed", m_fanSpeedNames, "Fan Speed" );
+
+    if( m_fanSpeedNameLabels.size() == m_fanSpeedNames.size() )
+    {
+        for( size_t n = 0; n < m_fanSpeedNames.size(); ++n )
+        {
+            m_indiP_fanSpeed[m_fanSpeedNames[n]].setLabel( m_fanSpeedNameLabels[n] );
+        }
+    }
+
+    derived().registerIndiPropertyNew( m_indiP_fanSpeed, st_newCallBack_stdCamera );
+
+    return 0;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::createFanSpeed( const mx::meta::trueFalseT<0> &f )
+{
+    static_cast<void>( f );
+
+    return 0;
+}
+
+template <class derivedT>
 int stdCamera<derivedT>::appStartup()
 {
 
@@ -1434,6 +1564,18 @@ int stdCamera<derivedT>::appStartup()
     {
         mx::meta::trueFalseT<derivedT::c_stdCamera_vShiftSpeed> tf;
         if( createVShiftSpeed( tf ) < 0 )
+        {
+#ifndef STDCAMERA_TEST_NOLOG
+            derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+            return -1;
+        }
+    }
+
+    if( derivedT::c_stdCamera_fanSpeed && m_fanSpeedControlEnabled )
+    {
+        mx::meta::trueFalseT<derivedT::c_stdCamera_fanSpeed> tf;
+        if( createFanSpeed( tf ) < 0 )
         {
 #ifndef STDCAMERA_TEST_NOLOG
             derivedT::template log<software_error>( { __FILE__, __LINE__ } );
@@ -2019,6 +2161,8 @@ int stdCamera<derivedT>::newCallBack_stdCamera( const pcf::IndiProperty &ipRecv 
         return newCallBack_readoutSpeed( ipRecv );
     else if( derivedT::c_stdCamera_vShiftSpeed && name == "vshift_speed" )
         return newCallBack_vShiftSpeed( ipRecv );
+    else if( derivedT::c_stdCamera_fanSpeed && m_fanSpeedControlEnabled && name == "fan_speed" )
+        return newCallBack_fanSpeed( ipRecv );
     else if( derivedT::c_stdCamera_emGain && name == "emgain" )
         return newCallBack_emgain( ipRecv );
     else if( derivedT::c_stdCamera_exptimeCtrl && name == "exptime" )
@@ -2278,6 +2422,66 @@ int stdCamera<derivedT>::newCallBack_vShiftSpeed( const pcf::IndiProperty &ipRec
 
         mx::meta::trueFalseT<derivedT::c_stdCamera_vShiftSpeed> tf;
         return setVShiftSpeed( tf );
+    }
+
+    return 0;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::setFanSpeed( const mx::meta::trueFalseT<true> &t )
+{
+    static_cast<void>( t );
+    return derived().setFanSpeed();
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::setFanSpeed( const mx::meta::trueFalseT<false> &f )
+{
+    static_cast<void>( f );
+    return 0;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::newCallBack_fanSpeed( const pcf::IndiProperty &ipRecv )
+{
+    if( derivedT::c_stdCamera_fanSpeed && m_fanSpeedControlEnabled )
+    {
+#ifdef XWCTEST_INDI_CALLBACK_VALIDATION
+        return 0;
+#endif
+
+        std::unique_lock<std::mutex> lock( derived().m_indiMutex );
+
+        std::string newspeed;
+
+        for( size_t i = 0; i < m_fanSpeedNames.size(); ++i )
+        {
+            if( !ipRecv.find( m_fanSpeedNames[i] ) )
+                continue;
+
+            if( ipRecv[m_fanSpeedNames[i]].getSwitchState() == pcf::IndiElement::On )
+            {
+                if( newspeed != "" )
+                {
+                    derivedT::template log<text_log>( "More than one fan speed selected", logPrio::LOG_ERROR );
+                    return -1;
+                }
+
+                newspeed = m_fanSpeedNames[i];
+            }
+        }
+
+        if( newspeed == "" )
+        {
+            m_fanSpeedNameSet = m_fanSpeedName;
+        }
+        else
+        {
+            m_fanSpeedNameSet = newspeed;
+        }
+
+        mx::meta::trueFalseT<derivedT::c_stdCamera_fanSpeed> tf;
+        return setFanSpeed( tf );
     }
 
     return 0;
@@ -3092,6 +3296,11 @@ int stdCamera<derivedT>::updateINDI()
                 m_indiP_vShiftSpeed, m_vShiftSpeedName, derived().m_indiDriver, INDI_OK );
         }
 
+        if( derivedT::c_stdCamera_fanSpeed && m_fanSpeedControlEnabled )
+        {
+            indi::updateSelectionSwitchIfChanged( m_indiP_fanSpeed, m_fanSpeedName, derived().m_indiDriver, INDI_OK );
+        }
+
         if( derivedT::c_stdCamera_emGain )
         {
             derived().updateIfChanged( m_indiP_emGain, "current", m_emGain, INDI_IDLE );
@@ -3261,6 +3470,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
     static bool        last_synchro      = false;
     static float       last_vshiftSpeed  = -1;
     static bool        last_cropMode     = false;
+    static std::string last_fanSpeed;
     static std::string last_readoutSpeed;
 
     if( force || m_modeName != last_mode || m_currentROI.x != last_roi.x || m_currentROI.y != last_roi.y ||
@@ -3270,7 +3480,8 @@ int stdCamera<derivedT>::recordCamera( bool force )
         m_ccdTempSetpt != last_ccdTempSetpt || m_tempControlStatus != last_tempControlStatus ||
         m_tempControlOnTarget != last_tempControlOnTarget || m_tempControlStatusStr != last_tempControlStatusStr ||
         m_shutterStatus != last_shutterStatus || m_shutterState != last_shutterState || m_synchro != last_synchro ||
-        m_vshiftSpeed != last_vshiftSpeed || m_cropMode != last_cropMode || m_readoutSpeedName != last_readoutSpeed)
+        m_vshiftSpeed != last_vshiftSpeed || m_cropMode != last_cropMode || m_fanSpeedName != last_fanSpeed ||
+        m_readoutSpeedName != last_readoutSpeed )
     {
         derived().template telem<telem_stdcam>( { m_modeName,
                                                   m_currentROI.x,
@@ -3293,6 +3504,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
                                                   (uint8_t)m_synchro,
                                                   m_vshiftSpeed,
                                                   (uint8_t)m_cropMode,
+                                                  m_fanSpeedName,
                                                   m_readoutSpeedName } );
 
         last_mode                 = m_modeName;
@@ -3311,6 +3523,7 @@ int stdCamera<derivedT>::recordCamera( bool force )
         last_synchro              = m_synchro;
         last_vshiftSpeed          = m_vshiftSpeed;
         last_cropMode             = m_cropMode;
+        last_fanSpeed             = m_fanSpeedName;
         last_readoutSpeed         = m_readoutSpeedName;
     }
 

--- a/libMagAOX/logger/types/schemas/telem_stdcam.fbs
+++ b/libMagAOX/logger/types/schemas/telem_stdcam.fbs
@@ -50,9 +50,10 @@ table Telem_stdcam_fb
 
    cropMode:int8 = -1;
 
+   fan_speed:string;
+
    readout_speed:string;
 
 }
 
 root_type Telem_stdcam_fb;
-

--- a/libMagAOX/logger/types/telem_stdcam.hpp
+++ b/libMagAOX/logger/types/telem_stdcam.hpp
@@ -57,6 +57,7 @@ struct telem_stdcam : public flatbuffer_log
                 const uint8_t & synchro,             ///<[in]
                 const float & vshift,                ///<[in]
                 const uint8_t & cropMode,            ///<[in]
+                const std::string & fan_speed,       ///<[in]
                 const std::string & readout_speed     ///<[in]
               )
       {
@@ -69,9 +70,10 @@ struct telem_stdcam : public flatbuffer_log
          auto _shutterStatusStr = builder.CreateString(shutterStatusSr);
          auto _shutter = CreateShutter(builder, _shutterStatusStr, shutterState);
 
+         auto _fanSpeed = builder.CreateString(fan_speed);
          auto _readoutSpeed = builder.CreateString(readout_speed);
 
-         auto fp = CreateTelem_stdcam_fb(builder, _mode, _roi, exptime, fps, emGain, adcSpeed, _tempCtrl, _shutter, synchro, vshift, cropMode, _readoutSpeed);
+         auto fp = CreateTelem_stdcam_fb(builder, _mode, _roi, exptime, fps, emGain, adcSpeed, _tempCtrl, _shutter, synchro, vshift, cropMode, _fanSpeed, _readoutSpeed);
          builder.Finish(fp);
       }
 
@@ -188,6 +190,15 @@ struct telem_stdcam : public flatbuffer_log
          {
             msg += " rospd: ";
             msg += fbs->readout_speed()->c_str();
+         }
+      }
+
+      if(fbs->fan_speed() != nullptr)
+      {
+         if(fbs->fan_speed()->size() > 0)
+         {
+            msg += " fan: ";
+            msg += fbs->fan_speed()->c_str();
          }
       }
 
@@ -355,6 +366,16 @@ struct telem_stdcam : public flatbuffer_log
       else return false;
    }
 
+   static std::string fan_speed( void * msgBuffer )
+   {
+      auto fbs = GetTelem_stdcam_fb(msgBuffer);
+      if(fbs->fan_speed() != nullptr)
+      {
+         return std::string(fbs->fan_speed()->c_str());
+      }
+      else return "";
+   }
+
    static std::string readout_speed( void * msgBuffer )
    {
       auto fbs = GetTelem_stdcam_fb(msgBuffer);
@@ -393,6 +414,7 @@ struct telem_stdcam : public flatbuffer_log
       else if(member == "synchro") return logMetaDetail({"SYNCHRO", logMeta::valTypes::Bool, logMeta::metaTypes::State, reinterpret_cast<void*>(&synchro)});
       else if(member == "vshift") return logMetaDetail({"VERT SHIFT SPEED", logMeta::valTypes::Float, logMeta::metaTypes::State, reinterpret_cast<void*>(&vshift)});
       else if(member == "cropMode") return logMetaDetail({"CROP MODE", logMeta::valTypes::Bool, logMeta::metaTypes::State, reinterpret_cast<void*>(&cropMode)});
+      else if(member == "fan_speed") return logMetaDetail({"FAN SPEED", logMeta::valTypes::String, logMeta::metaTypes::State, reinterpret_cast<void*>(&fan_speed)});
       else if(member == "readout_speed") return logMetaDetail({"READOUT SPEED", logMeta::valTypes::String, logMeta::metaTypes::State, reinterpret_cast<void*>(&readout_speed)});
       else
       {
@@ -409,4 +431,3 @@ struct telem_stdcam : public flatbuffer_log
 } //namespace MagAOX
 
 #endif //logger_types_telem_stdcam_hpp
-


### PR DESCRIPTION

This work was performed by Codex (GPT-5) in response to the prompt: "Implement config-driven pvcam/stdCamera fan control, with startup/default handling, telemetry, and logging."

## Summary

This PR adds shared `stdCamera` fan control support and wires it into `pvcamCtrl`.

Changes included:
- add optional fan control support to `dev::stdCamera`
- add `camera.fanSpeedControl` and `camera.defaultFanSpeed` config support
- hard-fail invalid `camera.defaultFanSpeed` values
- expose fan control through INDI as `fan_speed`
- add fan state to `telem_stdcam`
- implement PVCAM fan mapping in `pvcamCtrl` for:
  - `high`
  - `medium`
  - `low`
  - `off`
- read back the current PVCAM fan state on connect before applying the configured default
- log fan-speed application/changes at `LOG_NOTICE`

## Behavior

When fan control is enabled in config:
- `stdCamera` publishes a `fan_speed` selection property
- `pvcamCtrl` reads the current camera fan setting on connect
- `pvcamCtrl` applies the configured default fan speed
- startup always emits a fan-speed log message
- telemetry records the current fan state

If `camera.defaultFanSpeed` is invalid, config load fails immediately.

## Notes

This is intentionally config-driven rather than runtime feature-discovery driven:
- compile-time support is declared by the app
- config determines whether the control is exposed
- the operator is responsible for matching config to hardware

For PVCAM cameras that do not support `PARAM_FAN_SPEED_SETPOINT`, startup/set operations will fail clearly at runtime.

## Verification

Verified locally:
- `telem_stdcam` FlatBuffer regeneration succeeded
- the `libMagAOX` side rebuilt successfully
- PVCAM fan control worked in deployment testing

Local limitation:
- a full `pvcamCtrl` build could not be completed in this environment because the PVCAM SDK headers were not installed
