### PR TITLE
Add shmim info utility

### DIFF
--- a/tests/tests.list
+++ b/tests/tests.list
@@ -111,6 +111,7 @@
 
 ../utils/tests/cursesINDI_test
 ../utils/tests/logdump_test
+../utils/tests/shmimInfo_test
 ../utils/tests/shmimLat_test
 ../utils/tests/shmimPlot_test
 ../utils/tests/xrif2fits_test

--- a/utils/shmimInfo/Makefile
+++ b/utils/shmimInfo/Makefile
@@ -1,0 +1,6 @@
+
+allall: all
+
+OTHER_HEADERS=
+TARGET=shmimInfo
+include ../../Make/magAOXUtil.mk

--- a/utils/shmimInfo/shmimInfo.cpp
+++ b/utils/shmimInfo/shmimInfo.cpp
@@ -1,0 +1,349 @@
+/** \file shmimInfo.cpp
+ * \brief The shmimInfo main program and implementation.
+ *
+ * \ingroup shmimInfo_files
+ *
+ * \author Codex
+ */
+
+#include "shmimInfo.hpp"
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <ctime>
+#include <fcntl.h>
+#include <iomanip>
+#include <iostream>
+#include <semaphore.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace
+{
+
+volatile sig_atomic_t g_timeToDie = 0;
+
+/// Handle termination signals by requesting a clean shutdown.
+void sigTermHandler( int        signum /**< [in] received signal number. */,
+                     siginfo_t *siginf /**< [in] unused signal metadata. */,
+                     void      *ucont /**< [in] unused signal context. */ )
+{
+    static_cast<void>( signum );
+    static_cast<void>( siginf );
+    static_cast<void>( ucont );
+
+    std::cerr << "\n";
+
+    g_timeToDie = 1;
+}
+
+/// Install the signal handlers used by this utility.
+int installSignalHandlers( const std::string &invokedName /**< [in] utility name for error reporting. */ )
+{
+    struct sigaction act;
+    sigset_t         set;
+
+    act.sa_sigaction = sigTermHandler;
+    act.sa_flags     = SA_SIGINFO;
+    sigemptyset( &set );
+    act.sa_mask = set;
+
+    errno = 0;
+    if( sigaction( SIGTERM, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGTERM handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    errno = 0;
+    if( sigaction( SIGQUIT, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGQUIT handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    errno = 0;
+    if( sigaction( SIGINT, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGINT handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    return 0;
+}
+
+} // namespace
+
+shmimInfo::shmimInfo() = default;
+
+shmimInfo::~shmimInfo()
+{
+    closeStream();
+}
+
+void shmimInfo::setupConfig()
+{
+    config.add( "shmimName",
+                "n",
+                "shmimName",
+                argType::Required,
+                "",
+                "shmimName",
+                false,
+                "string",
+                "The name of the shared memory image stream to inspect." );
+
+    config.add( "nFrames",
+                "N",
+                "nFrames",
+                argType::Required,
+                "",
+                "nFrames",
+                false,
+                "int",
+                "The number of frame arrivals to time when measuring FPS. Default is 100." );
+
+    config.add( "timeout",
+                "t",
+                "timeout",
+                argType::Required,
+                "",
+                "timeout",
+                false,
+                "float",
+                "The per-frame wait timeout in seconds. Default is 1.0 second." );
+}
+
+void shmimInfo::loadConfig()
+{
+    config( m_shmimName, "shmimName" );
+    config( m_nFrames, "nFrames" );
+    config( m_timeoutSec, "timeout" );
+
+    if( m_shmimName.empty() )
+    {
+        std::cerr << "shmim name not specified with -n\n";
+        doHelp = true;
+        return;
+    }
+
+    if( m_nFrames < 2 )
+    {
+        std::cerr << "nFrames must be at least 2 to measure frame rate\n";
+        doHelp = true;
+        return;
+    }
+
+    if( m_timeoutSec <= 0 )
+    {
+        std::cerr << "timeout must be greater than 0 seconds\n";
+        doHelp = true;
+        return;
+    }
+}
+
+int shmimInfo::execute()
+{
+    if( installSignalHandlers( invokedName ) < 0 )
+    {
+        return -1;
+    }
+
+    if( openStream() < 0 )
+    {
+        closeStream();
+        return -1;
+    }
+
+    std::cout << "shmim: " << m_shmimName << "\n";
+    std::cout << "size: " << m_width << " " << m_height << " " << m_depth << "\n";
+
+    int rv = measureFrames();
+    closeStream();
+
+    return rv;
+}
+
+int shmimInfo::openStream()
+{
+    int logged = 0;
+
+    while( !g_timeToDie )
+    {
+        int  SM_fd;
+        char SM_fname[200];
+        ImageStreamIO_filename( SM_fname, sizeof( SM_fname ), m_shmimName.c_str() );
+
+        SM_fd = open( SM_fname, O_RDWR );
+        if( SM_fd == -1 )
+        {
+            if( !logged )
+            {
+                std::cerr << "ImageStream " << m_shmimName << " not found (yet). Retrying . . .\n";
+            }
+
+            logged = 1;
+            sleep( 1 );
+            continue;
+        }
+
+        logged = 0;
+        close( SM_fd );
+
+        if( ImageStreamIO_openIm( &m_imageStream, m_shmimName.c_str() ) != 0 )
+        {
+            mx::sys::sleep( 1 );
+            continue;
+        }
+
+        if( m_imageStream.md[0].sem <= m_semaphoreNumber )
+        {
+            ImageStreamIO_closeIm( &m_imageStream );
+            mx::sys::sleep( 1 );
+            continue;
+        }
+
+        struct stat buffer;
+        if( stat( SM_fname, &buffer ) != 0 )
+        {
+            std::cerr << "Could not get inode for " << m_shmimName << ".\n";
+            ImageStreamIO_closeIm( &m_imageStream );
+            return -1;
+        }
+
+        m_inode  = buffer.st_ino;
+        m_opened = true;
+
+        m_width  = m_imageStream.md[0].size[0];
+        m_height = 1;
+        m_depth  = 1;
+
+        if( m_imageStream.md[0].naxis > 1 )
+        {
+            m_height = m_imageStream.md[0].size[1];
+        }
+
+        if( m_imageStream.md[0].naxis > 2 )
+        {
+            m_depth = m_imageStream.md[0].size[2];
+        }
+
+        return 0;
+    }
+
+    return -1;
+}
+
+void shmimInfo::closeStream()
+{
+    if( !m_opened )
+    {
+        return;
+    }
+
+    if( m_semaphoreNumber >= 0 )
+    {
+        m_imageStream.semReadPID[m_semaphoreNumber] = 0;
+    }
+
+    ImageStreamIO_closeIm( &m_imageStream );
+    m_opened = false;
+}
+
+int shmimInfo::measureFrames()
+{
+    m_semaphoreNumber = ImageStreamIO_getsemwaitindex( &m_imageStream, m_semaphoreNumber );
+    if( m_semaphoreNumber < 0 )
+    {
+        std::cerr << "No valid semaphore found for " << m_shmimName << ".\n";
+        return -1;
+    }
+
+    ImageStreamIO_semflush( &m_imageStream, m_semaphoreNumber );
+
+    sem_t *sem = m_imageStream.semptr[m_semaphoreNumber];
+
+    timespec t0{};
+    timespec t1{};
+
+    for( size_t n = 0; n < m_nFrames; ++n )
+    {
+        timespec ts;
+
+        if( clock_gettime( CLOCK_REALTIME, &ts ) < 0 )
+        {
+            std::cerr << "error from clock_gettime\n";
+            return -1;
+        }
+
+        ts.tv_sec += static_cast<time_t>( m_timeoutSec );
+        ts.tv_nsec += static_cast<long>( ( m_timeoutSec - static_cast<time_t>( m_timeoutSec ) ) * 1e9 );
+        if( ts.tv_nsec >= 1000000000L )
+        {
+            ++ts.tv_sec;
+            ts.tv_nsec -= 1000000000L;
+        }
+
+        if( sem_timedwait( sem, &ts ) != 0 )
+        {
+            if( errno == ETIMEDOUT )
+            {
+                std::cerr << "Timed out waiting for frame " << ( n + 1 ) << " of " << m_nFrames << ".\n";
+            }
+            else if( errno == EINTR && g_timeToDie )
+            {
+                std::cerr << "Interrupted while waiting for frames.\n";
+            }
+            else
+            {
+                std::cerr << "error from sem_timedwait: " << strerror( errno ) << "\n";
+            }
+
+            char SM_fname[200];
+            ImageStreamIO_filename( SM_fname, sizeof( SM_fname ), m_shmimName.c_str() );
+
+            struct stat buffer;
+            if( stat( SM_fname, &buffer ) != 0 || buffer.st_ino != m_inode )
+            {
+                std::cerr << "The shmim changed while waiting for frames.\n";
+            }
+
+            return -1;
+        }
+
+        if( clock_gettime( CLOCK_MONOTONIC, n == 0 ? &t0 : &t1 ) < 0 )
+        {
+            std::cerr << "error from clock_gettime\n";
+            return -1;
+        }
+    }
+
+    double elapsed = elapsedSeconds( t0, t1 );
+    if( elapsed <= 0 )
+    {
+        std::cerr << "Measured non-positive elapsed time.\n";
+        return -1;
+    }
+
+    double fps = static_cast<double>( m_nFrames - 1 ) / elapsed;
+
+    std::cout << std::fixed << std::setprecision( 6 );
+    std::cout << "timed_frames: " << m_nFrames << "\n";
+    std::cout << "elapsed_sec: " << elapsed << "\n";
+    std::cout << "fps: " << fps << "\n";
+
+    return 0;
+}
+
+double shmimInfo::elapsedSeconds( const timespec &t0, const timespec &t1 )
+{
+    return static_cast<double>( t1.tv_sec - t0.tv_sec ) + 1e-9 * static_cast<double>( t1.tv_nsec - t0.tv_nsec );
+}
+
+int main( int argc, char **argv )
+{
+    shmimInfo si;
+
+    return si.main( argc, argv );
+}

--- a/utils/shmimInfo/shmimInfo.hpp
+++ b/utils/shmimInfo/shmimInfo.hpp
@@ -1,0 +1,98 @@
+/** \file shmimInfo.hpp
+ * \brief The shmimInfo class declaration.
+ *
+ * \ingroup shmimInfo_files
+ *
+ * \author Codex
+ */
+
+#ifndef shmimInfo_hpp
+#define shmimInfo_hpp
+
+#include <ImageStreamIO/ImageStruct.h>
+#include <ImageStreamIO/ImageStreamIO.h>
+
+#include "../../libMagAOX/libMagAOX.hpp"
+
+/** \defgroup shmimInfo shmimInfo: report shmim dimensions and measured frame rate
+ * \brief Attaches to a shmim, reports its dimensions, and measures frame rate over a configurable number of frames.
+ *
+ * \ingroup utils
+ *
+ */
+
+/** \defgroup shmimInfo_files shmimInfo Files
+ * \ingroup shmimInfo
+ */
+
+/// Utility for reporting shmim dimensions and a measured frame rate.
+/**
+ * \ingroup shmimInfo
+ */
+class shmimInfo : public mx::app::application
+{
+  protected:
+    /** \name Configurable Parameters
+     * @{
+     */
+
+    std::string m_shmimName; ///< Name of the shmim to inspect.
+
+    size_t m_nFrames{ 100 }; ///< Number of frame arrivals to time when measuring frame rate.
+
+    double m_timeoutSec{ 1.0 }; ///< Timeout, in seconds, used for each frame-arrival wait.
+
+    ///@}
+
+    /** \name Stream State - Data
+     * @{
+     */
+
+    IMAGE m_imageStream{}; ///< Attached ImageStreamIO handle for the shmim under test.
+
+    bool m_opened{ false }; ///< Tracks whether `m_imageStream` currently owns an open attachment.
+
+    ino_t m_inode{ 0 }; ///< Inode of the backing shmim file used to detect stream replacement while waiting.
+
+    int m_semaphoreNumber{ 9 }; ///< Preferred semaphore index used to subscribe to frame arrivals.
+
+    uint32_t m_width{ 0 }; ///< Stream size along the first axis.
+
+    uint32_t m_height{ 1 }; ///< Stream size along the second axis, or 1 when absent.
+
+    uint32_t m_depth{ 1 }; ///< Stream size along the third axis, or 1 when absent.
+
+    ///@}
+
+  public:
+    /// Default constructor.
+    shmimInfo();
+
+    /// Destructor.
+    ~shmimInfo() override;
+
+    /// Define command-line and config-file options.
+    void setupConfig() override;
+
+    /// Load configured values into member state.
+    void loadConfig() override;
+
+    /// Connect to the shmim, report dimensions, and measure frame rate.
+    int execute() override;
+
+  protected:
+    /// Open the shmim and cache its dimensions.
+    int openStream();
+
+    /// Close the shmim attachment if it is open.
+    void closeStream();
+
+    /// Wait for the configured number of frame arrivals and report the measured FPS.
+    int measureFrames();
+
+    /// Convert a pair of timespec timestamps to elapsed seconds.
+    static double elapsedSeconds( const timespec &t0 /**< [in] starting timestamp. */,
+                                  const timespec &t1 /**< [in] ending timestamp. */ );
+};
+
+#endif // shmimInfo_hpp

--- a/utils/tests/shmimInfo_test.cpp
+++ b/utils/tests/shmimInfo_test.cpp
@@ -1,0 +1,21 @@
+/** \file shmimInfo_test.cpp
+ * \brief Catch2 tests for the shmimInfo utility.
+ *
+ * \author Codex
+ */
+
+#include "../../tests/catch2/catch.hpp"
+
+#include <type_traits>
+
+#include "../shmimInfo/shmimInfo.hpp"
+
+namespace shmimInfo_test
+{
+
+SCENARIO( "shmimInfo declares the expected application type", "[shmimInfo]" )
+{
+    REQUIRE( std::is_base_of_v<mx::app::application, shmimInfo> );
+}
+
+} // namespace shmimInfo_test


### PR DESCRIPTION
This work was performed by Codex (GPT-5-based) in response to the prompt: "I need a simple utility that connects to a shmim (image stream) and reports its size (three dimensions) and measures the frame rate of the stream my attaching to it and timing a configurable N frames.  The existing utils/shmimPlot can be reviewed for CLI style."

## Summary

Adds a new `utils/shmimInfo` utility that:
- attaches to a shmim by name
- reports the stream size as three dimensions
- measures frame rate by timing a configurable number of frame arrivals
- follows the existing `mx::app::application` CLI style used by the shmim utilities

## Changes

- added `utils/shmimInfo/` with:
  - `shmimInfo.hpp`
  - `shmimInfo.cpp`
  - `Makefile`
- added a lightweight utility test:
  - `utils/tests/shmimInfo_test.cpp`
- registered the new test in:
  - `tests/tests.list`

## CLI

Example:
```bash
shmimInfo -n camwfs -N 100 -t 1.0
