### PR TITLE
zaberlowlevel ascii crash hardening

### DIFF
--- a/agents/plans/zaberLowLevel-ascii-crash-hardening.md
+++ b/agents/plans/zaberLowLevel-ascii-crash-hardening.md
@@ -1,0 +1,255 @@
+Prompt: apps/zaberLowLevel is crashing frequently. The problem seems to be that a command is rejected, but the command is different which is rejected. Review AGENTS.md and analyze please. Let's document this as a plan under agents/plans, and please lay out a plan to address these issues.
+
+## Analysis
+
+The current `apps/zaberLowLevel` failure pattern is most consistent with ASCII protocol reply desynchronization, not with one specific invalid Zaber command.
+
+The reported symptoms line up as follows:
+
+- one poll cycle logs a rejected command such as `get driver.temperature` or `get system.led.enable`
+- the specific rejected command varies from run to run
+- the same cycle then logs an unknown warning token such as `6` or `5`
+- warning parsing then fails with `parsing incomplete warning response`
+- `zaberLowLevel` transitions from `READY` to `ERROR` to `FAILURE`
+
+### Observed protocol-handling problems
+
+#### 1. `sendCommand()` does not distinguish replies from alerts/info
+
+`apps/zaberLowLevel/zaberStage.hpp` uses `za_receive()` and `za_decode()` to read one ASCII message at a time after each command is sent.
+
+The bundled Zaber ASCII transport explicitly supports three decoded message types:
+
+- `@` normal reply
+- `!` alert
+- `#` info
+
+However, the stage code currently accepts the first decoded message whose `device_address` matches the stage and hands it to `getResponse()` as though it were the reply for the command in flight.
+
+That is unsafe because unsolicited `!` alerts and `#` info messages can arrive between command send and command reply. If one of those messages is consumed first:
+
+- `getResponse()` interprets the message as the command reply
+- `m_commandStatus` can be set false because the message does not carry normal `"OK"` reply flags
+- the command currently being issued gets blamed as "Rejected"
+
+This explains the most important observed symptom: the rejected command name changes from one crash to the next.
+
+The likely architecture bug is therefore:
+
+- command/response correlation is based only on device address
+- message type is ignored
+- asynchronous same-device traffic is misclassified as the synchronous reply
+
+#### 2. `parseWarnings()` accepts truncated payloads too far
+
+The warning parsing code expects a response shaped like:
+
+- `"00"`
+- `"01 WR"`
+- `"05 FD FQ FS FT FB"`
+
+But the guard inside the parsing loop currently checks:
+
+- `response.size() < 3 + n * 3`
+
+That bound is too weak for extracting a two-character warning token at `substr( 3 + n * 3, 2 )`.
+
+As a result, partially truncated warning payloads can:
+
+- produce a one-character token such as `"6"` or `"5"`
+- get logged as `unknown stage warning: 6`
+- continue to the next iteration
+- then finally fail with `parsing incomplete warning response`
+
+That matches the log sequence you captured.
+
+The correct minimum length for warning `n` is effectively:
+
+- `5 + n * 3`
+
+because the parser needs room for the separating space plus the two-character warning token.
+
+#### 3. The `READY` loop masks earlier failures and makes `getWarnings()` the fatal edge
+
+Inside `zaberLowLevel::appLogic()` in the `READY` state, the app polls:
+
+- knob state
+- LED state
+- parked state
+- position
+- temperature
+- warnings
+
+The return values from `getKnob()`, `getLED()`, `getParked()`, and `updateTemp()` are currently ignored by the caller. Those methods log their own failures, but the app keeps advancing through the poll sequence. The first poll method that is treated as fatal is `getWarnings()`, which moves the app to `ERROR`.
+
+Operationally this means:
+
+- the first visible log may be a rejected `get ...`
+- the state transition often happens only when warnings are polled afterward
+- the warning-query failure may be secondary fallout from a desynchronized receive stream
+
+So the current crash signature is likely showing:
+
+1. protocol desynchronization
+2. misattributed "rejected" command log
+3. malformed warning parse on a later read
+4. state-machine escalation
+
+#### 4. Alerts and stale input are not drained or modeled explicitly
+
+The ASCII path does not currently define clear handling for unsolicited traffic:
+
+- alerts from devices
+- info messages
+- stale replies left on the serial stream from earlier activity
+
+Without an explicit policy, the next synchronous query may consume the wrong message and shift the receive stream out of phase.
+
+## Likely Root Cause
+
+The most likely root cause is that the ASCII controller is not correlating replies robustly. An unsolicited `!` alert, `#` info message, or stale same-device message can be consumed as though it were the reply to the current command, causing:
+
+- a false `command Rejected` log on whichever query is in flight
+- stale or malformed response payloads to be handed to later queries
+- warning parsing failures
+- transition to `ERROR` and then `FAILURE`
+
+The warning parser off-by-one issue likely amplifies and clarifies the problem in logs, but it does not appear to be the primary source of the desynchronization.
+
+## Remediation Plan
+
+### 1. Harden reply correlation in `zaberStage`
+
+Update the ASCII receive path so that only a true `@` reply is accepted as the response to a command in flight.
+
+Implementation goals:
+
+- decode every received message before acting on it
+- ignore or separately process `!` alerts and `#` info messages during synchronous command waits
+- continue reading until the expected `@` reply for the addressed stage is found or timeout occurs
+- keep stage state updates from alerts explicit rather than letting them masquerade as command replies
+
+This is the highest-priority fix because it addresses the likely root cause behind the varying rejected command names.
+
+### 2. Decide and document alert/info handling policy
+
+Before changing code broadly, define what the app should do with unsolicited traffic while waiting for a reply.
+
+Recommended policy:
+
+- `@` reply for the target device: consume as the command reply
+- `!` alert for any device: log or update warning/state bookkeeping, then continue waiting
+- `#` info for any device: log at low priority or ignore, then continue waiting
+- reply/alert for a different configured device: do not treat it as the current command reply
+
+This policy should be reflected in code comments near the receive loop so the protocol assumptions remain explicit.
+
+### 3. Fix `parseWarnings()` bounds checking
+
+Tighten the warning parser so it rejects truncated payloads before producing one-character warning tokens.
+
+Expected outcomes:
+
+- no more `unknown stage warning: 5` or `6` from truncated responses
+- malformed warning strings fail immediately and deterministically
+- logs better distinguish "stream desync / truncated response" from "legitimate unknown warning code"
+
+Add or extend unit tests for:
+
+- `"00"`
+- valid multi-warning responses
+- truncated responses such as `"01 "`, `"02 WR"`, and `"06 6"`
+
+### 4. Fail the `READY` poll loop more coherently
+
+Revisit how `zaberLowLevel::appLogic()` handles poll failures in `READY`.
+
+Recommended change:
+
+- if any core query fails because reply parsing or command status is invalid, stop the cycle immediately
+- surface the first failing operation rather than continuing into later queries
+
+That should make field logs easier to interpret and reduce the amount of secondary corruption after the first protocol error.
+
+Potential scope:
+
+- `getKnob()`
+- `getLED()`
+- `getParked()`
+- `updatePos()`
+- `updateTemp()`
+- `getWarnings()`
+
+### 5. Improve diagnostic logging around received message type
+
+While hardening this path, add enough logging to confirm whether unsolicited alerts/info are present during failures.
+
+Useful diagnostics:
+
+- decoded message type (`@`, `!`, `#`)
+- device address
+- axis number
+- reply flags / warning flags
+- the raw command being waited on when a non-reply message arrives
+
+This logging should be concise and ideally guarded to avoid flooding normal operation, but it will be valuable during verification.
+
+### 6. Add targeted tests for protocol desynchronization behavior
+
+The existing tests focus on warning parsing. Add tests that exercise the new reply-selection logic.
+
+Targets:
+
+- a normal `@` reply path
+- an unsolicited `!` alert arriving before the matching `@` reply
+- an unsolicited `#` info message arriving before the matching `@` reply
+- malformed warning payload rejection
+
+If the current code structure makes direct unit tests difficult, factor the message-selection logic into a small helper that can be tested independently.
+
+### 7. Verify operational compatibility with actual stage firmware
+
+After code hardening, verify on hardware that the queried settings are in fact supported by the deployed controllers and firmware.
+
+This step is still worth doing even if desynchronization is the main bug, because a true command rejection remains possible.
+
+Verification targets:
+
+- `get driver.temperature`
+- `get system.led.enable`
+- `get knob.enable`
+- `warnings`
+
+Expected result:
+
+- if those commands are valid, the prior "Rejected" logs should disappear once reply correlation is fixed
+- if any command is truly unsupported on some devices, the app can then be updated to degrade gracefully per capability
+
+### 8. Stage the implementation in small, reviewable steps
+
+Recommended change order:
+
+1. add this plan and capture the root-cause hypothesis
+2. fix reply selection to require `@` replies
+3. fix warning-parser bounds and add tests
+4. tighten `READY` poll failure handling
+5. add temporary diagnostics if needed for on-hardware verification
+6. remove or reduce extra diagnostics once behavior is confirmed
+
+This sequencing keeps the highest-value protocol fix isolated and makes it easier to correlate behavior changes with logs from the next deployment.
+
+## Risks and Edge Cases
+
+- Some alerts may carry useful state transitions, so ignoring them entirely could lose information. The fix should skip treating them as command replies, but it may still be worth updating warning bookkeeping when they arrive.
+- If multiple devices on the daisy chain emit asynchronous messages, same-address filtering alone is definitely insufficient; the new code should remain strict about message type.
+- If there is already stale unread traffic in the serial buffer from earlier code paths, the first hardened receive may expose that more clearly. In that case, an explicit drain or recovery strategy may also be needed.
+- A true unsupported command may still exist on some hardware variants. The reply-correlation fix should not assume every rejection is false, only that the current logs are not reliable enough to prove a command-level incompatibility.
+
+## Expected Outcome
+
+After these changes, `apps/zaberLowLevel` should:
+
+- stop attributing random commands as rejected
+- stop producing misleading one-character warning codes from truncated payloads
+- fail closer to the first real protocol error, with better logs
+- become much easier to validate against the actual Zaber hardware behavior

--- a/apps/zaberLowLevel/tests/zaberStage_test.cpp
+++ b/apps/zaberLowLevel/tests/zaberStage_test.cpp
@@ -1,16 +1,16 @@
 /** \file zaberStage_test.cpp
-  * \brief Catch2 tests for the zaberStage in the zaberLowLevel app
-  * \author Jared R. Males (jaredmales@gmail.com)
-  *
-  * History:
-  */
+ * \brief Catch2 tests for the zaberStage in the zaberLowLevel app
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * History:
+ */
 #include "../../../tests/catch2/catch.hpp"
 
 #include "../zaberLowLevel.hpp"
 
 extern "C"
 {
-    #include "../za_serial.c" //to allow test to compile
+#include "../za_serial.c" //to allow test to compile
 }
 
 using namespace MagAOX::app;
@@ -18,215 +18,286 @@ using namespace MagAOX::app;
 namespace zaberStage_test
 {
 
-SCENARIO( "Parsing the warnings response", "[zaberStage]" )
+SCENARIO( "Classifying decoded device messages", "[zaberStage]" )
 {
-   GIVEN("A valid response to the warnings query")
-   {
-      int rv;
+    GIVEN( "A configured stage and decoded ASCII messages" )
+    {
+        zaberLowLevel zll;
 
-      WHEN("Valid response, no warnings")
-      {
-         zaberLowLevel zll;
+        zaberStage<zaberLowLevel> zstg( &zll );
 
-         zaberStage<zaberLowLevel> zstg(&zll);
+        REQUIRE( zstg.deviceAddress( 1 ) == 0 );
 
-         std::string tstr = "00";
+        za_reply rep{};
+        rep.device_address = 1;
 
-         rv = zstg.parseWarnings(tstr);
+        WHEN( "The message is a normal reply for the same device" )
+        {
+            rep.message_type = '@';
 
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == false);
-         REQUIRE(zstg.warnFD() == false);
-         REQUIRE(zstg.warnFQ() == false);
-         REQUIRE(zstg.warnFS() == false);
-         REQUIRE(zstg.warnFT() == false);
-         REQUIRE(zstg.warnFB() == false);
-         REQUIRE(zstg.warnFP() == false);
-         REQUIRE(zstg.warnFE() == false);
-         REQUIRE(zstg.warnWH() == false);
-         REQUIRE(zstg.warnWL() == false);
-         REQUIRE(zstg.warnWP() == false);
-         REQUIRE(zstg.warnWV() == false);
-         REQUIRE(zstg.warnWT() == false);
-         REQUIRE(zstg.warnWM() == false);
-         REQUIRE(zstg.warnWR() == false);
-         REQUIRE(zstg.warnNC() == false);
-         REQUIRE(zstg.warnNI() == false);
-         REQUIRE(zstg.warnND() == false);
-         REQUIRE(zstg.warnNU() == false);
-         REQUIRE(zstg.warnNJ() == false);
-         REQUIRE(zstg.warnUNK()== false);
-      }
+            REQUIRE( zstg.isCommandReply( rep ) == true );
+        }
 
-      WHEN("Valid response, one warning")
-      {
-         zaberLowLevel zll;
+        WHEN( "The message is an alert for the same device" )
+        {
+            rep.message_type = '!';
 
-         zaberStage<zaberLowLevel> zstg(&zll);
+            REQUIRE( zstg.isCommandReply( rep ) == false );
+        }
 
-         std::string tstr = "01 WR";
+        WHEN( "The message is an info message for the same device" )
+        {
+            rep.message_type = '#';
 
-         rv = zstg.parseWarnings(tstr);
+            REQUIRE( zstg.isCommandReply( rep ) == false );
+        }
 
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == true);
-         REQUIRE(zstg.warnFD() == false);
-         REQUIRE(zstg.warnFQ() == false);
-         REQUIRE(zstg.warnFS() == false);
-         REQUIRE(zstg.warnFT() == false);
-         REQUIRE(zstg.warnFB() == false);
-         REQUIRE(zstg.warnFP() == false);
-         REQUIRE(zstg.warnFE() == false);
-         REQUIRE(zstg.warnWH() == false);
-         REQUIRE(zstg.warnWL() == false);
-         REQUIRE(zstg.warnWP() == false);
-         REQUIRE(zstg.warnWV() == false);
-         REQUIRE(zstg.warnWT() == false);
-         REQUIRE(zstg.warnWM() == false);
-         REQUIRE(zstg.warnWR() == true);
-         REQUIRE(zstg.warnNC() == false);
-         REQUIRE(zstg.warnNI() == false);
-         REQUIRE(zstg.warnND() == false);
-         REQUIRE(zstg.warnNU() == false);
-         REQUIRE(zstg.warnNJ() == false);
-         REQUIRE(zstg.warnUNK()== false);
-      }
+        WHEN( "The message is a reply for a different device" )
+        {
+            rep.message_type   = '@';
+            rep.device_address = 2;
 
-      WHEN("Valid response, five warnings")
-      {
-         zaberLowLevel zll;
-
-         zaberStage<zaberLowLevel> zstg(&zll);
-
-         std::string tstr = "05 FD FQ FS FT FB";
-
-         rv = zstg.parseWarnings(tstr);
-
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == true);
-         REQUIRE(zstg.warnFD() == true);
-         REQUIRE(zstg.warnFQ() == true);
-         REQUIRE(zstg.warnFS() == true);
-         REQUIRE(zstg.warnFT() == true);
-         REQUIRE(zstg.warnFB() == true);
-         REQUIRE(zstg.warnFP() == false);
-         REQUIRE(zstg.warnFE() == false);
-         REQUIRE(zstg.warnWH() == false);
-         REQUIRE(zstg.warnWL() == false);
-         REQUIRE(zstg.warnWP() == false);
-         REQUIRE(zstg.warnWV() == false);
-         REQUIRE(zstg.warnWT() == false);
-         REQUIRE(zstg.warnWM() == false);
-         REQUIRE(zstg.warnWR() == false);
-         REQUIRE(zstg.warnNC() == false);
-         REQUIRE(zstg.warnNI() == false);
-         REQUIRE(zstg.warnND() == false);
-         REQUIRE(zstg.warnNU() == false);
-         REQUIRE(zstg.warnNJ() == false);
-         REQUIRE(zstg.warnUNK()== false);
-      }
-
-      WHEN("Valid response, ten warnings")
-      {
-         zaberLowLevel zll;
-
-         zaberStage<zaberLowLevel> zstg(&zll);
-
-         std::string tstr = "10 FP FE WH WL WP WV WT WM WR NC";
-
-         rv = zstg.parseWarnings(tstr);
-
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == true);
-         REQUIRE(zstg.warnFD() == false);
-         REQUIRE(zstg.warnFQ() == false);
-         REQUIRE(zstg.warnFS() == false);
-         REQUIRE(zstg.warnFT() == false);
-         REQUIRE(zstg.warnFB() == false);
-         REQUIRE(zstg.warnFP() == true);
-         REQUIRE(zstg.warnFE() == true);
-         REQUIRE(zstg.warnWH() == true);
-         REQUIRE(zstg.warnWL() == true);
-         REQUIRE(zstg.warnWP() == true);
-         REQUIRE(zstg.warnWV() == true);
-         REQUIRE(zstg.warnWT() == true);
-         REQUIRE(zstg.warnWM() == true);
-         REQUIRE(zstg.warnWR() == true);
-         REQUIRE(zstg.warnNC() == true);
-         REQUIRE(zstg.warnNI() == false);
-         REQUIRE(zstg.warnND() == false);
-         REQUIRE(zstg.warnNU() == false);
-         REQUIRE(zstg.warnNJ() == false);
-         REQUIRE(zstg.warnUNK()== false);
-      }
-      WHEN("Valid response, 2 warnings")
-      {
-         zaberLowLevel zll;
-
-         zaberStage<zaberLowLevel> zstg(&zll);
-
-         std::string tstr = "02 NI ND";
-
-         rv = zstg.parseWarnings(tstr);
-
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == true);
-         REQUIRE(zstg.warnFD() == false);
-         REQUIRE(zstg.warnFQ() == false);
-         REQUIRE(zstg.warnFS() == false);
-         REQUIRE(zstg.warnFT() == false);
-         REQUIRE(zstg.warnFB() == false);
-         REQUIRE(zstg.warnFP() == false);
-         REQUIRE(zstg.warnFE() == false);
-         REQUIRE(zstg.warnWH() == false);
-         REQUIRE(zstg.warnWL() == false);
-         REQUIRE(zstg.warnWP() == false);
-         REQUIRE(zstg.warnWV() == false);
-         REQUIRE(zstg.warnWT() == false);
-         REQUIRE(zstg.warnWM() == false);
-         REQUIRE(zstg.warnWR() == false);
-         REQUIRE(zstg.warnNC() == false);
-         REQUIRE(zstg.warnNI() == true);
-         REQUIRE(zstg.warnND() == true);
-         REQUIRE(zstg.warnNU() == false);
-         REQUIRE(zstg.warnNJ() == false);
-         REQUIRE(zstg.warnUNK()== false);
-      }
-      WHEN("Valid response, 3 warnings")
-      {
-         zaberLowLevel zll;
-
-         zaberStage<zaberLowLevel> zstg(&zll);
-
-
-         std::string tstr = "03 NU NJ UN";
-
-         rv = zstg.parseWarnings(tstr);
-
-         REQUIRE(rv == 0);
-         REQUIRE(zstg.warningState() == true);
-         REQUIRE(zstg.warnFD() == false);
-         REQUIRE(zstg.warnFQ() == false);
-         REQUIRE(zstg.warnFS() == false);
-         REQUIRE(zstg.warnFT() == false);
-         REQUIRE(zstg.warnFB() == false);
-         REQUIRE(zstg.warnFP() == false);
-         REQUIRE(zstg.warnFE() == false);
-         REQUIRE(zstg.warnWH() == false);
-         REQUIRE(zstg.warnWL() == false);
-         REQUIRE(zstg.warnWP() == false);
-         REQUIRE(zstg.warnWV() == false);
-         REQUIRE(zstg.warnWT() == false);
-         REQUIRE(zstg.warnWM() == false);
-         REQUIRE(zstg.warnWR() == false);
-         REQUIRE(zstg.warnNC() == false);
-         REQUIRE(zstg.warnNI() == false);
-         REQUIRE(zstg.warnND() == false);
-         REQUIRE(zstg.warnNU() == true);
-         REQUIRE(zstg.warnNJ() == true);
-         REQUIRE(zstg.warnUNK()== true);
-      }
-   }
+            REQUIRE( zstg.isCommandReply( rep ) == false );
+        }
+    }
 }
 
-} //namespace zaberStage_test
+SCENARIO( "Parsing the warnings response", "[zaberStage]" )
+{
+    GIVEN( "A valid response to the warnings query" )
+    {
+        int rv;
+
+        WHEN( "Valid response, no warnings" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "00";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == false );
+            REQUIRE( zstg.warnFD() == false );
+            REQUIRE( zstg.warnFQ() == false );
+            REQUIRE( zstg.warnFS() == false );
+            REQUIRE( zstg.warnFT() == false );
+            REQUIRE( zstg.warnFB() == false );
+            REQUIRE( zstg.warnFP() == false );
+            REQUIRE( zstg.warnFE() == false );
+            REQUIRE( zstg.warnWH() == false );
+            REQUIRE( zstg.warnWL() == false );
+            REQUIRE( zstg.warnWP() == false );
+            REQUIRE( zstg.warnWV() == false );
+            REQUIRE( zstg.warnWT() == false );
+            REQUIRE( zstg.warnWM() == false );
+            REQUIRE( zstg.warnWR() == false );
+            REQUIRE( zstg.warnNC() == false );
+            REQUIRE( zstg.warnNI() == false );
+            REQUIRE( zstg.warnND() == false );
+            REQUIRE( zstg.warnNU() == false );
+            REQUIRE( zstg.warnNJ() == false );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+
+        WHEN( "Valid response, one warning" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "01 WR";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == true );
+            REQUIRE( zstg.warnFD() == false );
+            REQUIRE( zstg.warnFQ() == false );
+            REQUIRE( zstg.warnFS() == false );
+            REQUIRE( zstg.warnFT() == false );
+            REQUIRE( zstg.warnFB() == false );
+            REQUIRE( zstg.warnFP() == false );
+            REQUIRE( zstg.warnFE() == false );
+            REQUIRE( zstg.warnWH() == false );
+            REQUIRE( zstg.warnWL() == false );
+            REQUIRE( zstg.warnWP() == false );
+            REQUIRE( zstg.warnWV() == false );
+            REQUIRE( zstg.warnWT() == false );
+            REQUIRE( zstg.warnWM() == false );
+            REQUIRE( zstg.warnWR() == true );
+            REQUIRE( zstg.warnNC() == false );
+            REQUIRE( zstg.warnNI() == false );
+            REQUIRE( zstg.warnND() == false );
+            REQUIRE( zstg.warnNU() == false );
+            REQUIRE( zstg.warnNJ() == false );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+
+        WHEN( "Valid response, five warnings" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "05 FD FQ FS FT FB";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == true );
+            REQUIRE( zstg.warnFD() == true );
+            REQUIRE( zstg.warnFQ() == true );
+            REQUIRE( zstg.warnFS() == true );
+            REQUIRE( zstg.warnFT() == true );
+            REQUIRE( zstg.warnFB() == true );
+            REQUIRE( zstg.warnFP() == false );
+            REQUIRE( zstg.warnFE() == false );
+            REQUIRE( zstg.warnWH() == false );
+            REQUIRE( zstg.warnWL() == false );
+            REQUIRE( zstg.warnWP() == false );
+            REQUIRE( zstg.warnWV() == false );
+            REQUIRE( zstg.warnWT() == false );
+            REQUIRE( zstg.warnWM() == false );
+            REQUIRE( zstg.warnWR() == false );
+            REQUIRE( zstg.warnNC() == false );
+            REQUIRE( zstg.warnNI() == false );
+            REQUIRE( zstg.warnND() == false );
+            REQUIRE( zstg.warnNU() == false );
+            REQUIRE( zstg.warnNJ() == false );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+
+        WHEN( "Valid response, ten warnings" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "10 FP FE WH WL WP WV WT WM WR NC";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == true );
+            REQUIRE( zstg.warnFD() == false );
+            REQUIRE( zstg.warnFQ() == false );
+            REQUIRE( zstg.warnFS() == false );
+            REQUIRE( zstg.warnFT() == false );
+            REQUIRE( zstg.warnFB() == false );
+            REQUIRE( zstg.warnFP() == true );
+            REQUIRE( zstg.warnFE() == true );
+            REQUIRE( zstg.warnWH() == true );
+            REQUIRE( zstg.warnWL() == true );
+            REQUIRE( zstg.warnWP() == true );
+            REQUIRE( zstg.warnWV() == true );
+            REQUIRE( zstg.warnWT() == true );
+            REQUIRE( zstg.warnWM() == true );
+            REQUIRE( zstg.warnWR() == true );
+            REQUIRE( zstg.warnNC() == true );
+            REQUIRE( zstg.warnNI() == false );
+            REQUIRE( zstg.warnND() == false );
+            REQUIRE( zstg.warnNU() == false );
+            REQUIRE( zstg.warnNJ() == false );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+        WHEN( "Valid response, 2 warnings" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "02 NI ND";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == true );
+            REQUIRE( zstg.warnFD() == false );
+            REQUIRE( zstg.warnFQ() == false );
+            REQUIRE( zstg.warnFS() == false );
+            REQUIRE( zstg.warnFT() == false );
+            REQUIRE( zstg.warnFB() == false );
+            REQUIRE( zstg.warnFP() == false );
+            REQUIRE( zstg.warnFE() == false );
+            REQUIRE( zstg.warnWH() == false );
+            REQUIRE( zstg.warnWL() == false );
+            REQUIRE( zstg.warnWP() == false );
+            REQUIRE( zstg.warnWV() == false );
+            REQUIRE( zstg.warnWT() == false );
+            REQUIRE( zstg.warnWM() == false );
+            REQUIRE( zstg.warnWR() == false );
+            REQUIRE( zstg.warnNC() == false );
+            REQUIRE( zstg.warnNI() == true );
+            REQUIRE( zstg.warnND() == true );
+            REQUIRE( zstg.warnNU() == false );
+            REQUIRE( zstg.warnNJ() == false );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+        WHEN( "Valid response, 3 warnings" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "03 NU NJ UN";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv == 0 );
+            REQUIRE( zstg.warningState() == true );
+            REQUIRE( zstg.warnFD() == false );
+            REQUIRE( zstg.warnFQ() == false );
+            REQUIRE( zstg.warnFS() == false );
+            REQUIRE( zstg.warnFT() == false );
+            REQUIRE( zstg.warnFB() == false );
+            REQUIRE( zstg.warnFP() == false );
+            REQUIRE( zstg.warnFE() == false );
+            REQUIRE( zstg.warnWH() == false );
+            REQUIRE( zstg.warnWL() == false );
+            REQUIRE( zstg.warnWP() == false );
+            REQUIRE( zstg.warnWV() == false );
+            REQUIRE( zstg.warnWT() == false );
+            REQUIRE( zstg.warnWM() == false );
+            REQUIRE( zstg.warnWR() == false );
+            REQUIRE( zstg.warnNC() == false );
+            REQUIRE( zstg.warnNI() == false );
+            REQUIRE( zstg.warnND() == false );
+            REQUIRE( zstg.warnNU() == true );
+            REQUIRE( zstg.warnNJ() == true );
+            REQUIRE( zstg.warnUNK() == true );
+        }
+
+        WHEN( "Truncated response ends before the first warning token" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "01 ";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv < 0 );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+
+        WHEN( "Truncated response ends inside a later warning token" )
+        {
+            zaberLowLevel zll;
+
+            zaberStage<zaberLowLevel> zstg( &zll );
+
+            std::string tstr = "06 6";
+
+            rv = zstg.parseWarnings( tstr );
+
+            REQUIRE( rv < 0 );
+            REQUIRE( zstg.warnUNK() == false );
+        }
+    }
+}
+
+} // namespace zaberStage_test

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -135,7 +135,6 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     /// Enable or disable a stages LED
     pcf::IndiProperty m_indiP_led_enable;
 
-
   public:
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_tgt_pos );
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_req_home );
@@ -472,9 +471,10 @@ int zaberLowLevel::appStartup()
         m_indiP_parked[m_stages[n].name()].set( m_stages[n].parked() );
         m_indiP_lastHomed[m_stages[n].name()].set( m_stages[n].lastHomed() );
         m_indiP_max_pos[m_stages[n].name()].set( m_stages[n].maxPos() );
-        m_indiP_knob_enable[m_stages[n].name()].set( m_stages[n].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off );
-        m_indiP_led_enable[m_stages[n].name()].set( m_stages[n].ledEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off );
-
+        m_indiP_knob_enable[m_stages[n].name()].set( m_stages[n].knobEnabled() ? pcf::IndiElement::On
+                                                                               : pcf::IndiElement::Off );
+        m_indiP_led_enable[m_stages[n].name()].set( m_stages[n].ledEnabled() ? pcf::IndiElement::On
+                                                                             : pcf::IndiElement::Off );
     }
 
     return 0;
@@ -653,18 +653,62 @@ int zaberLowLevel::appLogic()
 
             std::lock_guard<std::mutex> guard( m_indiMutex ); // Inside loop so INDI requests can steal it
 
-            m_stages[i].getKnob( m_port );
-            updateSwitchIfChanged( m_indiP_knob_enable, m_stages[i].name(),  (m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off) );
-            
-            m_stages[i].getLED( m_port );
-            updateSwitchIfChanged( m_indiP_led_enable, m_stages[i].name(),  (m_stages[i].ledEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off) );
+            if( m_stages[i].getKnob( m_port ) < 0 )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
 
-            m_stages[i].getParked( m_port );
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+            updateSwitchIfChanged( m_indiP_knob_enable,
+                                   m_stages[i].name(),
+                                   ( m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off ) );
+
+            if( m_stages[i].getLED( m_port ) < 0 )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
+
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
+            updateSwitchIfChanged( m_indiP_led_enable,
+                                   m_stages[i].name(),
+                                   ( m_stages[i].ledEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off ) );
+
+            if( m_stages[i].getParked( m_port ) < 0 )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
+
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
 
             updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
             updateIfChanged( m_indiP_lastHomed, m_stages[i].name(), m_stages[i].lastHomed() );
 
-            m_stages[i].updatePos( m_port );
+            if( m_stages[i].updatePos( m_port ) < 0 )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
+
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
 
             updateIfChanged( m_indiP_curr_pos, m_stages[i].name(), m_stages[i].rawPos() );
             updateIfChanged( m_indiP_tgt_pos, m_stages[i].name(), m_stages[i].tgtPos() );
@@ -744,7 +788,17 @@ int zaberLowLevel::appLogic()
                 updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::Off );
             }
 
-            m_stages[i].updateTemp( m_port );
+            if( m_stages[i].updateTemp( m_port ) < 0 )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
+
+                log<software_error>();
+                state( stateCodes::ERROR );
+                return 0;
+            }
             updateIfChanged( m_indiP_temp, m_stages[i].name(), m_stages[i].temp() );
 
             if( m_stages[i].getWarnings( m_port ) < 0 )
@@ -1140,19 +1194,18 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_knob_enable )( const pcf::IndiProp
     {
         return log<software_error, -1>( "no valid stage specified in req_knob, rejecting request" );
     }
-    
+
     bool enable_knob = ipRecv[m_stages[stageno].name()].getSwitchState() == pcf::IndiElement::On;
-    
+
     std::lock_guard<std::mutex> guard( m_indiMutex );
 
-    if( m_stages[stageno].enableKnob(m_port, enable_knob) < 0 )
+    if( m_stages[stageno].enableKnob( m_port, enable_knob ) < 0 )
     {
         return log<software_error, -1>( std::format( "error from enable knob for {}", m_stages[stageno].name() ) );
     }
 
     return 0;
 }
-
 
 INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_led_enable )( const pcf::IndiProperty &ipRecv )
 {
@@ -1189,12 +1242,12 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevel, m_indiP_led_enable )( const pcf::IndiPrope
     {
         return log<software_error, -1>( "no valid stage specified in req_led, rejecting request" );
     }
-    
+
     bool enable_led = ipRecv[m_stages[stageno].name()].getSwitchState() == pcf::IndiElement::On;
-    
+
     std::lock_guard<std::mutex> guard( m_indiMutex );
 
-    if( m_stages[stageno].enableLED(m_port, enable_led) < 0 )
+    if( m_stages[stageno].enableLED( m_port, enable_led ) < 0 )
     {
         return log<software_error, -1>( std::format( "error from enable led for {}", m_stages[stageno].name() ) );
     }

--- a/apps/zaberLowLevel/zaberStage.hpp
+++ b/apps/zaberLowLevel/zaberStage.hpp
@@ -289,6 +289,9 @@ class zaberStage
                      const za_reply &rep       ///< [in] the decodedstage reply
     );
 
+    /// Determine whether a decoded message is the awaited command reply.
+    bool isCommandReply( const za_reply &rep /**< [in] the decoded device message */ );
+
     /// Send a command and get the response
     int sendCommand( std::string       &response, ///< [out] the response received from the stage
                      z_port             port,     ///< [in]  the port with which to communicate
@@ -682,11 +685,11 @@ int zaberStage<parentT>::getResponse( std::string &response, const za_reply &rep
 
         if( m_deviceStatus == 'I' && m_homing )
         {
-            m_warnWR    = false; // Clear preemptively
-            m_homing    = false;
-            if(clock_gettime(CLOCK_ISIO, &m_lastHomed) < 0)
+            m_warnWR = false; // Clear preemptively
+            m_homing = false;
+            if( clock_gettime( CLOCK_ISIO, &m_lastHomed ) < 0 )
             {
-                MagAOXAppT::log<software_error>( {errno, 0, "clock_gettime for last homed"});
+                MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
             }
         }
 
@@ -708,6 +711,12 @@ int zaberStage<parentT>::getResponse( std::string &response, const za_reply &rep
         MagAOXAppT::log<software_error>( "wrong device" );
         return -1;
     }
+}
+
+template <class parentT>
+bool zaberStage<parentT>::isCommandReply( const za_reply &rep )
+{
+    return rep.message_type == '@' && rep.device_address == m_deviceAddress;
 }
 
 template <class parentT>
@@ -755,7 +764,7 @@ int zaberStage<parentT>::sendCommand( std::string &response, z_port port, const 
             break;
         }
 
-        if( rep.device_address == m_deviceAddress )
+        if( isCommandReply( rep ) )
             return getResponse( response, rep );
     }
 
@@ -854,7 +863,6 @@ int zaberStage<parentT>::getParked( z_port port )
     return 0;
 }
 
-
 template <class parentT>
 int zaberStage<parentT>::getKnob( z_port port )
 {
@@ -876,7 +884,7 @@ int zaberStage<parentT>::getKnob( z_port port )
 template <class parentT>
 int zaberStage<parentT>::getLED( z_port port )
 {
-    int rv = getValue( m_ledEnabled, port, "get system.led.enable");
+    int rv = getValue( m_ledEnabled, port, "get system.led.enable" );
 
     if( rv < 0 )
     {
@@ -890,7 +898,6 @@ int zaberStage<parentT>::getLED( z_port port )
 
     return 0;
 }
-
 
 template <class parentT>
 int zaberStage<parentT>::updatePos( z_port port )
@@ -960,7 +967,7 @@ int zaberStage<parentT>::sendCommand( z_port port, const std::string &command )
     }
     else
     {
-         if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
         {
             return -1; // don't log, but propagate error
         }
@@ -973,9 +980,9 @@ int zaberStage<parentT>::sendCommand( z_port port, const std::string &command )
 template <class parentT>
 int zaberStage<parentT>::enableKnob( z_port port, bool enable )
 {
-    std::string cmd = std::format("set knob.enable {}", enable ? "1" : "0");
+    std::string cmd = std::format( "set knob.enable {}", enable ? "1" : "0" );
 
-    int rv = sendCommand( port, cmd);
+    int rv = sendCommand( port, cmd );
 
     if( rv < 0 )
     {
@@ -993,7 +1000,7 @@ int zaberStage<parentT>::enableKnob( z_port port, bool enable )
 template <class parentT>
 int zaberStage<parentT>::enableLED( z_port port, bool enable )
 {
-    std::string cmd = std::format("set system.led.enable {}", enable ? "1" : "0");
+    std::string cmd = std::format( "set system.led.enable {}", enable ? "1" : "0" );
 
     int rv = sendCommand( port, cmd );
 
@@ -1457,7 +1464,7 @@ int zaberStage<parentT>::parseWarnings( std::string &response )
 
     for( size_t n = 0; n < nwarn; ++n )
     {
-        if( response.size() < 3 + n * 3 )
+        if( response.size() < 5 + n * 3 )
         {
             if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
             {
@@ -1769,11 +1776,11 @@ int zaberStage<parentT>::readStateFile( std::ifstream &fin )
         return MagAOXAppT::log<software_error, -1>( { "error reading last home time" } );
     }
 
-    m_rawPos    = rawPos;
-    m_tgtPos    = rawPos;
-    m_parked    = parked;
-    m_maxPos    = maxPos;
-    m_lastHomed.tv_sec = lastHomed;
+    m_rawPos            = rawPos;
+    m_tgtPos            = rawPos;
+    m_parked            = parked;
+    m_maxPos            = maxPos;
+    m_lastHomed.tv_sec  = lastHomed;
     m_lastHomed.tv_nsec = 0;
 
     return 0;


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "apps/zaberLowLevel is crashing frequently. the problem seems to be that a command is rejected, but the command is different which is rejected... Review AGENTS.md and analyze please. Let's document this as a plan under agents/plans, and please lay out a plan to address these issues. "

## Summary

This PR hardens the ASCII reply handling in `apps/zaberLowLevel` to reduce false command-rejection errors and secondary warning-parse failures that were driving the app into `ERROR` and `FAILURE`.

## What Changed

- Added a plan document under `agents/plans` capturing the observed failure mode, root-cause hypothesis, and remediation steps.
- Updated `zaberStage` so only decoded `@` reply messages for the addressed device are treated as command replies.
- Tightened `parseWarnings()` bounds checking so truncated warning payloads fail cleanly instead of producing bogus one-character warning codes.
- Updated the `READY` polling loop in `zaberLowLevel` so it stops on the first failed stage query instead of continuing into a later misleading `warnings` failure.
- Added regression coverage in `zaberStage_test` for:
  - reply classification (`@` vs `!` / `#`)
  - truncated warning payloads

## Rationale

The observed crash pattern suggested that unsolicited ASCII alert/info traffic or stale serial messages could be consumed as though they were synchronous command replies. That can make whichever command is in flight appear to have been rejected, with the specific command name varying from run to run. Once the stream is out of phase, the next `warnings` query can parse malformed data and push the app into `ERROR`.

This PR addresses that by making reply selection stricter and by making malformed warning payload handling deterministic.

## Verification

- Built `apps/zaberLowLevel` successfully with `make -C apps/zaberLowLevel`
- Built the focused regression test with `make -C tests -f Makefile.one t=../apps/zaberLowLevel/tests/zaberStage_test.cpp`
- Ran `./apps/zaberLowLevel/tests/zaberStage_test` successfully

## Notes

- `apps/zaberLowLevel/tests/zaberLowLevel_test` still appears to have a pre-existing mismatch against the current app interface (`tgt_relpos`) and was not changed in this PR.
- Unrelated untracked files in the working tree were left untouched.

## Files Changed

- `agents/plans/zaberLowLevel-ascii-crash-hardening.md`
- `apps/zaberLowLevel/zaberStage.hpp`
- `apps/zaberLowLevel/zaberLowLevel.hpp`
- `apps/zaberLowLevel/tests/zaberStage_test.cpp`
