### PR TITLE
stage parking gui updates

### DIFF
--- a/agents/plans/stage-parking-gui-updates.md
+++ b/agents/plans/stage-parking-gui-updates.md
@@ -1,0 +1,130 @@
+Task: review AGENTS.md then consider: in zaber stage control we have a recently added feature implementing parking.  This allows a zaber stage to maintain its position through power-offs.  GUIs need to catch up so that if a stage is in POWEROFF but parked=true, the GUIs report the stage position and/or associate preset that should be reported by zaberCtrl.  This will affect the cameraGUI, stageGUI, and the rtimv cameraStaus plugin.  Please make a plan to update these guis and append it below:
+
+Plan:
+
+## Analysis
+
+The current GUI stack does not have any parked-state handling:
+
+- `gui/widgets/stage/stage.hpp` disables the stage display entirely unless the FSM is `READY`, `OPERATING`, `CONFIGURING`, `NOTHOMED`, or `HOMING`.
+- `gui/widgets/xWidgets/statusCombo.hpp` and `gui/widgets/xWidgets/statusDisplay.hpp` only show the live value when the FSM is `READY` or `OPERATING`; otherwise they replace the value with the FSM text.
+- `gui/widgets/xWidgets/stageStatus.hpp` depends on `statusCombo`, so `cameraGUI` inherits that same behavior for camera-associated stages.
+- `gui/rtimv/plugins/cameraStatus/cameraStatus.cpp` only resolves filter/stage presets when `fsm.state` is `READY` or `OPERATING`; otherwise it prints the raw FSM state.
+
+So today a parked Zaber stage that transitions to `POWEROFF` will be rendered as unavailable even if `zaberCtrl` still has a meaningful current position and/or preset association to report.
+
+There is also an interface gap: neither the shared GUI widgets nor `cameraStatus` currently subscribe to any `parked` property from `zaberCtrl`, and `apps/zaberCtrl/zaberCtrl.hpp` does not currently relay a parked status from the low-level Zaber app. The GUI work therefore needs a small controller-contract update as part of the plan so the front ends can distinguish:
+
+- `POWEROFF` and parked
+- `POWEROFF` and not parked
+
+## Recommended Behavior
+
+For Zaber-backed stages, when:
+
+- `fsm.state == POWEROFF`
+- and `parked == true`
+
+the GUIs should continue to show the last controller-reported logical stage value instead of replacing it with `POWEROFF`.
+
+That means:
+
+- `stageGUI` should continue to show the parked position or preset name, but keep all motion controls disabled.
+- `cameraGUI` stage summary widgets should continue to show the parked preset/position text while still indicating the powered-off state through the FSM widget.
+- `rtimv` `cameraStatus` should continue to print the associated filter/stage preset line when available, and fall back to numeric position only if no preset is selected.
+
+If `parked != true`, the current `POWEROFF` behavior should remain unchanged.
+
+## Scope
+
+### 1. Add or verify the parked-state contract in `zaberCtrl`
+
+In `apps/zaberCtrl/zaberCtrl.hpp`:
+
+- verify that the controller preserves the last meaningful `position`/`filter` and `presetName`/`filterName` values when the low-level stage goes to `POWEROFF`
+- add a relayed `parked` property from the low-level Zaber app if one is not already exposed by `zaberCtrl`
+- subscribe to the low-level parked status alongside the existing stage-state/raw-position subscriptions
+- keep the parked indication device-local to the stage controller so all GUIs can consume one consistent interface
+
+This is the minimum controller-side change needed to let the GUIs recognize the parked-poweroff case without special-casing low-level app names.
+
+### 2. Update the shared stage widgets used by `stageGUI` and `cameraGUI`
+
+In `gui/widgets/stage/stage.hpp`:
+
+- subscribe to the stage `parked` property
+- store the parked flag in widget state
+- treat `POWEROFF && parked` as a displayable state rather than a disconnected/unavailable state
+- keep position text and selected preset visible in that state
+- continue to disable motion commands, homing, slider movement, and setpoint submission while powered off
+
+In `gui/widgets/xWidgets/statusCombo.hpp` and `gui/widgets/xWidgets/statusDisplay.hpp`:
+
+- extend the show-value logic to allow value display for `POWEROFF && parked`
+- preserve current behavior for all other non-ready states
+
+In `gui/widgets/xWidgets/stageStatus.hpp`:
+
+- subscribe to and pass through the parked state via the shared status widget path
+- confirm the fallback numeric formatting still works when no preset is active but the parked position is known
+
+Because `cameraGUI` stage rows are built from `stageStatus`, fixing the shared widgets should cover both `stageGUI` and the camera-side stage summaries with one implementation.
+
+### 3. Update the `rtimv` `cameraStatus` plugin
+
+In `gui/rtimv/plugins/cameraStatus/cameraStatus.cpp`:
+
+- subscribe to each filter/stage device `parked` property in addition to `fsm.state` and preset property blobs
+- treat `POWEROFF && parked` as eligible for preset lookup, just like `READY` and `OPERATING`
+- if no preset switch is active, optionally show the parked numeric position if that is already available in the plugin dictionary; otherwise keep the existing state text fallback
+
+This keeps the overlay aligned with the standalone GUIs instead of regressing to `device: POWEROFF` for parked stages.
+
+### 4. Decide the exact fallback hierarchy once and apply it consistently
+
+Use one display rule across all three GUI surfaces:
+
+1. show active preset/filter name if one is selected
+2. otherwise show numeric current position/filter index if available
+3. otherwise show FSM state text
+
+For parked stages in `POWEROFF`, the same hierarchy should apply, but controls must remain disabled.
+
+## Verification Plan
+
+### 1. Interface verification
+
+Confirm `zaberCtrl` publishes all of the data the GUIs need in the parked-poweroff case:
+
+- `fsm.state`
+- `parked`
+- current position/filter value
+- preset/filter-name switch property
+
+### 2. GUI behavior verification
+
+Check the following cases in both `stageGUI` and `cameraGUI`:
+
+1. `READY`, unparked: current behavior unchanged.
+2. `POWEROFF`, `parked=false`: current behavior unchanged and value hidden.
+3. `POWEROFF`, `parked=true`, preset selected: preset remains visible and controls are disabled.
+4. `POWEROFF`, `parked=true`, no preset selected: numeric position remains visible and controls are disabled.
+
+### 3. Overlay verification
+
+In `rtimv` `cameraStatus`, confirm:
+
+1. parked powered-off filter wheels/stages still render the preset line
+2. unparked powered-off devices still render `device: POWEROFF`
+3. no duplicate or contradictory lines are introduced when state transitions between `READY`, `OPERATING`, and `POWEROFF`
+
+## Execution Order
+
+1. Inspect and, if needed, extend `zaberCtrl` to publish a GUI-consumable `parked` status while preserving last meaningful position/preset values.
+2. Update the shared stage/status widgets in `gui/widgets` so parked powered-off stages continue to display values but remain read-only.
+3. Update `gui/rtimv/plugins/cameraStatus` to apply the same parked-poweroff display rule.
+4. Build the affected GUIs/plugins and manually verify the state combinations above.
+
+## Open Question
+
+The one point to confirm during implementation is whether `zaberCtrl` should expose `parked` as a dedicated top-level property or fold it into an existing status property. A dedicated `parked` property is the cleaner choice because the existing GUI code already reasons about FSM state separately from displayability, and this avoids overloading the meaning of `POWEROFF`.

--- a/apps/zaberCtrl/tests/zaberCtrl_test.cpp
+++ b/apps/zaberCtrl/tests/zaberCtrl_test.cpp
@@ -1,11 +1,9 @@
 /** \file zaberCtrl_test.cpp
-  * \brief Catch2 tests for the zaberCtrl app.
-  * \author Jared R. Males (jaredmales@gmail.com)
-  *
-  * History:
-  */
-
-
+ * \brief Catch2 tests for the zaberCtrl app.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * History:
+ */
 
 #include "../../../tests/catch2/catch.hpp"
 #include "../../tests/testMacrosINDI.hpp"
@@ -20,45 +18,44 @@ namespace ZCTRLTEST
 class zaberCtrl_test : public zaberCtrl
 {
 
-public:
-    zaberCtrl_test(const std::string & device)
+  public:
+    zaberCtrl_test( const std::string &device )
     {
         m_configName = device;
 
-        XWCTEST_SETUP_INDI_NEW_PROP(pos);
-        XWCTEST_SETUP_INDI_NEW_PROP(rawPos);
+        XWCTEST_SETUP_INDI_NEW_PROP( pos );
+        XWCTEST_SETUP_INDI_NEW_PROP( rawPos );
 
-        //stdMotionStage:
-        XWCTEST_SETUP_INDI_NEW_PROP(preset);
-        XWCTEST_SETUP_INDI_NEW_PROP(presetName);
-        XWCTEST_SETUP_INDI_NEW_PROP(home);
-        XWCTEST_SETUP_INDI_NEW_PROP(stop);
+        // stdMotionStage:
+        XWCTEST_SETUP_INDI_NEW_PROP( preset );
+        XWCTEST_SETUP_INDI_NEW_PROP( presetName );
+        XWCTEST_SETUP_INDI_NEW_PROP( home );
+        XWCTEST_SETUP_INDI_NEW_PROP( stop );
 
-        XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_stageState, stest, curr_state);
-        XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_stageMaxRawPos, stest, max_pos);
-        XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_stageRawPos, stest, curr_pos);
-        XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_stageTgtPos, stest, tgt_pos);
-        XWCTEST_SETUP_INDI_ARB_PROP(m_indiP_stageTemp, stest, temp);
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageState, stest, curr_state );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageMaxRawPos, stest, max_pos );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageRawPos, stest, curr_pos );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageTgtPos, stest, tgt_pos );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageTemp, stest, temp );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageParked, stest, parked );
     }
 };
 
-
 SCENARIO( "INDI Callbacks", "[zaberCtrl]" )
 {
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, pos);
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, rawPos);
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, preset);
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, presetName);
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, home);
-    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, stop);
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, pos );
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, rawPos );
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, preset );
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, presetName );
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, home );
+    XWCTEST_INDI_NEW_CALLBACK( zaberCtrl, stop );
 
-    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageState, stest, curr_state);
-    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageMaxRawPos, stest, max_pos);
-    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageRawPos, stest, curr_pos);
-    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTgtPos, stest, tgt_pos);
-    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTemp, stest, temp);
-
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageState, stest, curr_state );
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageMaxRawPos, stest, max_pos );
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageRawPos, stest, curr_pos );
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTgtPos, stest, tgt_pos );
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTemp, stest, temp );
+    XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageParked, stest, parked );
 }
 
-
-} //namespace zaberCtrl_test
+} // namespace ZCTRLTEST

--- a/apps/zaberCtrl/tests/zaberCtrl_test.cpp
+++ b/apps/zaberCtrl/tests/zaberCtrl_test.cpp
@@ -19,6 +19,7 @@ class zaberCtrl_test : public zaberCtrl
 {
 
   public:
+    /// Construct a testable controller instance.
     zaberCtrl_test( const std::string &device )
     {
         m_configName = device;
@@ -39,6 +40,58 @@ class zaberCtrl_test : public zaberCtrl
         XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageTemp, stest, temp );
         XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stageParked, stest, parked );
     }
+
+    /// Set the current test position state.
+    void setStagePosition( double pos, double countsPerMillimeter )
+    {
+        m_pos                 = pos;
+        m_countsPerMillimeter = countsPerMillimeter;
+    }
+
+    /// Set the configured preset positions and names for testing.
+    void setPresets( const std::vector<float> &positions, const std::vector<std::string> &names )
+    {
+        m_presetPositions = positions;
+        m_presetNames     = names;
+    }
+
+    /// Set the current parked state for testing.
+    void setParked( bool parked )
+    {
+        m_parked = parked;
+    }
+
+    /// Set the current motion and preset telemetry values for testing.
+    void setStageTelemetry( int8_t moving, float preset, float presetTarget )
+    {
+        m_moving        = moving;
+        m_preset        = preset;
+        m_preset_target = presetTarget;
+    }
+
+    /// Invoke the powered-off telemetry sync under test.
+    int syncPoweredOffTelemetry()
+    {
+        return syncPowerOffStageTelemetry();
+    }
+
+    /// Get the current logged moving state.
+    int8_t movingState() const
+    {
+        return m_moving;
+    }
+
+    /// Get the current logged preset value.
+    float presetValue() const
+    {
+        return m_preset;
+    }
+
+    /// Get the current logged preset target value.
+    float presetTargetValue() const
+    {
+        return m_preset_target;
+    }
 };
 
 SCENARIO( "INDI Callbacks", "[zaberCtrl]" )
@@ -56,6 +109,34 @@ SCENARIO( "INDI Callbacks", "[zaberCtrl]" )
     XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTgtPos, stest, tgt_pos );
     XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageTemp, stest, temp );
     XWCTEST_INDI_SET_CALLBACK( zaberCtrl, m_indiP_stageParked, stest, parked );
+}
+
+SCENARIO( "Power-off stage telemetry", "[zaberCtrl]" )
+{
+    zaberCtrl_test zct( "stest" );
+
+    zct.setPresets( { -1, 1, 2, 3 }, { "none", "one", "two", "three" } );
+    zct.setStagePosition( 2.0, 1000.0 );
+
+    WHEN( "the stage powers off while parked" )
+    {
+        zct.setParked( true );
+        zct.setStageTelemetry( 0, 2, 2 );
+
+        REQUIRE( zct.syncPoweredOffTelemetry() == 0 );
+        REQUIRE( zct.presetValue() == 2 );
+        REQUIRE( zct.presetTargetValue() == 2 );
+    }
+
+    WHEN( "the stage powers off while not parked" )
+    {
+        zct.setParked( false );
+        zct.setStageTelemetry( 0, 2, 2 );
+
+        REQUIRE( zct.syncPoweredOffTelemetry() == 0 );
+        REQUIRE( zct.presetValue() == 0 );
+        REQUIRE( zct.presetTargetValue() == 0 );
+    }
 }
 
 } // namespace ZCTRLTEST

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -185,6 +185,16 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
 
     int recordZaber( bool force = false );
 
+    /// Update the stage telemetry values used while the low-level stage is powered off.
+    /**
+     * When a parked stage transitions to `POWEROFF`, preserve the logical
+     * preset derived from the last reported position so telemetry consumers
+     * such as `xrif2fits` can keep writing valid preset headers.
+     *
+     * \returns 0 on success
+     */
+    int syncPowerOffStageTelemetry();
+
     ///@}
 };
 
@@ -495,6 +505,30 @@ int zaberCtrl::appLogic()
     return 0;
 }
 
+int zaberCtrl::syncPowerOffStageTelemetry()
+{
+    if( !m_parked )
+    {
+        m_preset        = 0;
+        m_preset_target = 0;
+        return 0;
+    }
+
+    int n = presetNumber();
+    if( n == 0 )
+    {
+        m_preset        = 0;
+        m_preset_target = 0;
+    }
+    else
+    {
+        m_preset        = n;
+        m_preset_target = n;
+    }
+
+    return 0;
+}
+
 int zaberCtrl::appShutdown()
 {
     return 0;
@@ -692,6 +726,8 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageState )( const pcf::IndiProperty 
     {
         state( stateCodes::POWEROFF );
         m_moving = -2;
+        syncPowerOffStageTelemetry();
+        dev::stdMotionStage<zaberCtrl>::recordStage( true );
     }
     else if( sstr == "POWERON" )
     {
@@ -891,6 +927,12 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageParked )( const pcf::IndiProperty
     std::lock_guard<std::mutex> guard( m_indiMutex );
 
     m_parked = ( ipRecv[m_stageName].get<int>() != 0 );
+
+    if( state() == stateCodes::POWEROFF )
+    {
+        syncPowerOffStageTelemetry();
+        dev::stdMotionStage<zaberCtrl>::recordStage( true );
+    }
 
     updateIfChanged( m_indiP_parked, "current", static_cast<int>( m_parked ) );
 

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -1,5 +1,6 @@
 /** \file zaberCtrl.hpp
  * \brief The MagAO-X Zaber Stage Controller header file
+ * \author Jared R. Males (jaredmales@gmail.com)
  *
  * \ingroup zaberCtrl_files
  */
@@ -62,9 +63,10 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     double m_tgtRawPos{ 0 }; ///< Target raw position in counts
     double m_stageTemp{ 0 }; ///< Temperature reported by the stage
 
-    double m_maxPos{ 0 }; ///< Maximum position in mm available on this stage
-    double m_pos{ 0 };    ///< Current position in mm
-    double m_tgtPos{ 0 }; ///< Target position in mm.
+    double m_maxPos{ 0 };     ///< Maximum position in mm available on this stage
+    double m_pos{ 0 };        ///< Current position in mm
+    double m_tgtPos{ 0 };     ///< Target position in mm.
+    bool   m_parked{ false }; ///< Whether the low-level Zaber stage reports a parked state.
 
     bool m_wason = true; ///< Whether the stage was in state power on before power off
 
@@ -146,6 +148,7 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     pcf::IndiProperty m_indiP_rawPos;
     pcf::IndiProperty m_indiP_maxPos;
     pcf::IndiProperty m_indiP_temp;
+    pcf::IndiProperty m_indiP_parked;
     pcf::IndiProperty m_indiP_lastHomed;
 
   public:
@@ -158,6 +161,7 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     pcf::IndiProperty m_indiP_stageRawPos;
     pcf::IndiProperty m_indiP_stageTgtPos;
     pcf::IndiProperty m_indiP_stageTemp;
+    pcf::IndiProperty m_indiP_stageParked;
     pcf::IndiProperty m_indiP_stageLastHomed;
 
   public:
@@ -166,6 +170,7 @@ class zaberCtrl : public MagAOXApp<>, public dev::stdMotionStage<zaberCtrl>, pub
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageRawPos );
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageTgtPos );
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageTemp );
+    INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageParked );
     INDI_SETCALLBACK_DECL( zaberCtrl, m_indiP_stageLastHomed );
 
     /** \name Telemeter Interface
@@ -299,6 +304,11 @@ int zaberCtrl::appStartup()
     indi::addNumberElement( m_indiP_temp, "current", -50, 100, 0, "%0.1f" );
     registerIndiPropertyReadOnly( m_indiP_temp );
 
+    createROIndiNumber( m_indiP_parked, "parked", "Parked State" );
+    indi::addNumberElement<int>( m_indiP_parked, "current", 0, 1, 1, "%d" );
+    m_indiP_parked["current"].set<int>( 0 );
+    registerIndiPropertyReadOnly( m_indiP_parked );
+
     createROIndiNumber( m_indiP_lastHomed, "last_homed", "Time of last home [sec]" );
     indi::addNumberElement<time_t>( m_indiP_lastHomed, "time_sec", 0, std::numeric_limits<time_t>::max(), 1, "%d" );
     registerIndiPropertyReadOnly( m_indiP_lastHomed );
@@ -309,6 +319,7 @@ int zaberCtrl::appStartup()
     REG_INDI_SETPROP( m_indiP_stageRawPos, m_lowLevelName, std::string( "curr_pos" ) );
     REG_INDI_SETPROP( m_indiP_stageTgtPos, m_lowLevelName, std::string( "tgt_pos" ) );
     REG_INDI_SETPROP( m_indiP_stageTemp, m_lowLevelName, std::string( "temp" ) );
+    REG_INDI_SETPROP( m_indiP_stageParked, m_lowLevelName, std::string( "parked" ) );
     REG_INDI_SETPROP( m_indiP_stageLastHomed, m_lowLevelName, std::string( "last_homed" ) );
 
     if( m_presetNames.size() != m_presetPositions.size() )
@@ -499,7 +510,7 @@ int zaberCtrl::startHoming()
     indiP_stageHome.setPerm( pcf::IndiProperty::ReadWrite );
     indiP_stageHome.setState( pcf::IndiProperty::Idle );
     indiP_stageHome.add( pcf::IndiElement( m_stageName ) );
-    indiP_stageHome[m_stageName].setSwitchState(pcf::IndiElement::On);
+    indiP_stageHome[m_stageName].setSwitchState( pcf::IndiElement::On );
 
     m_moving      = 2;
     m_homingState = 1;
@@ -522,7 +533,7 @@ int zaberCtrl::stop()
     indiP_stageHalt.setPerm( pcf::IndiProperty::ReadWrite );
     indiP_stageHalt.setState( pcf::IndiProperty::Idle );
     indiP_stageHalt.add( pcf::IndiElement( m_stageName ) );
-    indiP_stageHalt[m_stageName].setSwitchState(pcf::IndiElement::On);
+    indiP_stageHalt[m_stageName].setSwitchState( pcf::IndiElement::On );
 
     if( sendNewProperty( indiP_stageHalt ) < 0 )
     {
@@ -560,7 +571,7 @@ int zaberCtrl::moveTo( const double &target )
     indiP_stageTgtPos.setPerm( pcf::IndiProperty::ReadWrite );
     indiP_stageTgtPos.setState( pcf::IndiProperty::Idle );
     indiP_stageTgtPos.add( pcf::IndiElement( m_stageName ) );
-    indiP_stageTgtPos[m_stageName].set(m_tgtRawPos);
+    indiP_stageTgtPos[m_stageName].set( m_tgtRawPos );
 
     m_moving = 1;
     dev::stdMotionStage<zaberCtrl>::recordStage( true );
@@ -646,7 +657,7 @@ INDI_NEWCALLBACK_DEFN( zaberCtrl, m_indiP_rawPos )( const pcf::IndiProperty &ipR
     indiP_stageTgtPos.setPerm( pcf::IndiProperty::ReadWrite );
     indiP_stageTgtPos.setState( pcf::IndiProperty::Idle );
     indiP_stageTgtPos.add( pcf::IndiElement( m_stageName ) );
-    indiP_stageTgtPos[m_stageName].set(target);
+    indiP_stageTgtPos[m_stageName].set( target );
 
     dev::stdMotionStage<zaberCtrl>::recordStage( true );
 
@@ -864,6 +875,24 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageTemp )( const pcf::IndiProperty &
     m_stageTemp = ipRecv[m_stageName].get<double>();
 
     updateIfChanged( m_indiP_temp, "current", m_stageTemp );
+
+    return 0;
+}
+
+INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageParked )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_stageParked, ipRecv );
+
+    if( ipRecv.find( m_stageName ) != true ) // Just not our stage.
+    {
+        return 0;
+    }
+
+    std::lock_guard<std::mutex> guard( m_indiMutex );
+
+    m_parked = ( ipRecv[m_stageName].get<int>() != 0 );
+
+    updateIfChanged( m_indiP_parked, "current", static_cast<int>( m_parked ) );
 
     return 0;
 }

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -1,7 +1,11 @@
 
+/** \file cameraStatus.cpp
+ * \brief Overlay status rendering for camera-associated devices.
+ */
+
 #include "cameraStatus.hpp"
 
-#define errPrint(expl) std::cerr << "cameraStatus: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
+#define errPrint( expl ) std::cerr << "cameraStatus: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
 
 cameraStatus::cameraStatus() : rtimvOverlayInterface()
 {
@@ -11,92 +15,101 @@ cameraStatus::~cameraStatus()
 {
 }
 
-int cameraStatus::attachOverlay( rtimvOverlayAccess & roa,
-                                 mx::app::appConfigurator & config
-                               )
+int cameraStatus::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &config )
 {
     m_roa = roa;
     m_qgs = roa.m_graphicsView->scene();
 
+    config.configUnused( m_deviceName, mx::app::iniFile::makeKey( "camera", "name" ) );
 
-    config.configUnused(m_deviceName, mx::app::iniFile::makeKey("camera", "name"));
-
-    if(m_deviceName == "")
+    if( m_deviceName == "" )
     {
-        pluginLogInfo("not configured");
-       m_enableable = false;
-       disableOverlay();
-       return 1; //Tell rtimv to unload me since not configured.
+        pluginLogInfo( "not configured" );
+        m_enableable = false;
+        disableOverlay();
+        return 1; // Tell rtimv to unload me since not configured.
     }
 
     m_enableable = true;
-    m_enabled = true;
+    m_enabled    = true;
 
-    pluginLogInfo(std::format("enabling for {}", m_deviceName));
+    pluginLogInfo( std::format( "enabling for {}", m_deviceName ) );
 
-    config.configUnused(m_filterDeviceNames, mx::app::iniFile::makeKey("camera", "filterDevices"));
+    config.configUnused( m_filterDeviceNames, mx::app::iniFile::makeKey( "camera", "filterDevices" ) );
 
-    if(m_roa.m_dictionary != nullptr)
+    if( m_roa.m_dictionary != nullptr )
     {
-        //Register these
-        (*m_roa.m_dictionary)[m_deviceName + ".temp_ccd.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".fg_frameSize.width"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".fg_frameSize.height"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_w.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_h.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_x.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_y.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_bin_y.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_bin_x.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_w.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_h.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_x.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_y.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_bin_y.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".roi_region_bin_x.target"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".exptime.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".fps.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".emgain.current"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".shutter_status.status"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + ".shutter.toggle"].setBlob(nullptr, 0);
+        // Register these
+        ( *m_roa.m_dictionary )[m_deviceName + ".temp_ccd.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".fg_frameSize.width"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".fg_frameSize.height"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_w.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_h.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_x.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_y.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_bin_y.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_bin_x.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_w.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_h.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_x.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_y.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_bin_y.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".roi_region_bin_x.target"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".exptime.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".fps.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".emgain.current"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".shutter_status.status"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + ".shutter.toggle"].setBlob( nullptr, 0 );
 
-        m_presetNames.resize(m_filterDeviceNames.size());
+        m_presetNames.resize( m_filterDeviceNames.size() );
 
-        for(size_t f = 0; f < m_filterDeviceNames.size(); ++f)
+        for( size_t f = 0; f < m_filterDeviceNames.size(); ++f )
         {
-            if(m_filterDeviceNames[f].find("fw") == 0) m_presetNames[f] = ".filterName";
-            else if(m_filterDeviceNames[f].find("flip") == 0) m_presetNames[f] = ".presetName";
-            else m_presetNames[f] = ".presetName";
+            if( m_filterDeviceNames[f].find( "fw" ) == 0 )
+                m_presetNames[f] = ".filterName";
+            else if( m_filterDeviceNames[f].find( "flip" ) == 0 )
+                m_presetNames[f] = ".presetName";
+            else
+                m_presetNames[f] = ".presetName";
 
-            (*m_roa.m_dictionary)[m_filterDeviceNames[f] + ".fsm.state"].setBlob(nullptr, 0);
-            (*m_roa.m_dictionary)[m_filterDeviceNames[f] + m_presetNames[f]].setBlob(nullptr, 0);
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".fsm.state"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".parked.current"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + m_presetNames[f]].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".position.current"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".filter.current"].setBlob( nullptr, 0 );
         }
 
+        ( *m_roa.m_dictionary )[m_deviceName + "-sw.writing.toggle"].setBlob( nullptr, 0 );
+        ( *m_roa.m_dictionary )[m_deviceName + "-sw.fsm.state"].setBlob( nullptr, 0 );
 
-        (*m_roa.m_dictionary)[m_deviceName + "-sw.writing.toggle"].setBlob(nullptr, 0);
-        (*m_roa.m_dictionary)[m_deviceName + "-sw.fsm.state"].setBlob(nullptr, 0);
+        //(*m_roa.m_dictionary)[m_deviceName + ""].setBlob(nullptr, 0);
+    }
 
-      //(*m_roa.m_dictionary)[m_deviceName + ""].setBlob(nullptr, 0);
+    connect( this,
+             SIGNAL( newStretchBox( StretchBox * ) ),
+             m_roa.m_mainWindowObject,
+             SLOT( addStretchBox( StretchBox * ) ) );
+    connect( this,
+             SIGNAL( savingState( rtimv::savingState ) ),
+             m_roa.m_mainWindowObject,
+             SLOT( savingState( rtimv::savingState ) ) );
 
-   }
+    if( m_enabled )
+        enableOverlay();
+    else
+        disableOverlay();
 
-   connect(this, SIGNAL(newStretchBox(StretchBox *)), m_roa.m_mainWindowObject, SLOT(addStretchBox(StretchBox *)));
-   connect(this, SIGNAL(savingState(rtimv::savingState)), m_roa.m_mainWindowObject, SLOT(savingState(rtimv::savingState)));
-
-   if(m_enabled) enableOverlay();
-   else disableOverlay();
-
-   return 0;
+    return 0;
 }
 
-bool cameraStatus::blobExists( const std::string & propel )
+bool cameraStatus::blobExists( const std::string &propel )
 {
-    if(m_roa.m_dictionary->count(m_deviceName + "." + propel) == 0)
+    if( m_roa.m_dictionary->count( m_deviceName + "." + propel ) == 0 )
     {
         return false;
     }
 
-    if((*m_roa.m_dictionary)[m_deviceName + "." + propel].getBlobSize() == 0)
+    if( ( *m_roa.m_dictionary )[m_deviceName + "." + propel].getBlobSize() == 0 )
     {
         return false;
     }
@@ -104,19 +117,20 @@ bool cameraStatus::blobExists( const std::string & propel )
     return true;
 }
 
-bool cameraStatus::getBlobStr( const std::string & deviceName, const std::string & propel )
+bool cameraStatus::getBlobStr( const std::string &deviceName, const std::string &propel )
 {
-    if(m_roa.m_dictionary->count(deviceName + "." + propel) == 0)
+    if( m_roa.m_dictionary->count( deviceName + "." + propel ) == 0 )
     {
         return false;
     }
 
-    if( ((*m_roa.m_dictionary)[deviceName + "." + propel].getBlobStr(m_blob, sizeof(m_blob))) == sizeof(m_blob) )
+    if( ( ( *m_roa.m_dictionary )[deviceName + "." + propel].getBlobStr( m_blob, sizeof( m_blob ) ) ) ==
+        sizeof( m_blob ) )
     {
         return false;
     }
 
-    if(m_blob[0] == '\0')
+    if( m_blob[0] == '\0' )
     {
         return false;
     }
@@ -124,17 +138,17 @@ bool cameraStatus::getBlobStr( const std::string & deviceName, const std::string
     return true;
 }
 
-bool cameraStatus::getBlobStr( const std::string & propel )
+bool cameraStatus::getBlobStr( const std::string &propel )
 {
-    return getBlobStr(m_deviceName, propel);
+    return getBlobStr( m_deviceName, propel );
 }
 
-template<>
-int cameraStatus::getBlobVal<int>( const std::string & propel, int defVal )
+template <>
+int cameraStatus::getBlobVal<int>( const std::string &propel, int defVal )
 {
-    if(getBlobStr(propel))
+    if( getBlobStr( propel ) )
     {
-        return atoi(m_blob);
+        return atoi( m_blob );
     }
     else
     {
@@ -142,199 +156,221 @@ int cameraStatus::getBlobVal<int>( const std::string & propel, int defVal )
     }
 }
 
-template<>
-float cameraStatus::getBlobVal<float>( const std::string & propel, float defVal )
+template <>
+float cameraStatus::getBlobVal<float>( const std::string &propel, float defVal )
 {
-    if(getBlobStr(propel))
+    if( getBlobStr( propel ) )
     {
-        return strtod(m_blob,0);
+        return strtod( m_blob, 0 );
     }
     else
     {
         return defVal;
     }
 }
-
 
 int cameraStatus::updateOverlay()
 {
-    if(!m_enabled) return 0;
+    if( !m_enabled )
+        return 0;
 
-    if(m_roa.m_dictionary == nullptr) return 0;
+    if( m_roa.m_dictionary == nullptr )
+        return 0;
 
-    if(m_roa.m_graphicsView == nullptr) return 0;
+    if( m_roa.m_graphicsView == nullptr )
+        return 0;
 
     size_t n = 0;
-    //char * str;
-    char tstr[128];
+    // char * str;
+    char        tstr[128];
     std::string sstr;
 
-    if(getBlobStr("temp_ccd.current"))
+    if( getBlobStr( "temp_ccd.current" ) )
     {
-        snprintf(tstr, sizeof(tstr), "%0.1f C", strtod(m_blob,0));
-        m_roa.m_graphicsView->statusTextText(n, tstr);
+        snprintf( tstr, sizeof( tstr ), "%0.1f C", strtod( m_blob, 0 ) );
+        m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-    //Get curr size
+    // Get curr size
     m_width = -1;
-    if(getBlobStr("fg_frameSize.width"))
+    if( getBlobStr( "fg_frameSize.width" ) )
     {
-        m_width = atoi(m_blob);
+        m_width = atoi( m_blob );
     }
 
-    m_height=-1;
-    if(getBlobStr("fg_frameSize.height"))
+    m_height = -1;
+    if( getBlobStr( "fg_frameSize.height" ) )
     {
-        m_height = atoi(m_blob);
+        m_height = atoi( m_blob );
     }
 
-    if(blobExists("roi_region_w.current") && blobExists("roi_region_h.current") && blobExists("roi_region_x.current")
-                          && blobExists("roi_region_y.current") && blobExists("roi_region_bin_x.current") && blobExists("roi_region_bin_y.current"))
+    if( blobExists( "roi_region_w.current" ) && blobExists( "roi_region_h.current" ) &&
+        blobExists( "roi_region_x.current" ) && blobExists( "roi_region_y.current" ) &&
+        blobExists( "roi_region_bin_x.current" ) && blobExists( "roi_region_bin_y.current" ) )
     {
-        int w = getBlobVal<int>("roi_region_w.current", -1);
-        int h = getBlobVal<int>("roi_region_h.current", -1);
-        int ibx = getBlobVal<int>("roi_region_bin_x.current", -1);
-        int iby = getBlobVal<int>("roi_region_bin_y.current", -1);
-        float x = getBlobVal<float>("roi_region_x.current", -1);
-        float y = getBlobVal<float>("roi_region_y.current", -1);
+        int   w   = getBlobVal<int>( "roi_region_w.current", -1 );
+        int   h   = getBlobVal<int>( "roi_region_h.current", -1 );
+        int   ibx = getBlobVal<int>( "roi_region_bin_x.current", -1 );
+        int   iby = getBlobVal<int>( "roi_region_bin_y.current", -1 );
+        float x   = getBlobVal<float>( "roi_region_x.current", -1 );
+        float y   = getBlobVal<float>( "roi_region_y.current", -1 );
 
-        //Only go on if we got good values
-        if(w > 0 && h > 0 && x > 0 && y > 0 && ibx > 0 && iby > 0)
+        // Only go on if we got good values
+        if( w > 0 && h > 0 && x > 0 && y > 0 && ibx > 0 && iby > 0 )
         {
-            snprintf(tstr, sizeof(tstr), "%dx%d [%dx%d]", w, h, ibx, iby );
+            snprintf( tstr, sizeof( tstr ), "%dx%d [%dx%d]", w, h, ibx, iby );
 
             //****************
-            m_roa.m_graphicsView->statusTextText(n, tstr);
+            m_roa.m_graphicsView->statusTextText( n, tstr );
             ++n;
 
             float bx = ibx;
             float by = iby;
 
-            if(blobExists("roi_region_w.target") && blobExists("roi_region_h.target") && blobExists("roi_region_x.target")
-                          && blobExists("roi_region_y.target") && blobExists("roi_region_bin_x.target") && blobExists("roi_region_bin_y.target"))
+            if( blobExists( "roi_region_w.target" ) && blobExists( "roi_region_h.target" ) &&
+                blobExists( "roi_region_x.target" ) && blobExists( "roi_region_y.target" ) &&
+                blobExists( "roi_region_bin_x.target" ) && blobExists( "roi_region_bin_y.target" ) )
             {
 
-                std::lock_guard<std::mutex> guard(m_roiBoxMutex);
+                std::lock_guard<std::mutex> guard( m_roiBoxMutex );
 
-                int wt = getBlobVal<int>("roi_region_w.target", -1);
-                int ht = getBlobVal<int>("roi_region_h.target", -1);
-                float bxt = getBlobVal<float>("roi_region_bin_x.target", -1);
-                float byt = getBlobVal<float>("roi_region_bin_y.target", -1);
-                float xt = getBlobVal<float>("roi_region_x.target", -1);
-                float yt = getBlobVal<float>("roi_region_y.target", -1);
+                int   wt  = getBlobVal<int>( "roi_region_w.target", -1 );
+                int   ht  = getBlobVal<int>( "roi_region_h.target", -1 );
+                float bxt = getBlobVal<float>( "roi_region_bin_x.target", -1 );
+                float byt = getBlobVal<float>( "roi_region_bin_y.target", -1 );
+                float xt  = getBlobVal<float>( "roi_region_x.target", -1 );
+                float yt  = getBlobVal<float>( "roi_region_y.target", -1 );
 
-                if( (wt > 0 && ht > 0 && xt > 0 && yt > 0 && bxt >= 1 && byt >= 1) && ( wt != w || ht != h || xt != x || yt != y))
+                if( ( wt > 0 && ht > 0 && xt > 0 && yt > 0 && bxt >= 1 && byt >= 1 ) &&
+                    ( wt != w || ht != h || xt != x || yt != y ) )
                 {
-                    if(!m_roiBox)
+                    if( !m_roiBox )
                     {
-                        m_roiBox = new StretchBox(xt-0.5*(wt-1),yt-0.5*(ht-1),wt,ht);
-                        m_roiBox->setPenColor(Qt::magenta);
-                        m_roiBox->setPenWidth(1);
-                        m_roiBox->setVisible(true);
-                        m_roiBox->setStretchable(false);
-                        m_roiBox->setRemovable(false);
+                        m_roiBox = new StretchBox( xt - 0.5 * ( wt - 1 ), yt - 0.5 * ( ht - 1 ), wt, ht );
+                        m_roiBox->setPenColor( Qt::magenta );
+                        m_roiBox->setPenWidth( 1 );
+                        m_roiBox->setVisible( true );
+                        m_roiBox->setStretchable( false );
+                        m_roiBox->setRemovable( false );
                         std::cerr << "Connecting\n";
-                        connect(m_roiBox, SIGNAL(remove(StretchBox*)), this, SLOT(stretchBoxRemove(StretchBox*)));
-                        emit newStretchBox(m_roiBox);
+                        connect( m_roiBox,
+                                 SIGNAL( remove( StretchBox * ) ),
+                                 this,
+                                 SLOT( stretchBoxRemove( StretchBox * ) ) );
+                        emit newStretchBox( m_roiBox );
                     }
-                    //note: can only be here if bx > 0
-                    float xc = (xt*bxt-x*bx + 0.5*((float)m_width*bx-1))/bx;
-                    float yc = (m_height*by - ( yt*byt-y*by + 0.5*((float)m_height*by-1)))/by;
+                    // note: can only be here if bx > 0
+                    float xc = ( xt * bxt - x * bx + 0.5 * ( (float)m_width * bx - 1 ) ) / bx;
+                    float yc = ( m_height * by - ( yt * byt - y * by + 0.5 * ( (float)m_height * by - 1 ) ) ) / by;
 
-                    float bxleftX = xc-0.5*(wt*bxt/bx-1.0);
-                    float bxleftY = yc-0.5*(ht*byt/by-1.0);
-                    float bxW = wt*bxt/bx;
-                    float bxH = ht*byt/by;
+                    float bxleftX = xc - 0.5 * ( wt * bxt / bx - 1.0 );
+                    float bxleftY = yc - 0.5 * ( ht * byt / by - 1.0 );
+                    float bxW     = wt * bxt / bx;
+                    float bxH     = ht * byt / by;
 
-                    m_roiBox->setRect(m_roiBox->mapRectFromScene(bxleftX,bxleftY,bxW,bxH));
-                    m_roiBox->setVisible(true);
+                    m_roiBox->setRect( m_roiBox->mapRectFromScene( bxleftX, bxleftY, bxW, bxH ) );
+                    m_roiBox->setVisible( true );
                 }
                 else
                 {
-                    if(m_roiBox) m_roiBox->setVisible(false);
+                    if( m_roiBox )
+                        m_roiBox->setVisible( false );
                 }
 
-            }//if(blobExists("roi_region_w.target")
+            } // if(blobExists("roi_region_w.target")
 
-        }//if(w > 0 && h > 0 && x > 0 && y > 0 && ibx > 0 && iby > 0)
+        } // if(w > 0 && h > 0 && x > 0 && y > 0 && ibx > 0 && iby > 0)
 
-    }//if(blobExists("roi_region_w.current") ...
+    } // if(blobExists("roi_region_w.current") ...
 
     //***********************
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-
-    float et = getBlobVal<float>("exptime.current", -1);
-    if(et >= 0)
+    float et = getBlobVal<float>( "exptime.current", -1 );
+    if( et >= 0 )
     {
-        if(et >= 100)
+        if( et >= 100 )
         {
-            snprintf(tstr, sizeof(tstr), "%0.1f s", et);
+            snprintf( tstr, sizeof( tstr ), "%0.1f s", et );
         }
-        else if(et >= 10)
+        else if( et >= 10 )
         {
-            snprintf(tstr, sizeof(tstr), "%0.2f s", et);
+            snprintf( tstr, sizeof( tstr ), "%0.2f s", et );
         }
-        else if(et >= 0.1)
+        else if( et >= 0.1 )
         {
-            snprintf(tstr, sizeof(tstr), "%0.3f s", et);
+            snprintf( tstr, sizeof( tstr ), "%0.3f s", et );
         }
         else
         {
-            if(et >= 0.00009999)
+            if( et >= 0.00009999 )
             {
-                snprintf(tstr, sizeof(tstr), "%0.2f ms", et*1000.0);
+                snprintf( tstr, sizeof( tstr ), "%0.2f ms", et * 1000.0 );
             }
             else
             {
-                snprintf(tstr, sizeof(tstr), "%0.2f us", et*1000000.0);
+                snprintf( tstr, sizeof( tstr ), "%0.2f us", et * 1000000.0 );
             }
         }
 
-        m_roa.m_graphicsView->statusTextText(n, tstr);
+        m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-    float fps = getBlobVal<float>("fps.current",-1);
-    if(fps >= 0)
+    float fps = getBlobVal<float>( "fps.current", -1 );
+    if( fps >= 0 )
     {
-        snprintf(tstr, sizeof(tstr), "%0.1f FPS", fps);
-        m_roa.m_graphicsView->statusTextText(n, tstr);
+        snprintf( tstr, sizeof( tstr ), "%0.1f FPS", fps );
+        m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-    int emg = getBlobVal<int>("emgain.current", -1);
-    if(emg >= 0)
+    int emg = getBlobVal<int>( "emgain.current", -1 );
+    if( emg >= 0 )
     {
-        snprintf(tstr, sizeof(tstr), "EMG: %d", emg);
-        m_roa.m_graphicsView->statusTextText(n, tstr);
+        snprintf( tstr, sizeof( tstr ), "EMG: %d", emg );
+        m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-    for(size_t f = 0; f < m_filterDeviceNames.size(); ++f)
+    for( size_t f = 0; f < m_filterDeviceNames.size(); ++f )
     {
-        if(getBlobStr(m_filterDeviceNames[f], "fsm.state"))
+        if( getBlobStr( m_filterDeviceNames[f], "fsm.state" ) )
         {
-            std::string fwstate = std::string(m_blob);
+            std::string fwstate = std::string( m_blob );
+            bool        parked  = false;
 
-            if(fwstate == "READY" || fwstate == "OPERATING")
+            if( getBlobStr( m_filterDeviceNames[f], "parked.current" ) )
             {
-                dictionaryIteratorT start = m_roa.m_dictionary->lower_bound(m_filterDeviceNames[f] + m_presetNames[f]);
-                dictionaryIteratorT end = m_roa.m_dictionary->upper_bound(m_filterDeviceNames[f] + m_presetNames[f] + "Z");
+                parked = ( atoi( m_blob ) != 0 );
+            }
+
+            if( fwstate == "READY" || fwstate == "OPERATING" || ( fwstate == "POWEROFF" && parked ) )
+            {
+                dictionaryIteratorT start =
+                    m_roa.m_dictionary->lower_bound( m_filterDeviceNames[f] + m_presetNames[f] );
+                dictionaryIteratorT end =
+                    m_roa.m_dictionary->upper_bound( m_filterDeviceNames[f] + m_presetNames[f] + "Z" );
 
                 std::string fkey;
-                while(start != end)
+                while( start != end )
                 {
-                    if( (start->second.getBlobStr(m_blob, sizeof(m_blob))) == sizeof(m_blob) ) errPrint("bad string"); //Don't trust this as a string
+                    if( ( start->second.getBlobStr( m_blob, sizeof( m_blob ) ) ) == sizeof( m_blob ) )
+                        errPrint( "bad string" ); // Don't trust this as a string
 
-                    if(m_blob[0] != '\0')
+                    if( m_blob[0] != '\0' )
                     {
-                        if(std::string(m_blob) == "on")
+                        if( std::string( m_blob ) == "on" )
                         {
                             fkey = start->first;
                             break;
@@ -343,41 +379,66 @@ int cameraStatus::updateOverlay()
                     ++start;
                 }
 
-                size_t pp = fkey.rfind('.');
+                size_t      pp = fkey.rfind( '.' );
                 std::string filn;
-                if(pp != std::string::npos && pp < fkey.size()-1) //need to be able to add 1
+                if( pp != std::string::npos && pp < fkey.size() - 1 ) // need to be able to add 1
                 {
-                    filn = m_filterDeviceNames[f] + ": " + fkey.substr(pp+1).c_str();
+                    filn = m_filterDeviceNames[f] + ": " + fkey.substr( pp + 1 ).c_str();
                 }
                 else
                 {
-                    filn = m_filterDeviceNames[f] + ": unk";
+                    bool   havePos = false;
+                    double pos     = 0;
+
+                    if( getBlobStr( m_filterDeviceNames[f], "filter.current" ) )
+                    {
+                        pos     = strtod( m_blob, nullptr );
+                        havePos = true;
+                    }
+                    else if( getBlobStr( m_filterDeviceNames[f], "position.current" ) )
+                    {
+                        pos     = strtod( m_blob, nullptr );
+                        havePos = true;
+                    }
+
+                    if( havePos )
+                    {
+                        snprintf( tstr, sizeof( tstr ), "%s: %0.4f", m_filterDeviceNames[f].c_str(), pos );
+                        filn = tstr;
+                    }
+                    else
+                    {
+                        filn = m_filterDeviceNames[f] + ": unk";
+                    }
                 }
-                m_roa.m_graphicsView->statusTextText(n, filn.c_str());
+                m_roa.m_graphicsView->statusTextText( n, filn.c_str() );
                 ++n;
             }
             else
             {
-                fwstate = m_filterDeviceNames[f] +  ": " + fwstate;
-                m_roa.m_graphicsView->statusTextText(n, fwstate.c_str());
+                fwstate = m_filterDeviceNames[f] + ": " + fwstate;
+                m_roa.m_graphicsView->statusTextText( n, fwstate.c_str() );
                 ++n;
             }
         }
-        if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+        if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+            return 0;
     }
 
-    if(getBlobStr("shutter_status.status"))
+    if( getBlobStr( "shutter_status.status" ) )
     {
-        sstr = std::string(m_blob);
+        sstr = std::string( m_blob );
 
-        if(sstr == "READY")
+        if( sstr == "READY" )
         {
-            if(getBlobStr("shutter.toggle"))
+            if( getBlobStr( "shutter.toggle" ) )
             {
-                sstr = std::string(m_blob);
-                if(sstr == "on") sstr = "sh SHUT";
-                else sstr = "sh OPEN";
-                m_roa.m_graphicsView->statusTextText(n, sstr.c_str());
+                sstr = std::string( m_blob );
+                if( sstr == "on" )
+                    sstr = "sh SHUT";
+                else
+                    sstr = "sh OPEN";
+                m_roa.m_graphicsView->statusTextText( n, sstr.c_str() );
                 ++n;
             }
         }
@@ -385,92 +446,96 @@ int cameraStatus::updateOverlay()
         {
 
             sstr = "sh " + sstr;
-            m_roa.m_graphicsView->statusTextText(n, sstr.c_str());
+            m_roa.m_graphicsView->statusTextText( n, sstr.c_str() );
             ++n;
         }
     }
-    if(n > m_roa.m_graphicsView->statusTextNo()-1) return 0;
+    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        return 0;
 
-    if(getBlobStr(m_deviceName + "-sw", "fsm.state"))
+    if( getBlobStr( m_deviceName + "-sw", "fsm.state" ) )
     {
-        std::string fsmstr = std::string(m_blob);
+        std::string fsmstr = std::string( m_blob );
 
         std::string swtstr = "off";
 
-        if(getBlobStr(m_deviceName + "-sw", "writing.toggle"))
+        if( getBlobStr( m_deviceName + "-sw", "writing.toggle" ) )
         {
-            swtstr = std::string(m_blob);
+            swtstr = std::string( m_blob );
         }
 
-        if(fsmstr == "OPERATING")
+        if( fsmstr == "OPERATING" )
         {
-            if(swtstr == "on")
+            if( swtstr == "on" )
             {
-                emit savingState(rtimv::savingState::on);
+                emit savingState( rtimv::savingState::on );
             }
             else
             {
-                emit savingState(rtimv::savingState::waiting);
+                emit savingState( rtimv::savingState::waiting );
             }
         }
         else
         {
-            emit savingState(rtimv::savingState::off);
+            emit savingState( rtimv::savingState::off );
         }
     }
 
     return 0;
 }
 
-void cameraStatus::keyPressEvent( QKeyEvent * ke)
+void cameraStatus::keyPressEvent( QKeyEvent *ke )
 {
-   char key = ke->text()[0].toLatin1();
+    char key = ke->text()[0].toLatin1();
 
-   if(key == 'C')
-   {
-      if(m_enabled) disableOverlay();
-      else enableOverlay();
-   }
-   else if(key == 'R')
-   {
-      std::cerr << "ROI\n";
-   }
+    if( key == 'C' )
+    {
+        if( m_enabled )
+            disableOverlay();
+        else
+            enableOverlay();
+    }
+    else if( key == 'R' )
+    {
+        std::cerr << "ROI\n";
+    }
 }
 
 bool cameraStatus::overlayEnabled()
 {
-   return m_enabled;
+    return m_enabled;
 }
 
 void cameraStatus::enableOverlay()
 {
-   if(m_enableable == false) return;
+    if( m_enableable == false )
+        return;
 
-   m_enabled = true;
+    m_enabled = true;
 }
 
 void cameraStatus::disableOverlay()
 {
-   for(size_t n=0; n<m_roa.m_graphicsView->statusTextNo();++n)
-   {
-      m_roa.m_graphicsView->statusTextText(n, "");
-   }
+    for( size_t n = 0; n < m_roa.m_graphicsView->statusTextNo(); ++n )
+    {
+        m_roa.m_graphicsView->statusTextText( n, "" );
+    }
 
-   m_enabled = false;
+    m_enabled = false;
 }
 
-void cameraStatus::stretchBoxRemove(StretchBox * sb)
+void cameraStatus::stretchBoxRemove( StretchBox *sb )
 {
     std::cerr << "cameraStatus::stretchBoxRemove 1\n";
-    std::lock_guard<std::mutex> guard(m_roiBoxMutex);
-    if(!m_roiBox)
+    std::lock_guard<std::mutex> guard( m_roiBoxMutex );
+    if( !m_roiBox )
     {
         return;
     }
 
     std::cerr << "cameraStatus::stretchBoxRemove 2\n";
 
-    if(sb != m_roiBox)
+    if( sb != m_roiBox )
     {
         return;
     }
@@ -483,7 +548,7 @@ void cameraStatus::stretchBoxRemove(StretchBox * sb)
 std::vector<std::string> cameraStatus::info()
 {
     std::vector<std::string> vinfo;
-    vinfo.push_back("Camera Status overlay: " + m_deviceName);
+    vinfo.push_back( "Camera Status overlay: " + m_deviceName );
 
     return vinfo;
 }

--- a/gui/widgets/stage/stage.hpp
+++ b/gui/widgets/stage/stage.hpp
@@ -1,4 +1,8 @@
 
+/** \file stage.hpp
+ * \brief Stage control widget used by stage and camera GUIs.
+ */
+
 #ifndef stage_hpp
 #define stage_hpp
 
@@ -9,120 +13,160 @@
 namespace xqt
 {
 
+/// Stage control widget with parked-poweroff display support.
 class stage : public xWidget
 {
-   Q_OBJECT
+    Q_OBJECT
 
-   enum editchanges{NOTEDITING, STARTED, STOPPED};
+    enum editchanges
+    {
+        NOTEDITING,
+        STARTED,
+        STOPPED
+    };
 
-protected:
+  protected:
+    /// Most recent FSM state reported by the stage controller.
+    std::string m_appState;
 
-   std::string m_appState;
+    /// INDI device name of the stage controller.
+    std::string m_stageName;
+    /// Base window title shown while connected.
+    std::string m_winTitle;
 
-   std::string m_stageName;
-   std::string m_winTitle;
+    /// Known preset names exposed by the controller.
+    std::vector<std::string> m_presets;
+    /// Placeholder for the current preset selection.
+    std::string m_presetCurrent;
+    /// Placeholder for the target preset selection.
+    std::string m_presetTarget;
 
-   std::vector<std::string> m_presets;
-   std::string m_presetCurrent;
-   std::string m_presetTarget;
+    /// Whether this widget is presenting a filter wheel style interface.
+    bool m_filterWheel{ false };
 
-   bool m_filterWheel {false};
+    /// Current preset/filter label shown in the combo box.
+    std::string m_setPoint;
 
-   std::string m_setPoint;
+    /// Whether the controller reports this stage as parked.
+    bool m_parked{ false };
 
-   double m_maxPos  {100};
-   double m_position {-1e30};
-   bool m_position_changed {false};
+    /// Maximum allowed position in user units.
+    double m_maxPos{ 100 };
+    /// Current position in user units.
+    double m_position{ -1e30 };
+    /// Tracks when the displayed position should be highlighted as changed.
+    bool m_position_changed{ false };
 
-   double m_step {1};
+    /// Step size used by the incremental move buttons.
+    double m_step{ 1 };
 
-   int m_setPointEditing {STOPPED};
-   QTimer * m_setPointEditTimer {nullptr};
+    /// Tracks edit state for the preset combo box.
+    int m_setPointEditing{ STOPPED };
+    /// Timer that clears staged preset edits after inactivity.
+    QTimer *m_setPointEditTimer{ nullptr };
 
-public:
-   explicit stage( const std::string & stageName,
-                   QWidget * Parent = 0,
-                   Qt::WindowFlags f = Qt::WindowFlags()
-                 );
+  public:
+    /// Construct a stage widget for one INDI stage device.
+    explicit stage( const std::string &stageName, QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
 
-   ~stage();
+    /// Destroy the widget.
+    ~stage();
 
-   void subscribe();
+    /// Subscribe to the stage properties needed by the widget.
+    void subscribe();
 
-   virtual void onConnect();
-   virtual void onDisconnect();
+    /// Reset the widget for an active INDI connection.
+    virtual void onConnect();
+    /// Reset the widget for a disconnected INDI connection.
+    virtual void onDisconnect();
 
-   void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handle a newly defined property using the same path as updates.
+    void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
-   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+    /// Handle a deleted stage property.
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
 
-   void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handle a stage property update.
+    void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
-   void clear_focus();
+    /// Clear focus from the widget.
+    void clear_focus();
 
-public slots:
-   void updateGUI();
+  public slots:
+    /// Refresh the widget state from cached INDI values.
+    void updateGUI();
 
-   void on_setPoint_activated( int index );
+    /// Mark the set-point combo box as actively edited.
+    void on_setPoint_activated( int index );
 
-   void on_setPointGo_pressed();
+    /// Send the currently selected preset/filter target.
+    void on_setPointGo_pressed();
 
-   void on_positionSlider_sliderMoved( double s );
+    /// Preview the position corresponding to the slider drag.
+    void on_positionSlider_sliderMoved( double s );
 
-   void on_positionSlider_sliderReleased();
+    /// Send a move request from the released slider position.
+    void on_positionSlider_sliderReleased();
 
-   void on_position_returnPressed();
+    /// Send a move request from the typed position field.
+    void on_position_returnPressed();
 
-   void on_stepSize_editingFinished();
+    /// Persist an edited step size.
+    void on_stepSize_editingFinished();
 
-   void on_posMinus_pressed();
-   void on_posPlus_pressed();
+    /// Send a negative relative move.
+    void on_posMinus_pressed();
+    /// Send a positive relative move.
+    void on_posPlus_pressed();
 
-   void on_posStepMulTen_pressed();
-   void on_posStepDivTen_pressed();
+    /// Increase the step size by one decade.
+    void on_posStepMulTen_pressed();
+    /// Decrease the step size by one decade.
+    void on_posStepDivTen_pressed();
 
-   void on_home_pressed();
-   void on_stop_pressed();
+    /// Request a home operation.
+    void on_home_pressed();
+    /// Request an immediate stop.
+    void on_stop_pressed();
 
-   void setPointEditTimerOut();
+    /// End temporary preset-edit mode after the timer expires.
+    void setPointEditTimerOut();
 
-signals:
-   void setPointEditTimerStart(int);
+  signals:
+    void setPointEditTimerStart( int );
 
-   void doUpdateGUI();
+    void doUpdateGUI();
 
-protected:
-   virtual void paintEvent(QPaintEvent * e);
+  protected:
+    virtual void paintEvent( QPaintEvent *e );
 
-private:
-
-   Ui::stage ui;
+  private:
+    Ui::stage ui;
 };
 
-stage::stage( const std::string & stageName,
-              QWidget * Parent,
-              Qt::WindowFlags f) : xWidget(Parent, f), m_stageName{stageName}
+stage::stage( const std::string &stageName, QWidget *Parent, Qt::WindowFlags f )
+    : xWidget( Parent, f ), m_stageName{ stageName }
 {
-    ui.setupUi(this);
+    ui.setupUi( this );
 
     m_winTitle = m_stageName;
 
-    ui.fsmState->device(m_stageName);
+    ui.fsmState->device( m_stageName );
     QFont qf = ui.stageName->font();
-    qf.setPixelSize(XW_FONT_SIZE+3);
-    ui.stageName->setFont(qf);
+    qf.setPixelSize( XW_FONT_SIZE + 3 );
+    ui.stageName->setFont( qf );
 
-    ui.stageName->setText(m_stageName.c_str());
+    ui.stageName->setText( m_stageName.c_str() );
 
-    ui.setPoint->setProperty("isStatus", true);
+    ui.setPoint->setProperty( "isStatus", true );
 
-    ui.position->setAlignment(Qt::AlignCenter);
-    ui.stepSize->setAlignment(Qt::AlignCenter);
+    ui.position->setAlignment( Qt::AlignCenter );
+    ui.stepSize->setAlignment( Qt::AlignCenter );
 
-    m_setPointEditTimer = new QTimer(this);
-    connect(m_setPointEditTimer, SIGNAL(timeout()), this, SLOT(setPointEditTimerOut()));
-    connect(this, SIGNAL(setPointEditTimerStart(int)), m_setPointEditTimer, SLOT(start(int)));
-    connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()));
+    m_setPointEditTimer = new QTimer( this );
+    connect( m_setPointEditTimer, SIGNAL( timeout() ), this, SLOT( setPointEditTimerOut() ) );
+    connect( this, SIGNAL( setPointEditTimerStart( int ) ), m_setPointEditTimer, SLOT( start( int ) ) );
+    connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ) );
 
     onDisconnect();
 }
@@ -133,478 +177,516 @@ stage::~stage()
 
 void stage::subscribe()
 {
-   if(!m_parent) return;
+    if( !m_parent )
+        return;
 
-   m_parent->addSubscriberProperty(this, m_stageName, "fsm");
-   m_parent->addSubscriberProperty(this, m_stageName, "maxpos");
-   m_parent->addSubscriberProperty(this, m_stageName, "position");
-   m_parent->addSubscriberProperty(this, m_stageName, "filter");
-   m_parent->addSubscriberProperty(this, m_stageName, "presetName");
-   m_parent->addSubscriberProperty(this, m_stageName, "filterName");
-   m_parent->addSubscriber(ui.fsmState);
+    m_parent->addSubscriberProperty( this, m_stageName, "fsm" );
+    m_parent->addSubscriberProperty( this, m_stageName, "maxpos" );
+    m_parent->addSubscriberProperty( this, m_stageName, "position" );
+    m_parent->addSubscriberProperty( this, m_stageName, "filter" );
+    m_parent->addSubscriberProperty( this, m_stageName, "parked" );
+    m_parent->addSubscriberProperty( this, m_stageName, "presetName" );
+    m_parent->addSubscriberProperty( this, m_stageName, "filterName" );
+    m_parent->addSubscriber( ui.fsmState );
 
-   return;
+    return;
 }
 
 void stage::onConnect()
 {
-   setWindowTitle(QString(m_winTitle.c_str()));
+    setWindowTitle( QString( m_winTitle.c_str() ) );
 
-   ui.stepSize->setText(QString::number(m_step));
+    ui.stepSize->setText( QString::number( m_step ) );
 
-   clearFocus();
+    clearFocus();
 }
 
 void stage::onDisconnect()
 {
-   m_appState.clear();
-   m_presets.clear();
-   m_presetCurrent.clear();
-   m_presetTarget.clear();
-   m_setPoint.clear();
-   m_filterWheel = false;
-   m_maxPos = 100;
-   m_position = -1e30;
-   m_position_changed = false;
+    m_appState.clear();
+    m_presets.clear();
+    m_presetCurrent.clear();
+    m_presetTarget.clear();
+    m_setPoint.clear();
+    m_parked           = false;
+    m_filterWheel      = false;
+    m_maxPos           = 100;
+    m_position         = -1e30;
+    m_position_changed = false;
 
-   setWindowTitle(QString(m_winTitle.c_str()) + QString(" (disconnected)"));
+    setWindowTitle( QString( m_winTitle.c_str() ) + QString( " (disconnected)" ) );
 
-   ui.stageName->setEnabled(false);
-   ui.fsmState->setEnabled(false);
-   ui.setPoint->clear();
-   ui.setPoint->setEnabled(false);
-   ui.setPointGo->setEnabled(false);
-   ui.positionSlider->setEnabled(false);
-   ui.position->setText("---");
-   ui.position->setEnabled(false);
-   ui.stepSize->setEnabled(false);
+    ui.stageName->setEnabled( false );
+    ui.fsmState->setEnabled( false );
+    ui.setPoint->clear();
+    ui.setPoint->setEnabled( false );
+    ui.setPointGo->setEnabled( false );
+    ui.positionSlider->setEnabled( false );
+    ui.position->setText( "---" );
+    ui.position->setEnabled( false );
+    ui.stepSize->setEnabled( false );
 
-   ui.posMinus->setEnabled(false);
-   ui.posPlus->setEnabled(false);
-   ui.posStepMulTen->setEnabled(false);
-   ui.posStepDivTen->setEnabled(false);
+    ui.posMinus->setEnabled( false );
+    ui.posPlus->setEnabled( false );
+    ui.posStepMulTen->setEnabled( false );
+    ui.posStepDivTen->setEnabled( false );
 
-   ui.home->setEnabled(false);
-   ui.stop->setEnabled(false);
+    ui.home->setEnabled( false );
+    ui.stop->setEnabled( false );
 
-   ui.fsmState->onDisconnect();
+    ui.fsmState->onDisconnect();
 }
 
-void stage::handleDefProperty( const pcf::IndiProperty & ipRecv)
+void stage::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   return handleSetProperty(ipRecv);
+    return handleSetProperty( ipRecv );
 }
 
-void stage::handleDelProperty( const pcf::IndiProperty & ipRecv)
+void stage::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getDevice() != m_stageName) return;
+    if( ipRecv.getDevice() != m_stageName )
+        return;
 
-   if(ipRecv.getName() == "fsm" ||
-      ipRecv.getName() == "maxpos" ||
-      ipRecv.getName() == "position" ||
-      ipRecv.getName() == "filter" ||
-      ipRecv.getName() == "presetName" ||
-      ipRecv.getName() == "filterName")
-   {
-      onDisconnect();
-   }
+    if( ipRecv.getName() == "parked" )
+    {
+        m_parked = false;
+        emit doUpdateGUI();
+        return;
+    }
+
+    if( ipRecv.getName() == "fsm" || ipRecv.getName() == "maxpos" || ipRecv.getName() == "position" ||
+        ipRecv.getName() == "filter" || ipRecv.getName() == "presetName" || ipRecv.getName() == "filterName" )
+    {
+        onDisconnect();
+    }
 }
 
-void stage::handleSetProperty( const pcf::IndiProperty & ipRecv)
+void stage::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getDevice() != m_stageName) return;
+    if( ipRecv.getDevice() != m_stageName )
+        return;
 
-   if(ipRecv.getName() == "fsm")
-   {
-      if(ipRecv.find("state"))
-      {
-         m_appState = ipRecv["state"].get<std::string>();
-      }
-   }
+    if( ipRecv.getName() == "fsm" )
+    {
+        if( ipRecv.find( "state" ) )
+        {
+            m_appState = ipRecv["state"].get<std::string>();
+        }
+    }
 
-   if(ipRecv.getName() == "maxpos")
-   {
-      if(ipRecv.find("value"))
-      {
-         m_maxPos = ipRecv["value"].get<double>();
-      }
-   }
+    if( ipRecv.getName() == "maxpos" )
+    {
+        if( ipRecv.find( "value" ) )
+        {
+            m_maxPos = ipRecv["value"].get<double>();
+        }
+    }
 
-   if(ipRecv.getName()== "position")
-   {
-      if(ipRecv.find("current"))
-      {
-         double val = ipRecv["current"].get<double>();
-         if(val != m_position) m_position_changed = true;
-         m_position = val;
-      }
-   }
-   else if(ipRecv.getName()== "filter")
-   {
-      m_filterWheel = true;
-      if(ipRecv.find("current"))
-      {
-         double val = ipRecv["current"].get<double>();
-         if(val != m_position) m_position_changed = true;
-         m_position = val;
-      }
-   }
+    if( ipRecv.getName() == "position" )
+    {
+        if( ipRecv.find( "current" ) )
+        {
+            double val = ipRecv["current"].get<double>();
+            if( val != m_position )
+                m_position_changed = true;
+            m_position = val;
+        }
+    }
+    else if( ipRecv.getName() == "parked" )
+    {
+        if( ipRecv.find( "current" ) )
+        {
+            m_parked = ( ipRecv["current"].get<int>() != 0 );
+        }
+    }
+    else if( ipRecv.getName() == "filter" )
+    {
+        m_filterWheel = true;
+        if( ipRecv.find( "current" ) )
+        {
+            double val = ipRecv["current"].get<double>();
+            if( val != m_position )
+                m_position_changed = true;
+            m_position = val;
+        }
+    }
 
-   if(ipRecv.getName() == "presetName" || ipRecv.getName() == "filterName")
-   {
-      if(ipRecv.getName() == "filterName") m_filterWheel = true;
+    if( ipRecv.getName() == "presetName" || ipRecv.getName() == "filterName" )
+    {
+        if( ipRecv.getName() == "filterName" )
+            m_filterWheel = true;
 
-      int n =0;
-      std::string newName;
-      for(auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it)
-      {
-         ++n;
-         if(ui.setPoint->findText(QString(it->second.getName().c_str())) == -1)
-         {
-            ui.setPoint->addItem(QString(it->second.getName().c_str()));
-         }
-
-         if(it->second.getSwitchState() == pcf::IndiElement::On)
-         {
-            if(newName != "")
+        int         n = 0;
+        std::string newName;
+        for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
+        {
+            ++n;
+            if( ui.setPoint->findText( QString( it->second.getName().c_str() ) ) == -1 )
             {
-               std::cerr << "More than one switch selected in " << ipRecv.getDevice() << "." << ipRecv.getName() << "\n";
+                ui.setPoint->addItem( QString( it->second.getName().c_str() ) );
             }
 
-            newName = it->second.getName();
-            m_setPoint = newName;
-            ui.setPoint->setCurrentText(m_setPoint.c_str());
-            //if(newName != m_value) m_valChanged = true;
-            //m_value = newName;
-         }
-      }
+            if( it->second.getSwitchState() == pcf::IndiElement::On )
+            {
+                if( newName != "" )
+                {
+                    std::cerr << "More than one switch selected in " << ipRecv.getDevice() << "." << ipRecv.getName()
+                              << "\n";
+                }
 
-      if(m_filterWheel) m_maxPos = n + 0.5;
-   }
+                newName    = it->second.getName();
+                m_setPoint = newName;
+                ui.setPoint->setCurrentText( m_setPoint.c_str() );
+                // if(newName != m_value) m_valChanged = true;
+                // m_value = newName;
+            }
+        }
 
-   emit doUpdateGUI();
+        if( m_filterWheel )
+            m_maxPos = n + 0.5;
+    }
+
+    emit doUpdateGUI();
 }
 
 void stage::updateGUI()
 {
-   if( m_appState != "READY" && m_appState != "OPERATING"
-             && m_appState != "CONFIGURING"  && m_appState != "NOTHOMED"
-                     && m_appState != "HOMING")
-   {
-      ui.stageName->setEnabled(false);
-      ui.fsmState->setEnabled(false);
-      ui.setPoint->setEnabled(false);
-      ui.setPointGo->setEnabled(false);
-      ui.positionSlider->setEnabled(false);
-      ui.position->setText("---");
-      ui.position->setEnabled(false);
-      ui.stepSize->setEnabled(false);
+    bool parkedPowerOff = ( m_appState == "POWEROFF" && m_parked );
 
-      ui.posMinus->setEnabled(false);
-      ui.posPlus->setEnabled(false);
-      ui.posStepMulTen->setEnabled(false);
-      ui.posStepDivTen->setEnabled(false);
+    if( m_appState != "READY" && m_appState != "OPERATING" && m_appState != "CONFIGURING" && m_appState != "NOTHOMED" &&
+        m_appState != "HOMING" && !parkedPowerOff )
+    {
+        ui.stageName->setEnabled( false );
+        ui.fsmState->setEnabled( false );
+        ui.setPoint->setEnabled( false );
+        ui.setPointGo->setEnabled( false );
+        ui.positionSlider->setEnabled( false );
+        ui.position->setText( "---" );
+        ui.position->setEnabled( false );
+        ui.stepSize->setEnabled( false );
 
-      ui.home->setEnabled(false);
-      ui.stop->setEnabled(false);
+        ui.posMinus->setEnabled( false );
+        ui.posPlus->setEnabled( false );
+        ui.posStepMulTen->setEnabled( false );
+        ui.posStepDivTen->setEnabled( false );
 
-      return;
-   }
+        ui.home->setEnabled( false );
+        ui.stop->setEnabled( false );
 
-   if( m_appState == "READY" || m_appState == "OPERATING" || m_appState == "HOMING" || m_appState == "CONFIGURING")
-   {
-      ui.stageName->setEnabled(true);
-      ui.fsmState->setEnabled(true);
-      ui.setPoint->setEnabled(true);
-      ui.stepSize->setEnabled(true);
-      ui.posStepMulTen->setEnabled(true);
-      ui.posStepDivTen->setEnabled(true);
-      ui.stop->setEnabled(true);
+        return;
+    }
 
-      if( m_appState == "READY" )
-      {
-         ui.setPointGo->setEnabled(true);
-         ui.positionSlider->setEnabled(true);
-         ui.position->setEnabled(true);
-         ui.posMinus->setEnabled(true);
-         ui.posPlus->setEnabled(true);
-         ui.home->setEnabled(true);
-      }
-      else
-      {
-         ui.setPointGo->setEnabled(false);
-         ui.positionSlider->setEnabled(false);
-         ui.position->setEnabled(false);
-         ui.posMinus->setEnabled(false);
-         ui.posPlus->setEnabled(false);
-         ui.home->setEnabled(false);
-      }
-   }
-   else if( m_appState == "NOTHOMED")
-   {
-      ui.stageName->setEnabled(true);
-      ui.fsmState->setEnabled(true);
-      ui.setPoint->setEnabled(false);
-      ui.stepSize->setEnabled(false);
-      ui.posStepMulTen->setEnabled(false);
-      ui.posStepDivTen->setEnabled(false);
-      ui.stop->setEnabled(false);
+    if( parkedPowerOff )
+    {
+        ui.stageName->setEnabled( true );
+        ui.fsmState->setEnabled( true );
+        ui.setPoint->setEnabled( false );
+        ui.setPointGo->setEnabled( false );
+        ui.positionSlider->setEnabled( false );
+        ui.position->setEnabled( true );
+        ui.stepSize->setEnabled( false );
 
-      ui.setPointGo->setEnabled(false);
-      ui.positionSlider->setEnabled(false);
-      ui.position->setEnabled(false);
-      ui.posMinus->setEnabled(false);
-      ui.posPlus->setEnabled(false);
-      ui.home->setEnabled(true);
-   }
+        ui.posMinus->setEnabled( false );
+        ui.posPlus->setEnabled( false );
+        ui.posStepMulTen->setEnabled( false );
+        ui.posStepDivTen->setEnabled( false );
 
-   if(m_position_changed)
-   {
-      ui.position->setTextChanged(QString::number(m_position));
-      m_position_changed = false;
-   }
-   else
-   {
-      ui.position->setText(QString::number(m_position));
-   }
+        ui.home->setEnabled( false );
+        ui.stop->setEnabled( false );
+    }
+    else if( m_appState == "READY" || m_appState == "OPERATING" || m_appState == "HOMING" ||
+             m_appState == "CONFIGURING" )
+    {
+        ui.stageName->setEnabled( true );
+        ui.fsmState->setEnabled( true );
+        ui.setPoint->setEnabled( true );
+        ui.stepSize->setEnabled( true );
+        ui.posStepMulTen->setEnabled( true );
+        ui.posStepDivTen->setEnabled( true );
+        ui.stop->setEnabled( true );
 
-   ui.positionSlider->setValue(m_position/m_maxPos * 100.);
-   //ui.position->updateGUI();
+        if( m_appState == "READY" )
+        {
+            ui.setPointGo->setEnabled( true );
+            ui.positionSlider->setEnabled( true );
+            ui.position->setEnabled( true );
+            ui.posMinus->setEnabled( true );
+            ui.posPlus->setEnabled( true );
+            ui.home->setEnabled( true );
+        }
+        else
+        {
+            ui.setPointGo->setEnabled( false );
+            ui.positionSlider->setEnabled( false );
+            ui.position->setEnabled( false );
+            ui.posMinus->setEnabled( false );
+            ui.posPlus->setEnabled( false );
+            ui.home->setEnabled( false );
+        }
+    }
+    else if( m_appState == "NOTHOMED" )
+    {
+        ui.stageName->setEnabled( true );
+        ui.fsmState->setEnabled( true );
+        ui.setPoint->setEnabled( false );
+        ui.stepSize->setEnabled( false );
+        ui.posStepMulTen->setEnabled( false );
+        ui.posStepDivTen->setEnabled( false );
+        ui.stop->setEnabled( false );
 
-} //updateGUI()
+        ui.setPointGo->setEnabled( false );
+        ui.positionSlider->setEnabled( false );
+        ui.position->setEnabled( false );
+        ui.posMinus->setEnabled( false );
+        ui.posPlus->setEnabled( false );
+        ui.home->setEnabled( true );
+    }
+
+    if( m_position_changed )
+    {
+        ui.position->setTextChanged( QString::number( m_position ) );
+        m_position_changed = false;
+    }
+    else
+    {
+        ui.position->setText( QString::number( m_position ) );
+    }
+
+    ui.positionSlider->setValue( m_position / m_maxPos * 100. );
+    // ui.position->updateGUI();
+
+} // updateGUI()
 
 void stage::clear_focus()
 {
 }
 
-void stage::on_setPoint_activated(int index)
+void stage::on_setPoint_activated( int index )
 {
-   static_cast<void>(index);
+    static_cast<void>( index );
 
-   m_setPointEditing = STARTED;
-   emit setPointEditTimerStart(10000);
-   update();
+    m_setPointEditing = STARTED;
+    emit setPointEditTimerStart( 10000 );
+    update();
 }
 
 void stage::on_setPointGo_pressed()
 {
-   std::string selection = ui.setPoint->currentText().toStdString();
+    std::string selection = ui.setPoint->currentText().toStdString();
 
-   if(selection == "")
-   {
-      return;
-   }
+    if( selection == "" )
+    {
+        return;
+    }
 
-   try
-   {
-      pcf::IndiProperty ipSend(pcf::IndiProperty::Switch);
-      ipSend.setDevice(m_stageName);
-      if(m_filterWheel)
-      {
-         ipSend.setName("filterName");
-      }
-      else
-      {
-         ipSend.setName("presetName");
-      }
-      ipSend.setPerm(pcf::IndiProperty::ReadWrite);
-      ipSend.setState(pcf::IndiProperty::Idle);
-      ipSend.setRule(pcf::IndiProperty::OneOfMany);
+    try
+    {
+        pcf::IndiProperty ipSend( pcf::IndiProperty::Switch );
+        ipSend.setDevice( m_stageName );
+        if( m_filterWheel )
+        {
+            ipSend.setName( "filterName" );
+        }
+        else
+        {
+            ipSend.setName( "presetName" );
+        }
+        ipSend.setPerm( pcf::IndiProperty::ReadWrite );
+        ipSend.setState( pcf::IndiProperty::Idle );
+        ipSend.setRule( pcf::IndiProperty::OneOfMany );
 
-      for(int idx = 0; idx < ui.setPoint->count(); ++idx)
-      {
-         std::string elName = ui.setPoint->itemText(idx).toStdString();
+        for( int idx = 0; idx < ui.setPoint->count(); ++idx )
+        {
+            std::string elName = ui.setPoint->itemText( idx ).toStdString();
 
-         if(elName == selection)
-         {
-            ipSend.add(pcf::IndiElement(elName, pcf::IndiElement::On));
-         }
-         else
-         {
-            ipSend.add(pcf::IndiElement(elName, pcf::IndiElement::Off));
-         }
-      }
+            if( elName == selection )
+            {
+                ipSend.add( pcf::IndiElement( elName, pcf::IndiElement::On ) );
+            }
+            else
+            {
+                ipSend.add( pcf::IndiElement( elName, pcf::IndiElement::Off ) );
+            }
+        }
 
-      sendNewProperty(ipSend);
-   }
-   catch(...)
-   {
-      std::cerr << "exception thrown in stage::on_setPointGo_pressed\n";
-   }
+        sendNewProperty( ipSend );
+    }
+    catch( ... )
+    {
+        std::cerr << "exception thrown in stage::on_setPointGo_pressed\n";
+    }
 
-   m_setPointEditing = STOPPED;
-   ui.setPoint->setCurrentText(m_setPoint.c_str());
-   update();
+    m_setPointEditing = STOPPED;
+    ui.setPoint->setCurrentText( m_setPoint.c_str() );
+    update();
 }
 
 void stage::on_positionSlider_sliderMoved( double s )
 {
-   double epos = s/100.0 * m_maxPos;
+    double epos = s / 100.0 * m_maxPos;
 
-   ui.position->setEditText(QString::number(epos));
+    ui.position->setEditText( QString::number( epos ) );
 }
 
 void stage::on_positionSlider_sliderReleased()
 {
-   ui.position->stopEditing();
+    ui.position->stopEditing();
 
-   double s = ui.positionSlider->value();
-   double newPos = s/100.0 * m_maxPos;
+    double s      = ui.positionSlider->value();
+    double newPos = s / 100.0 * m_maxPos;
 
-   ui.positionSlider->setValue(m_position/m_maxPos * 100.);
+    ui.positionSlider->setValue( m_position / m_maxPos * 100. );
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   ip.setDevice(m_stageName);
-   if(m_filterWheel)
-   {
-      ip.setName("filter");
-   }
-   else
-   {
-      ip.setName("position");
-   }
-   ip.add(pcf::IndiElement("target"));
-   ip["target"] = newPos;
+    ip.setDevice( m_stageName );
+    if( m_filterWheel )
+    {
+        ip.setName( "filter" );
+    }
+    else
+    {
+        ip.setName( "position" );
+    }
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = newPos;
 
-   sendNewProperty(ip);
-
+    sendNewProperty( ip );
 }
 
 void stage::on_position_returnPressed()
 {
-   double newPos = ui.position->editText().toDouble();
+    double newPos = ui.position->editText().toDouble();
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   ip.setDevice(m_stageName);
-   if(m_filterWheel)
-   {
-      ip.setName("filter");
-   }
-   else
-   {
-      ip.setName("position");
-   }
-   ip.add(pcf::IndiElement("target"));
-   ip["target"] = newPos;
+    ip.setDevice( m_stageName );
+    if( m_filterWheel )
+    {
+        ip.setName( "filter" );
+    }
+    else
+    {
+        ip.setName( "position" );
+    }
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = newPos;
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 
-   ui.position->clearFocus();
+    ui.position->clearFocus();
 }
 
 void stage::on_stepSize_editingFinished()
 {
-   m_step = ui.stepSize->text().toDouble();
-   ui.stepSize->setText(QString::number(m_step));
-
+    m_step = ui.stepSize->text().toDouble();
+    ui.stepSize->setText( QString::number( m_step ) );
 }
 
 void stage::on_posMinus_pressed()
 {
-   double newPos = m_position - m_step;
+    double newPos = m_position - m_step;
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   ip.setDevice(m_stageName);
-   if(m_filterWheel)
-   {
-      ip.setName("filter");
-   }
-   else
-   {
-      ip.setName("position");
-   }
-   ip.add(pcf::IndiElement("target"));
-   ip["target"] = newPos;
+    ip.setDevice( m_stageName );
+    if( m_filterWheel )
+    {
+        ip.setName( "filter" );
+    }
+    else
+    {
+        ip.setName( "position" );
+    }
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = newPos;
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void stage::on_posPlus_pressed()
 {
-   double newPos = m_position + m_step;
+    double newPos = m_position + m_step;
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   ip.setDevice(m_stageName);
-   if(m_filterWheel)
-   {
-      ip.setName("filter");
-   }
-   else
-   {
-      ip.setName("position");
-   }
-   ip.add(pcf::IndiElement("target"));
-   ip["target"] = newPos;
+    ip.setDevice( m_stageName );
+    if( m_filterWheel )
+    {
+        ip.setName( "filter" );
+    }
+    else
+    {
+        ip.setName( "position" );
+    }
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = newPos;
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void stage::on_posStepMulTen_pressed()
 {
-   m_step *= 10.0;
-   ui.stepSize->setText(QString::number(m_step));
+    m_step *= 10.0;
+    ui.stepSize->setText( QString::number( m_step ) );
 }
 
 void stage::on_posStepDivTen_pressed()
 {
-   m_step /= 10.0;
-   ui.stepSize->setText(QString::number(m_step));
+    m_step /= 10.0;
+    ui.stepSize->setText( QString::number( m_step ) );
 }
 
 void stage::on_home_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_stageName);
-   ipFreq.setName("home");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_stageName );
+    ipFreq.setName( "home" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void stage::on_stop_pressed()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_stageName);
-   ipFreq.setName("stop");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_stageName );
+    ipFreq.setName( "stop" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void stage::setPointEditTimerOut()
 {
-   m_setPointEditing = STOPPED;
-   ui.setPoint->setCurrentText(m_setPoint.c_str());
-   update();
+    m_setPointEditing = STOPPED;
+    ui.setPoint->setCurrentText( m_setPoint.c_str() );
+    update();
 }
 
-void stage::paintEvent(QPaintEvent * e)
+void stage::paintEvent( QPaintEvent *e )
 {
-   if(m_setPointEditing == STARTED)
-   {
-      ui.setPoint->setProperty("isStatus", false);
-      ui.setPoint->setProperty("isEditing", true);
-      style()->unpolish(ui.setPoint);
-   }
-   else
-   {
-      ui.setPoint->setProperty("isEditing", false);
-      ui.setPoint->setProperty("isStatus", true);
-      style()->unpolish(ui.setPoint);
-   }
+    if( m_setPointEditing == STARTED )
+    {
+        ui.setPoint->setProperty( "isStatus", false );
+        ui.setPoint->setProperty( "isEditing", true );
+        style()->unpolish( ui.setPoint );
+    }
+    else
+    {
+        ui.setPoint->setProperty( "isEditing", false );
+        ui.setPoint->setProperty( "isStatus", true );
+        style()->unpolish( ui.setPoint );
+    }
 
-   QWidget::paintEvent(e);
+    QWidget::paintEvent( e );
 }
 
-} //namespace xqt
+} // namespace xqt
 
 #include "moc_stage.cpp"
 

--- a/gui/widgets/xWidgets/statusCombo.hpp
+++ b/gui/widgets/xWidgets/statusCombo.hpp
@@ -1,3 +1,7 @@
+/** \file statusCombo.hpp
+ * \brief Shared status-combo widget for INDI stateful values.
+ */
+
 #ifndef statusCombo_hpp
 #define statusCombo_hpp
 
@@ -9,94 +13,136 @@
 namespace xqt
 {
 
+/// Combo-box status widget that can fall back to FSM text.
 class statusCombo : public xWidget
 {
     Q_OBJECT
 
-    enum editchanges{NOTEDITING, STARTED, STOPPED};
+    enum editchanges
+    {
+        NOTEDITING,
+        STARTED,
+        STOPPED
+    };
 
-protected:
+  protected:
+    /// Optional detailed control widget opened from this summary row.
     xWidget *m_ctrlWidget{ nullptr };
 
+    /// INDI device name providing this status.
     std::string m_device;
+    /// INDI property name used for the selectable value.
     std::string m_property;
+    /// Optional INDI element name for direct-value properties.
     std::string m_element;
 
+    /// Label shown to the left of the status field.
     std::string m_label;
+    /// Units suffix shown in the label when provided.
     std::string m_units;
 
+    /// Whether value changes should be visually highlighted.
     bool m_highlightChanges{ true };
 
+    /// Whether the displayed value needs repainting.
     bool m_valChanged{ false };
 
+    /// Latest FSM state received for the device.
     std::string m_fsmState;
+    /// Latest selected value text received for the device.
     std::string m_value;
+    /// Whether the device is explicitly reporting a parked state.
+    bool m_parked{ false };
+    /// Whether the value should be shown instead of the FSM state.
     bool m_showVal{ true };
 
-    int m_statusEditing {STOPPED};
-    QTimer * m_statusEditTimer {nullptr};
+    /// Tracks edit state for the combo box.
+    int m_statusEditing{ STOPPED };
+    /// Timer that clears staged combo-box edits after inactivity.
+    QTimer *m_statusEditTimer{ nullptr };
 
   public:
+    /// Construct an unconfigured status combo widget.
     statusCombo( QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
 
+    /// Construct and configure a status combo widget.
     statusCombo( const std::string &device,
                  const std::string &property,
                  const std::string &element,
                  const std::string &label,
                  const std::string &units,
-                 QWidget *Parent = 0,
-                 Qt::WindowFlags f = Qt::WindowFlags() );
+                 QWidget           *Parent = 0,
+                 Qt::WindowFlags    f      = Qt::WindowFlags() );
 
+    /// Destroy the widget.
     ~statusCombo();
 
+    /// Configure the device, property, and label metadata for the widget.
     void setup( const std::string &device,
                 const std::string &property,
                 const std::string &element,
                 const std::string &label,
                 const std::string &units );
 
+    /// Replace the optional detailed control widget.
     void ctrlWidget( xWidget *cw );
 
+    /// Return the optional detailed control widget.
     xWidget *ctrlWidget();
 
+    /// Format the current value text for display.
     virtual QString formatValue();
 
+    /// Subscribe to the required INDI properties.
     virtual void subscribe();
 
+    /// Reset the widget for an active INDI connection.
     virtual void onConnect();
 
+    /// Reset the widget for a disconnected INDI connection.
     virtual void onDisconnect();
 
+    /// Handle a newly defined property using the same path as updates.
     virtual void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
+    /// Handle deletion of an INDI property used by this widget.
     virtual void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
 
+    /// Handle updates to the device FSM, parked state, or value property.
     virtual void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
   public:
-
+    /// Hide the control widget when this summary row becomes disabled.
     virtual void changeEvent( QEvent *e );
 
   public slots:
 
+    /// Refresh the displayed text from cached state.
     virtual void updateGUI();
 
+    /// Mark the combo box as actively edited.
     void on_status_activated( int index );
 
+    /// Send the selected value back to INDI.
     void on_buttonGo_pressed();
 
+    /// Show the detailed control widget, if present.
     void on_buttonCtrl_pressed();
 
+    /// End temporary edit mode after the timer expires.
     void statusEditTimerOut();
 
   signals:
 
-    void statusEditTimerStart(int);
+    void statusEditTimerStart( int );
 
     void doUpdateGUI();
 
-protected:
-    virtual void paintEvent(QPaintEvent * e);
+  protected:
+    /// Decide whether the widget should show the value instead of FSM text.
+    bool shouldShowValue() const;
+
+    virtual void paintEvent( QPaintEvent *e );
 
     Ui::statusCombo ui;
 };
@@ -110,8 +156,9 @@ statusCombo::statusCombo( const std::string &device,
                           const std::string &element,
                           const std::string &label,
                           const std::string &units,
-                          QWidget *Parent,
-                          Qt::WindowFlags f ) : xWidget( Parent, f )
+                          QWidget           *Parent,
+                          Qt::WindowFlags    f )
+    : xWidget( Parent, f )
 {
     setup( device, property, element, label, units );
 }
@@ -127,15 +174,15 @@ void statusCombo::setup( const std::string &device,
                          const std::string &units )
 
 {
-    m_device = device;
+    m_device   = device;
     m_property = property;
-    m_element = element;
-    m_label = label;
-    m_units = units;
+    m_element  = element;
+    m_label    = label;
+    m_units    = units;
 
     ui.setupUi( this );
-    ui.status->setEditable(false);
-    ui.status->setProperty("isStatus", true);
+    ui.status->setEditable( false );
+    ui.status->setProperty( "isStatus", true );
 
     std::string lab = m_label;
     if( m_units != "" )
@@ -155,11 +202,11 @@ void statusCombo::setup( const std::string &device,
 
     connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ) );
 
-    m_statusEditTimer = new QTimer(this);
+    m_statusEditTimer = new QTimer( this );
 
-    connect(m_statusEditTimer, SIGNAL(timeout()), this, SLOT(statusEditTimerOut()));
+    connect( m_statusEditTimer, SIGNAL( timeout() ), this, SLOT( statusEditTimerOut() ) );
 
-    connect(this, SIGNAL(statusEditTimerStart(int)), m_statusEditTimer, SLOT(start(int)));
+    connect( this, SIGNAL( statusEditTimerStart( int ) ), m_statusEditTimer, SLOT( start( int ) ) );
 
     onDisconnect();
 }
@@ -172,14 +219,14 @@ void statusCombo::ctrlWidget( xWidget *cw )
         m_ctrlWidget = nullptr;
     }
 
-    if(cw == nullptr)
+    if( cw == nullptr )
     {
-        ui.buttonCtrl->setVisible(false);
+        ui.buttonCtrl->setVisible( false );
     }
     else
     {
         m_ctrlWidget = cw;
-        ui.buttonCtrl->setVisible(true);
+        ui.buttonCtrl->setVisible( true );
     }
 }
 
@@ -193,6 +240,11 @@ QString statusCombo::formatValue()
     return QString( m_value.c_str() );
 }
 
+bool statusCombo::shouldShowValue() const
+{
+    return ( m_fsmState == "READY" || m_fsmState == "OPERATING" || ( m_fsmState == "POWEROFF" && m_parked ) );
+}
+
 void statusCombo::subscribe()
 {
     if( !m_parent )
@@ -201,6 +253,7 @@ void statusCombo::subscribe()
     }
 
     m_parent->addSubscriberProperty( this, m_device, "fsm" );
+    m_parent->addSubscriberProperty( this, m_device, "parked" );
 
     if( m_property != "" )
     {
@@ -229,7 +282,8 @@ void statusCombo::onDisconnect()
 {
     m_fsmState.clear();
     m_value.clear();
-    m_showVal = false;
+    m_parked     = false;
+    m_showVal    = false;
     m_valChanged = false;
 
     ui.status->clear();
@@ -252,6 +306,25 @@ void statusCombo::handleDelProperty( const pcf::IndiProperty &ipRecv )
     if( ipRecv.getDevice() != m_device )
         return;
 
+    if( ipRecv.getName() == "parked" )
+    {
+        if( m_parked )
+        {
+            m_parked = false;
+
+            bool showVal = shouldShowValue();
+            if( showVal != m_showVal )
+            {
+                m_showVal    = showVal;
+                m_valChanged = true;
+            }
+
+            emit doUpdateGUI();
+        }
+
+        return;
+    }
+
     if( ipRecv.getName() == "fsm" || ipRecv.getName() == m_property )
     {
         onDisconnect();
@@ -268,42 +341,48 @@ void statusCombo::handleSetProperty( const pcf::IndiProperty &ipRecv )
         if( ipRecv.find( "state" ) )
         {
             std::string fsmState = ipRecv["state"].get();
+            bool        showVal  = false;
 
-            if( fsmState == "READY" || fsmState == "OPERATING" )
+            if( fsmState != m_fsmState )
             {
-                if( fsmState != m_fsmState )
-                {
-                    m_valChanged = true;
-                }
-
-                if( !m_showVal )
-                {
-                    m_valChanged = true;
-                }
-
-                m_showVal = true;
-            }
-            else
-            {
-                m_showVal = false;
-
-                if( fsmState != m_fsmState )
-                {
-                    m_valChanged = true;
-                }
-
-                if( m_showVal )
-                {
-                    m_valChanged = true;
-                }
+                m_valChanged = true;
             }
 
             m_fsmState = fsmState;
+            showVal    = shouldShowValue();
+
+            if( showVal != m_showVal )
+            {
+                m_valChanged = true;
+                m_showVal    = showVal;
+            }
+        }
+    }
+    else if( ipRecv.getName() == "parked" )
+    {
+        if( ipRecv.find( "current" ) )
+        {
+            bool parked  = ( ipRecv["current"].get<int>() != 0 );
+            bool showVal = false;
+
+            if( parked != m_parked )
+            {
+                m_valChanged = true;
+            }
+
+            m_parked = parked;
+            showVal  = shouldShowValue();
+
+            if( showVal != m_showVal )
+            {
+                m_valChanged = true;
+                m_showVal    = showVal;
+            }
         }
     }
     else if( ipRecv.getName() == m_property )
     {
-        if(ipRecv.getType() != pcf::IndiProperty::Switch)
+        if( ipRecv.getType() != pcf::IndiProperty::Switch )
         {
             std::cerr << "statusCombo: property is not a switch\n";
             return;
@@ -313,25 +392,25 @@ void statusCombo::handleSetProperty( const pcf::IndiProperty &ipRecv )
 
         std::string value;
 
-        if(elmap.size() > 0 )
+        if( elmap.size() > 0 )
         {
-            //Go through all elements in the property, which should be a switch vector
-            for(auto it = elmap.begin(); it != elmap.end(); ++it)
+            // Go through all elements in the property, which should be a switch vector
+            for( auto it = elmap.begin(); it != elmap.end(); ++it )
             {
-                QString name(it->second.getName().c_str());
-                //Check if it's in the list
-                if(ui.status->findText(name) == -1)
+                QString name( it->second.getName().c_str() );
+                // Check if it's in the list
+                if( ui.status->findText( name ) == -1 )
                 {
-                    if(name != "" && name != "none")
+                    if( name != "" && name != "none" )
                     {
-                        ui.status->addItem(name);
+                        ui.status->addItem( name );
                     }
                 }
 
-                //See if it's on
-                if(it->second.getSwitchState() == pcf::IndiElement::On)
+                // See if it's on
+                if( it->second.getSwitchState() == pcf::IndiElement::On )
                 {
-                    if(value != "")
+                    if( value != "" )
                     {
                         std::cerr << "statusCombo: more than one item selected\n";
                     }
@@ -373,8 +452,8 @@ void statusCombo::updateGUI()
             if( m_valChanged )
             {
                 QString value = formatValue();
-                ui.status->setPlaceholderText(value);
-                ui.status->setCurrentIndex(-1);
+                ui.status->setPlaceholderText( value );
+                ui.status->setCurrentIndex( -1 );
                 m_valChanged = false;
             }
         }
@@ -382,8 +461,8 @@ void statusCombo::updateGUI()
         {
             if( m_valChanged )
             {
-                ui.status->setPlaceholderText(m_fsmState.c_str());
-                ui.status->setCurrentIndex(-1);
+                ui.status->setPlaceholderText( m_fsmState.c_str() );
+                ui.status->setCurrentIndex( -1 );
                 m_valChanged = false;
             }
         }
@@ -393,10 +472,10 @@ void statusCombo::updateGUI()
 
 void statusCombo::on_status_activated( int index )
 {
-    static_cast<void>(index);
+    static_cast<void>( index );
 
     m_statusEditing = STARTED;
-    emit statusEditTimerStart(10000);
+    emit statusEditTimerStart( 10000 );
     update();
 }
 
@@ -404,43 +483,43 @@ void statusCombo::on_buttonGo_pressed()
 {
     std::string selection = ui.status->currentText().toStdString();
 
-    if(selection == "")
+    if( selection == "" )
     {
         return;
     }
 
     try
     {
-        pcf::IndiProperty ipSend(pcf::IndiProperty::Switch);
-        ipSend.setDevice(m_device);
-        ipSend.setName(m_property);
-        ipSend.setPerm(pcf::IndiProperty::ReadWrite);
-        ipSend.setState(pcf::IndiProperty::Idle);
-        ipSend.setRule(pcf::IndiProperty::OneOfMany);
+        pcf::IndiProperty ipSend( pcf::IndiProperty::Switch );
+        ipSend.setDevice( m_device );
+        ipSend.setName( m_property );
+        ipSend.setPerm( pcf::IndiProperty::ReadWrite );
+        ipSend.setState( pcf::IndiProperty::Idle );
+        ipSend.setRule( pcf::IndiProperty::OneOfMany );
 
-        for(int idx = 0; idx < ui.status->count(); ++idx)
+        for( int idx = 0; idx < ui.status->count(); ++idx )
         {
-            std::string elName = ui.status->itemText(idx).toStdString();
+            std::string elName = ui.status->itemText( idx ).toStdString();
 
-            if(elName == selection)
+            if( elName == selection )
             {
-                ipSend.add(pcf::IndiElement(elName, pcf::IndiElement::On));
+                ipSend.add( pcf::IndiElement( elName, pcf::IndiElement::On ) );
             }
             else
             {
-                ipSend.add(pcf::IndiElement(elName, pcf::IndiElement::Off));
+                ipSend.add( pcf::IndiElement( elName, pcf::IndiElement::Off ) );
             }
         }
 
-        sendNewProperty(ipSend);
+        sendNewProperty( ipSend );
     }
-    catch(...)
+    catch( ... )
     {
         std::cerr << "INDI exception thrown in statusCombo::on_buttonGo_pressed\n";
     }
 
     m_statusEditing = STOPPED;
-    ui.status->setCurrentText(formatValue());
+    ui.status->setCurrentText( formatValue() );
     ui.status->clearFocus();
     ui.buttonGo->clearFocus();
     update();
@@ -457,28 +536,28 @@ void statusCombo::on_buttonCtrl_pressed()
 
 void statusCombo::statusEditTimerOut()
 {
-   m_statusEditing = STOPPED;
-   ui.status->setCurrentText(formatValue());
-   ui.status->clearFocus();
-   update();
+    m_statusEditing = STOPPED;
+    ui.status->setCurrentText( formatValue() );
+    ui.status->clearFocus();
+    update();
 }
 
-void statusCombo::paintEvent(QPaintEvent * e)
+void statusCombo::paintEvent( QPaintEvent *e )
 {
-   if(m_statusEditing == STARTED)
-   {
-      ui.status->setProperty("isStatus", false);
-      ui.status->setProperty("isEditing", true);
-      style()->unpolish(ui.status);
-   }
-   else
-   {
-      ui.status->setProperty("isEditing", false);
-      ui.status->setProperty("isStatus", true);
-      style()->unpolish(ui.status);
-   }
+    if( m_statusEditing == STARTED )
+    {
+        ui.status->setProperty( "isStatus", false );
+        ui.status->setProperty( "isEditing", true );
+        style()->unpolish( ui.status );
+    }
+    else
+    {
+        ui.status->setProperty( "isEditing", false );
+        ui.status->setProperty( "isStatus", true );
+        style()->unpolish( ui.status );
+    }
 
-   QWidget::paintEvent(e);
+    QWidget::paintEvent( e );
 }
 
 } // namespace xqt


### PR DESCRIPTION
This work was performed by Codex GPT-5 

## Summary

Adds explicit parked-state support for Zaber stage GUIs.

`zaberCtrl` now republishes a read-only `parked` status from the low-level Zaber app, and the GUI layers use that signal to keep showing stage/filter position or preset information when a stage is `POWEROFF` but still parked. GUI code also handles devices that do not publish `parked` by treating the property as optional and falling back to existing behavior.

## Changes

- add read-only `parked.current` publication in `apps/zaberCtrl/zaberCtrl.hpp`
- add `zaberCtrl` test coverage for the relayed parked callback
- update the shared `statusCombo` widget to subscribe to optional `parked` and continue showing values for `POWEROFF && parked`
- update the standalone stage widget to keep position/preset visible while leaving controls disabled for parked powered-off stages
- update the `rtimv` `cameraStatus` plugin to treat `POWEROFF && parked` like a displayable state and fall back to numeric position when no preset is active
- append the implementation plan to `agents/plans/stage-parking-gui-updates.md`

## Verification

- built `gui/apps/stageGUI`
- built `gui/apps/cameraGUI`
- built `gui/rtimv/plugins/cameraStatus`
- built `apps/zaberCtrl/tests/zaberCtrl_test`
- ran `apps/zaberCtrl/tests/zaberCtrl_test`
- test result: all tests passed
