### PR TITLE
Fix dmCtrlGUI list refresh handling

### DIFF
--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -6,6 +6,8 @@
 #ifndef dmCtrl_hpp
 #define dmCtrl_hpp
 
+#include <QSignalBlocker>
+
 #include <mutex>
 #include <vector>
 
@@ -291,8 +293,6 @@ void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
 
 void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-    std::lock_guard<std::mutex> lock( m_stateMutex );
-
     if( ipRecv.getDevice() != m_dmName )
     {
         return;
@@ -301,6 +301,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "state" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             m_appState = ipRecv["state"].get<std::string>();
         }
 
@@ -310,11 +311,13 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "name" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             m_shmimName = ipRecv["name"].get<std::string>();
         }
     }
     else if( ipRecv.getName() == "flat" )
     {
+        std::lock_guard<std::mutex> lock( m_stateMutex );
         m_flatOptions.clear();
         m_flatName = "";
         for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
@@ -328,6 +331,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "channel" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             m_flatShmim = ipRecv["channel"].get<std::string>();
         }
     }
@@ -335,6 +339,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "toggle" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             if( ipRecv["toggle"] == pcf::IndiElement::On )
                 m_flatSet = true;
             else
@@ -343,6 +348,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
     else if( ipRecv.getName() == "test" )
     {
+        std::lock_guard<std::mutex> lock( m_stateMutex );
         m_testOptions.clear();
         m_testName = "";
         for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
@@ -356,6 +362,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "channel" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             m_testShmim = ipRecv["channel"].get<std::string>();
         }
     }
@@ -363,6 +370,7 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     {
         if( ipRecv.find( "toggle" ) )
         {
+            std::lock_guard<std::mutex> lock( m_stateMutex );
             if( ipRecv["toggle"] == pcf::IndiElement::On )
                 m_testSet = true;
             else
@@ -409,17 +417,35 @@ void dmCtrl::updateGUI()
     ui.labelFlatShmim_value->setText( flatShmim.c_str() );
     ui.labelTestShmim_value->setText( testShmim.c_str() );
 
-    ui.comboSelectFlat->clear();
-    for( const auto &opt : flatOptions )
-        ui.comboSelectFlat->addItem( opt.c_str() );
-    if( !flatName.empty() )
-        ui.comboSelectFlat->setCurrentText( flatName.c_str() );
+    { // mutex scope
+        QSignalBlocker blockFlat( ui.comboSelectFlat );
 
-    ui.comboSelectTest->clear();
-    for( const auto &opt : testOptions )
-        ui.comboSelectTest->addItem( opt.c_str() );
-    if( !testName.empty() )
-        ui.comboSelectTest->setCurrentText( testName.c_str() );
+        ui.comboSelectFlat->clear();
+        for( const auto &opt : flatOptions )
+            ui.comboSelectFlat->addItem( opt.c_str() );
+
+        if( !flatName.empty() )
+        {
+            int flatIndex = ui.comboSelectFlat->findText( flatName.c_str() );
+            if( flatIndex >= 0 )
+                ui.comboSelectFlat->setCurrentIndex( flatIndex );
+        }
+    }
+
+    { // mutex scope
+        QSignalBlocker blockTest( ui.comboSelectTest );
+
+        ui.comboSelectTest->clear();
+        for( const auto &opt : testOptions )
+            ui.comboSelectTest->addItem( opt.c_str() );
+
+        if( !testName.empty() )
+        {
+            int testIndex = ui.comboSelectTest->findText( testName.c_str() );
+            if( testIndex >= 0 )
+                ui.comboSelectTest->setCurrentIndex( testIndex );
+        }
+    }
 
     if( appState != "NOTHOMED" && appState != "READY" && appState != "OPERATING" )
     {
@@ -538,6 +564,9 @@ void dmCtrl::on_buttonRelease_pressed()
 
 void dmCtrl::on_comboSelectFlat_activated( int index )
 {
+    if( index < 0 || index >= ui.comboSelectFlat->count() )
+        return;
+
     std::string       choice = ui.comboSelectFlat->itemText( index ).toStdString();
     pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
     ipFreq.setDevice( m_dmName );
@@ -582,6 +611,9 @@ void dmCtrl::on_buttonZeroFlat_pressed()
 
 void dmCtrl::on_comboSelectTest_activated( int index )
 {
+    if( index < 0 || index >= ui.comboSelectTest->count() )
+        return;
+
     std::string       choice = ui.comboSelectTest->itemText( index ).toStdString();
     pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
     ipFreq.setDevice( m_dmName );


### PR DESCRIPTION
This work was performed by Codex (GPT-5-based) in response to the prompt: "dmCtrlGUI is crashing when the list flats or tests is updated. please investigate"

## Summary

This PR hardens `dmCtrlGUI` against crashes while the DM `flat` and `test` option lists are refreshed from INDI.

## Changes

- Block `QComboBox` signals while rebuilding the `flat` and `test` selection lists in `dmCtrl`.
- Preserve the selected item by restoring it with `findText` / `setCurrentIndex` only when the option still exists.
- Guard the `flat` and `test` activation handlers against invalid combo-box indices.
- Reduce `m_stateMutex` scope in `handleSetProperty` so cached state updates remain protected without holding the lock across child-widget FSM handling.

## Verification

- Ran `clang-format -i gui/widgets/dmCtrl/dmCtrl.hpp`
- Built successfully with:
  - `make -C gui/apps/dmCtrlGUI`

## Files Changed

- `gui/widgets/dmCtrl/dmCtrl.hpp`

## Notes

This change is intentionally minimal and scoped to the `dmCtrl` widget refresh path. Live reproduction against a running DM/INDI source was not available here, so verification was limited to code inspection and successful rebuild.
