### PR TITLE
Fix dmCtrlGUI reconnect on list refresh

### DIFF
--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -283,11 +283,49 @@ void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
         return;
     }
 
-    if( ipRecv.getName() == "fsm" || ipRecv.getName() == "sm_shmimName" || ipRecv.getName() == "flat" ||
-        ipRecv.getName() == "flat_shmim" || ipRecv.getName() == "flat_set" || ipRecv.getName() == "test" ||
-        ipRecv.getName() == "test_shmim" || ipRecv.getName() == "test_set" )
+    if( ipRecv.getName() == "fsm" )
     {
         emit doOnDisconnect();
+        return;
+    }
+
+    if( ipRecv.getName() == "sm_shmimName" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_shmimName.clear();
+        }
+
+        emit doUpdateGUI();
+        return;
+    }
+
+    if( ipRecv.getName() == "flat" || ipRecv.getName() == "flat_shmim" || ipRecv.getName() == "flat_set" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_flatShmim.clear();
+            m_flatSet = false;
+            m_flatName.clear();
+            m_flatOptions.clear();
+        }
+
+        emit doUpdateGUI();
+        return;
+    }
+
+    if( ipRecv.getName() == "test" || ipRecv.getName() == "test_shmim" || ipRecv.getName() == "test_set" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_testShmim.clear();
+            m_testSet = false;
+            m_testName.clear();
+            m_testOptions.clear();
+        }
+
+        emit doUpdateGUI();
+        return;
     }
 }
 


### PR DESCRIPTION
This work was performed by Codex (GPT-5-based) in response to the prompt: "the gui now doesn't segfault, but it goes to a disconnected state and does not reconnect when the flat list changes"

## Summary

This PR fixes `dmCtrlGUI` dropping into a disconnected state when the DM `flat` or `test` properties are temporarily deleted and redefined during list refresh.

## Changes

- Narrow `dmCtrl::handleDelProperty()` so only loss of `fsm` is treated as a full device disconnect.
- When `sm_shmimName` is deleted, clear only the cached shmim name and refresh the GUI.
- When `flat`, `flat_shmim`, or `flat_set` is deleted, clear only the flat-related cached state and refresh the GUI.
- When `test`, `test_shmim`, or `test_set` is deleted, clear only the test-related cached state and refresh the GUI.

## Verification

- Ran `clang-format -i gui/widgets/dmCtrl/dmCtrl.hpp`
- Built successfully with:
  - `make -C gui/apps/dmCtrlGUI`

## Files Changed

- `gui/widgets/dmCtrl/dmCtrl.hpp`

## Notes

The earlier list-refresh crash fix is already in `dev` via `jrmales/dmctrlgui-list-update-fix`. This PR is the follow-up reconnect fix after live testing showed the widget was treating list redefinition as a full disconnect.
