### PR TITLE
Jrmales/stdmotionstage preset aliases

### DIFF
--- a/agents/plans/stdMotionStage-preset-aliases.md
+++ b/agents/plans/stdMotionStage-preset-aliases.md
@@ -1,0 +1,44 @@
+Problem: in the stdMotionStage base class if two or more presets have the same position but different names, and the user selects one of them by name, the earliest one in the list will be selected as the preset name instead of the one selected.  We need to implement tracking the intended preset name as well as the position and handle the case where multiple presets have the same position such that the user sees their intended preset name.  Review AGENTS.md then fill in this document with a plan to implement this capability.
+
+Plan:
+1. Inspect and document the current failure path in `libMagAOX/app/dev/stdMotionStage.hpp`.
+   The alias bug comes from `newCallBack_m_indiP_presetName()` translating the requested switch selection into only `m_preset_target`, while `updateINDI()` and `recordStage()` later reconstruct the displayed preset name from `derived().presetNumber()`.
+   Because that reconstruction uses only the current numeric preset index, any duplicate-position presets collapse to the first matching entry and the originally requested alias is lost.
+
+2. Add explicit preset-name tracking state to `stdMotionStage`.
+   Introduce protected member data for the selected or intended preset-name index, separate from the floating-point preset position.
+   Keep this state documented in the same style as the rest of the class and place it with the other stage status members.
+   Initialize and clear it in the same places where `m_preset` and `m_preset_target` are initialized or reset, including the power-off path.
+
+3. Capture alias intent when commands arrive.
+   Update `newCallBack_m_indiP_presetName()` so that, in addition to setting `m_preset_target`, it records the exact preset-name entry the user selected before issuing `moveTo()`.
+   Update `newCallBack_m_indiP_preset()` so direct numeric moves clear the explicit-name selection, since those moves do not identify a unique alias.
+   Preserve current behavior for homing and stop requests unless the motion-state transitions require clearing stale alias intent.
+
+4. Define when tracked alias intent remains valid.
+   In `updateINDI()`, prefer the tracked preset-name selection when all of the following are true:
+   the tracked index is in range, the stage is at the tracked preset position, and the current move was a preset-name-driven request or has otherwise converged to that same alias target.
+   Fall back to the current numeric `presetNumber()` lookup when there is no valid tracked alias, when the stage has been moved by raw position, or when the current position no longer matches the tracked alias location.
+   This keeps alias display sticky only when it is justified by actual stage state.
+
+5. Update INDI and telemetry emission to use the tracked name consistently.
+   Refactor the name-resolution logic used by `updateINDI()` and `recordStage()` into one shared helper or one consistent code path so the INDI `presetName` property and `telem_stage` logging report the same alias.
+   Ensure duplicate-position presets set only the intended switch element to `On`, rather than the first matching name.
+   Keep the existing busy/idle handling for `m_indiP_preset` and `m_indiP_presetName`.
+
+6. Audit derived-stage interactions for compatibility.
+   Confirm that the current `filterWheelCtrl`, `hsfwCtrl`, and `zaberCtrl` code only needs the base-class behavior change and does not need per-app alias logic.
+   Pay special attention to paths that overwrite `m_preset_target` after homing or while syncing telemetry, because those transitions may need to clear or preserve the tracked alias intentionally.
+
+7. Expand regression coverage around duplicate preset positions.
+   Add or extend unit tests, most likely in `apps/zaberCtrl/tests/zaberCtrl_test.cpp`, to cover:
+   selecting one of multiple preset names that share a position,
+   verifying `presetName` reports the selected alias after motion completes,
+   verifying a direct numeric move to the same position does not falsely claim a specific alias,
+   verifying power-off or other reset paths clear stale alias state.
+   If `stdMotionStage` behavior is easiest to exercise through the existing zaber test fixture, keep the new tests there rather than introducing a separate harness.
+
+8. Finish with style and verification steps required by this repo.
+   Run `clang-format` on any touched C++ files.
+   Re-read touched files for Doxygen/member documentation consistency per `AGENTS.md`.
+   Run the relevant stage test target if available, or otherwise document what was verified and what remains untested.

--- a/apps/filterWheelCtrl/filterWheelCtrl.hpp
+++ b/apps/filterWheelCtrl/filterWheelCtrl.hpp
@@ -1,29 +1,27 @@
 /** \file filterWheelCtrl.hpp
-  * \brief The MagAO-X Filter Wheel Controller
-  *
-  * \ingroup filterWheelCtrl_files
-  */
-
+ * \brief The MagAO-X Filter Wheel Controller
+ *
+ * \ingroup filterWheelCtrl_files
+ */
 
 #ifndef filterWheelCtrl_hpp
 #define filterWheelCtrl_hpp
-
 
 #include "../../libMagAOX/libMagAOX.hpp" //Note this is included on command line to trigger pch
 #include "../../magaox_git_version.h"
 
 /** \defgroup filterWheelCtrl Filter Wheel Control
-  * \brief Control of MagAO-X MCBL-based f/w.
-  *
-  * <a href="../handbook/operating/software/apps/filterWheelCtrl.html">Application Documentation</a>
-  *
-  * \ingroup apps
-  *
-  */
+ * \brief Control of MagAO-X MCBL-based f/w.
+ *
+ * <a href="../handbook/operating/software/apps/filterWheelCtrl.html">Application Documentation</a>
+ *
+ * \ingroup apps
+ *
+ */
 
 /** \defgroup filterWheelCtrl_files Filter Wheel Control Files
-  * \ingroup filterWheelCtrl
-  */
+ * \ingroup filterWheelCtrl
+ */
 
 namespace MagAOX
 {
@@ -31,971 +29,1050 @@ namespace app
 {
 
 /** MagAO-X application to control a Faulhaber MCBL controlled filter wheel.
-  *
-  * \todo add temperature monitoring
-  * \todo add INDI props to md doc
-  * \todo should move in least time direction, rather than always in the same direction.
-  * \todo add tests
-  * \todo should be an iodevice
-  *
-  * \ingroup filterWheelCtrl
-  */
-class filterWheelCtrl : public MagAOXApp<>, public tty::usbDevice, public dev::stdMotionStage<filterWheelCtrl>, public dev::telemeter<filterWheelCtrl>
+ *
+ * \todo add temperature monitoring
+ * \todo add INDI props to md doc
+ * \todo should move in least time direction, rather than always in the same direction.
+ * \todo add tests
+ * \todo should be an iodevice
+ *
+ * \ingroup filterWheelCtrl
+ */
+class filterWheelCtrl : public MagAOXApp<>,
+                        public tty::usbDevice,
+                        public dev::stdMotionStage<filterWheelCtrl>,
+                        public dev::telemeter<filterWheelCtrl>
 {
 
-   friend class dev::stdMotionStage<filterWheelCtrl>;
+    friend class dev::stdMotionStage<filterWheelCtrl>;
 
-   friend class dev::telemeter<filterWheelCtrl>;
+    friend class dev::telemeter<filterWheelCtrl>;
 
-protected:
-
-   /** \name Non-configurable parameters
+  protected:
+    /** \name Non-configurable parameters
      *@{
      */
 
-   int m_motorType {2};
+    int m_motorType{ 2 };
 
-   ///@}
+    ///@}
 
-   /** \name Configurable Parameters
+    /** \name Configurable Parameters
      * @{
      */
 
-   int m_writeTimeOut {1000};  ///< The timeout for writing to the device [msec].
-   int m_readTimeOut {1000}; ///< The timeout for reading from the device [msec].
+    int m_writeTimeOut{ 1000 }; ///< The timeout for writing to the device [msec].
+    int m_readTimeOut{ 1000 };  ///< The timeout for reading from the device [msec].
 
-   double m_acceleration {100};
-   double m_deceleration {50};
-   double m_motorSpeed {3000};
+    double m_acceleration{ 100 };
+    double m_deceleration{ 50 };
+    double m_motorSpeed{ 3000 };
 
-   long m_circleSteps {0}; ///< The number of position counts in 1 360-degree revolution.
-   long m_homeOffset {0}; ///< The number of position counts to offset from the home position
+    long m_circleSteps{ 0 }; ///< The number of position counts in 1 360-degree revolution.
+    long m_homeOffset{ 0 };  ///< The number of position counts to offset from the home position
 
+    ///@}
 
-
-   ///@}
-
-   /** \name Status
+    /** \name Status
      * @{
      */
 
-   bool m_switch{false}; ///< The home switch status
+    bool m_switch{ false }; ///< The home switch status
 
-   long m_rawPos {0}; ///< The position of the wheel in motor counts.
+    long m_rawPos{ 0 }; ///< The position of the wheel in motor counts.
 
-   int m_homingState{0}; ///< The homing state, tracks the stages of homing.
-   ///@}
+    int m_homingState{ 0 }; ///< The homing state, tracks the stages of homing.
+                            ///@}
 
+  public:
+    /// Default c'tor.
+    filterWheelCtrl();
 
-public:
+    /// D'tor, declared and defined for noexcept.
+    ~filterWheelCtrl() noexcept
+    {
+    }
 
-   /// Default c'tor.
-   filterWheelCtrl();
+    /// Setup the configuration system (called by MagAOXApp::setup())
+    virtual void setupConfig();
 
-   /// D'tor, declared and defined for noexcept.
-   ~filterWheelCtrl() noexcept
-   {}
+    /// load the configuration system results (called by MagAOXApp::setup())
+    virtual void loadConfig();
 
-   /// Setup the configuration system (called by MagAOXApp::setup())
-   virtual void setupConfig();
-
-   /// load the configuration system results (called by MagAOXApp::setup())
-   virtual void loadConfig();
-
-   /// Startup functions
-   /** Setsup the INDI vars.
+    /// Startup functions
+    /** Setsup the INDI vars.
      *
      * \returns 0 on success
      * \returns -1 on error.
      */
-   virtual int appStartup();
+    virtual int appStartup();
 
-   /// Implementation of the FSM for the TTM Modulator
-   /**
+    /// Implementation of the FSM for the TTM Modulator
+    /**
      * \returns 0 on success
      * \returns -1 on error.
      */
-   virtual int appLogic();
+    virtual int appLogic();
 
-   /// Do any needed shutdown tasks.  Currently nothing in this app.
-   /**
+    /// Do any needed shutdown tasks.  Currently nothing in this app.
+    /**
      * \returns 0 on success
      * \returns -1 on error.
      */
-   virtual int appShutdown();
+    virtual int appShutdown();
 
-
-   /// This method is called when the change to poweroff is detected.
-   /**
+    /// This method is called when the change to poweroff is detected.
+    /**
      * \returns 0 on success.
      * \returns -1 on any error which means the app should exit.
      */
-   virtual int onPowerOff();
+    virtual int onPowerOff();
 
-   /// This method is called while the power is off, once per FSM loop.
-   /**
+    /// This method is called while the power is off, once per FSM loop.
+    /**
      * \returns 0 on success.
      * \returns -1 on any error which means the app should exit.
      */
-   virtual int whilePowerOff();
+    virtual int whilePowerOff();
 
-protected:
+  protected:
+    // declare our properties
 
-   //declare our properties
+    /// The position of the wheel in counts
+    pcf::IndiProperty m_indiP_counts;
 
-   ///The position of the wheel in counts
-   pcf::IndiProperty m_indiP_counts;
+  public:
+    INDI_NEWCALLBACK_DECL( filterWheelCtrl, m_indiP_counts );
 
-public:
-   INDI_NEWCALLBACK_DECL(filterWheelCtrl, m_indiP_counts);
+  protected:
+    // Each of these should have m_indiMutex locked before being called.
 
-protected:
-   //Each of these should have m_indiMutex locked before being called.
-
-   /// Set up the MCBL controller, called after each power-on/connection
-   /**
+    /// Set up the MCBL controller, called after each power-on/connection
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int onPowerOnConnect();
+    int onPowerOnConnect();
 
-   /// Get the home switch status, sets m_switch to true or false.
-   /**
+    /// Get the home switch status, sets m_switch to true or false.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int getSwitch();
+    int getSwitch();
 
-   /// Get the moving-state of the wheel, sets m_moving to true or false.
-   /**
+    /// Get the moving-state of the wheel, sets m_moving to true or false.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int getMoving();
+    int getMoving();
 
-   /// Get the current position of the wheel, sets m_rawPos to the current motor counts.
-   /**
+    /// Get the current position of the wheel, sets m_rawPos to the current motor counts.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int getPos();
+    int getPos();
 
-   /// Start a high-level homing sequence.
-   /** For this device this includes the homing dither.
+    /// Start a high-level homing sequence.
+    /** For this device this includes the homing dither.
      *
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int startHoming();
+    int startHoming();
 
-   int presetNumber();
+    int presetNumber();
 
-   /// Start a low-level homing sequence.
-   /** This initiates the device homing sequence.
+    /// Start a low-level homing sequence.
+    /** This initiates the device homing sequence.
      *
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int home();
+    int home();
 
-   /// Stop the wheel motion immediately.
-   /**
+    /// Stop the wheel motion immediately.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int stop();
+    int stop();
 
-   /// Move to an absolute position in raw counts.
-   /**
+    /// Move to an absolute position in raw counts.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int moveToRaw( const long & counts /**< [in] The new position in absolute motor counts*/);
+    int moveToRaw( const long &counts /**< [in] The new position in absolute motor counts*/ );
 
-   /// Move to a new position relative to current, in raw counts.
-   /**
+    /// Move to a new position relative to current, in raw counts.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int moveToRawRelative( const long & counts /**< [in] The new position in relative motor counts*/ );
+    int moveToRawRelative( const long &counts /**< [in] The new position in relative motor counts*/ );
 
-   /// Move to an absolute position in filter units.
-   /**
+    /// Move to an absolute position in filter units.
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int moveTo( const double & filters /**< [in] The new position in absolute filter units*/ );
+    int moveTo( const double &filters /**< [in] The new position in absolute filter units*/ );
 
-   /** \name Telemeter Interface
+    /** \name Telemeter Interface
      *
      * @{
      */
-   int checkRecordTimes();
+    int checkRecordTimes();
 
-   int recordTelem( const telem_stage * );
+    int recordTelem( const telem_stage * );
 
-   int recordTelem( const telem_position * );
+    int recordTelem( const telem_position * );
 
-   int recordStage( bool force = false );
+    int recordStage( bool force = false );
 
-   int recordPosition( bool force = false );
+    int recordPosition( bool force = false );
 
-   ///@}
+    ///@}
 };
 
-inline
-filterWheelCtrl::filterWheelCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
+inline filterWheelCtrl::filterWheelCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
-   m_presetNotation = "filter"; //sets the name of the configs, etc.
+    m_presetNotation = "filter"; // sets the name of the configs, etc.
 
-   m_powerMgtEnabled = true;
+    m_powerMgtEnabled = true;
 
-   return;
+    return;
 }
 
-inline
-void filterWheelCtrl::setupConfig()
+inline void filterWheelCtrl::setupConfig()
 {
-   tty::usbDevice::setupConfig(config);
+    tty::usbDevice::setupConfig( config );
 
-   config.add("timeouts.write", "", "timeouts.write", argType::Required, "timeouts", "write", false, "int", "The timeout for writing to the device [msec]. Default = 1000");
-   config.add("timeouts.read", "", "timeouts.read", argType::Required, "timeouts", "read", false, "int", "The timeout for reading the device [msec]. Default = 1000");
+    config.add( "timeouts.write",
+                "",
+                "timeouts.write",
+                argType::Required,
+                "timeouts",
+                "write",
+                false,
+                "int",
+                "The timeout for writing to the device [msec]. Default = 1000" );
+    config.add( "timeouts.read",
+                "",
+                "timeouts.read",
+                argType::Required,
+                "timeouts",
+                "read",
+                false,
+                "int",
+                "The timeout for reading the device [msec]. Default = 1000" );
 
-   config.add("motor.acceleration", "", "motor.acceleration", argType::Required, "motor", "acceleration", false, "real", "The motor acceleration parameter. Default=100.");
-   config.add("motor.deceleration", "", "motor.deceleration", argType::Required, "motor", "deceleration", false, "real", "The motor deceleration parameter. Default=50.");
-   config.add("motor.speed", "", "motor.speed", argType::Required, "motor", "speed", false, "real", "The motor speed parameter.  Default=3000.");
-   config.add("motor.circleSteps", "", "motor.circleSteps", argType::Required, "motor", "circleSteps", false, "long", "The number of steps in 1 revolution.");
-   config.add("stage.homeOffset", "", "stage.homeOffset", argType::Required, "stage", "homeOffset", false, "long", "The homing offset in motor counts.");
+    config.add( "motor.acceleration",
+                "",
+                "motor.acceleration",
+                argType::Required,
+                "motor",
+                "acceleration",
+                false,
+                "real",
+                "The motor acceleration parameter. Default=100." );
+    config.add( "motor.deceleration",
+                "",
+                "motor.deceleration",
+                argType::Required,
+                "motor",
+                "deceleration",
+                false,
+                "real",
+                "The motor deceleration parameter. Default=50." );
+    config.add( "motor.speed",
+                "",
+                "motor.speed",
+                argType::Required,
+                "motor",
+                "speed",
+                false,
+                "real",
+                "The motor speed parameter.  Default=3000." );
+    config.add( "motor.circleSteps",
+                "",
+                "motor.circleSteps",
+                argType::Required,
+                "motor",
+                "circleSteps",
+                false,
+                "long",
+                "The number of steps in 1 revolution." );
+    config.add( "stage.homeOffset",
+                "",
+                "stage.homeOffset",
+                argType::Required,
+                "stage",
+                "homeOffset",
+                false,
+                "long",
+                "The homing offset in motor counts." );
 
-   dev::stdMotionStage<filterWheelCtrl>::setupConfig(config);
+    dev::stdMotionStage<filterWheelCtrl>::setupConfig( config );
 
-   dev::telemeter<filterWheelCtrl>::setupConfig(config);
+    dev::telemeter<filterWheelCtrl>::setupConfig( config );
 }
 
-inline
-void filterWheelCtrl::loadConfig()
+inline void filterWheelCtrl::loadConfig()
 {
-   this->m_baudRate = B9600; //default for MCBL controller.  Will be overridden by any config setting.
+    this->m_baudRate = B9600; // default for MCBL controller.  Will be overridden by any config setting.
 
-   int rv = tty::usbDevice::loadConfig(config);
+    int rv = tty::usbDevice::loadConfig( config );
 
-   if(rv != 0 && rv != TTY_E_NODEVNAMES && rv != TTY_E_DEVNOTFOUND) //Ignore error if not plugged in
-   {
-      log<software_error>( {__FILE__, __LINE__, rv, tty::ttyErrorString(rv)});
-   }
+    if( rv != 0 && rv != TTY_E_NODEVNAMES && rv != TTY_E_DEVNOTFOUND ) // Ignore error if not plugged in
+    {
+        log<software_error>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
+    }
 
-   config(m_writeTimeOut, "timeouts.write");
-   config(m_readTimeOut, "timeouts.read");
+    config( m_writeTimeOut, "timeouts.write" );
+    config( m_readTimeOut, "timeouts.read" );
 
-   config(m_acceleration, "motor.acceleration");
-   config(m_deceleration, "motor.deceleration");
-   config(m_motorSpeed, "motor.speed");
-   config(m_circleSteps, "motor.circleSteps");
-   config(m_homeOffset, "stage.homeOffset");
+    config( m_acceleration, "motor.acceleration" );
+    config( m_deceleration, "motor.deceleration" );
+    config( m_motorSpeed, "motor.speed" );
+    config( m_circleSteps, "motor.circleSteps" );
+    config( m_homeOffset, "stage.homeOffset" );
 
+    dev::stdMotionStage<filterWheelCtrl>::loadConfig( config );
 
-   dev::stdMotionStage<filterWheelCtrl>::loadConfig(config);
-
-   dev::telemeter<filterWheelCtrl>::loadConfig(config);
+    dev::telemeter<filterWheelCtrl>::loadConfig( config );
 }
 
-inline
-int filterWheelCtrl::appStartup()
+inline int filterWheelCtrl::appStartup()
 {
-   if( state() == stateCodes::UNINITIALIZED )
-   {
-      log<text_log>( "In appStartup but in state UNINITIALIZED.", logPrio::LOG_CRITICAL );
-      return -1;
-   }
+    if( state() == stateCodes::UNINITIALIZED )
+    {
+        log<text_log>( "In appStartup but in state UNINITIALIZED.", logPrio::LOG_CRITICAL );
+        return -1;
+    }
 
-   // set up the  INDI properties
-   createStandardIndiNumber<long>( m_indiP_counts, "counts", std::numeric_limits<long>::lowest(), std::numeric_limits<long>::max(), 0.0, "%ld");
-   registerIndiPropertyNew( m_indiP_counts, INDI_NEWCALLBACK(m_indiP_counts)) ;
+    // set up the  INDI properties
+    createStandardIndiNumber<long>(
+        m_indiP_counts, "counts", std::numeric_limits<long>::lowest(), std::numeric_limits<long>::max(), 0.0, "%ld" );
+    registerIndiPropertyNew( m_indiP_counts, INDI_NEWCALLBACK( m_indiP_counts ) );
 
+    dev::stdMotionStage<filterWheelCtrl>::appStartup();
 
-   dev::stdMotionStage<filterWheelCtrl>::appStartup();
+    if( dev::telemeter<filterWheelCtrl>::appStartup() < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
 
-   if(dev::telemeter<filterWheelCtrl>::appStartup() < 0)
-   {
-      return log<software_error,-1>({__FILE__,__LINE__});
-   }
-
-   return 0;
+    return 0;
 }
 
-inline
-int filterWheelCtrl::appLogic()
+inline int filterWheelCtrl::appLogic()
 {
-   if( state() == stateCodes::INITIALIZED )
-   {
-      log<text_log>( "In appLogic but in state INITIALIZED.", logPrio::LOG_CRITICAL );
-      return -1;
-   }
+    if( state() == stateCodes::INITIALIZED )
+    {
+        log<text_log>( "In appLogic but in state INITIALIZED.", logPrio::LOG_CRITICAL );
+        return -1;
+    }
 
-   if( state() == stateCodes::POWERON )
-   {
-      if(m_deviceName == "") state(stateCodes::NODEVICE);
-      else
-      {
-         state(stateCodes::NOTCONNECTED);
-         std::stringstream logs;
-         logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " found in udev as " << m_deviceName;
-         log<text_log>(logs.str());
-      }
-   }
-
-   if( state() == stateCodes::NODEVICE )
-   {
-      int rv = tty::usbDevice::getDeviceName();
-      if(rv < 0 && rv != TTY_E_DEVNOTFOUND && rv != TTY_E_NODEVNAMES)
-      {
-         state(stateCodes::FAILURE);
-         if(!stateLogged())
-         {
-            log<software_critical>({__FILE__, __LINE__, rv, tty::ttyErrorString(rv)});
-         }
-         return -1;
-      }
-
-      if(rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES)
-      {
-         state(stateCodes::NODEVICE);
-
-         if(!stateLogged())
-         {
+    if( state() == stateCodes::POWERON )
+    {
+        if( m_deviceName == "" )
+            state( stateCodes::NODEVICE );
+        else
+        {
+            state( stateCodes::NOTCONNECTED );
             std::stringstream logs;
-            logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " not found in udev";
-            log<text_log>(logs.str());
-         }
-         return 0;
-      }
-      else
-      {
-         state(stateCodes::NOTCONNECTED);
-         if(!stateLogged())
-         {
-            std::stringstream logs;
-            logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " found in udev as " << m_deviceName;
-            log<text_log>(logs.str());
-         }
-      }
-   }
+            logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " found in udev as "
+                 << m_deviceName;
+            log<text_log>( logs.str() );
+        }
+    }
 
-   if( state() == stateCodes::NOTCONNECTED )
-   {
-      int rv;
-      {
-         elevatedPrivileges elPriv(this);
-         rv = connect();
-      }
-
-      if(rv < 0)
-      {
-         int nrv = tty::usbDevice::getDeviceName();
-         if(nrv < 0 && nrv != TTY_E_DEVNOTFOUND && nrv != TTY_E_NODEVNAMES)
-         {
-            state(stateCodes::FAILURE);
-            if(!stateLogged()) log<software_critical>({__FILE__, __LINE__, nrv, tty::ttyErrorString(nrv)});
+    if( state() == stateCodes::NODEVICE )
+    {
+        int rv = tty::usbDevice::getDeviceName();
+        if( rv < 0 && rv != TTY_E_DEVNOTFOUND && rv != TTY_E_NODEVNAMES )
+        {
+            state( stateCodes::FAILURE );
+            if( !stateLogged() )
+            {
+                log<software_critical>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
+            }
             return -1;
-         }
+        }
 
-         if(nrv == TTY_E_DEVNOTFOUND || nrv == TTY_E_NODEVNAMES)
-         {
-            state(stateCodes::NODEVICE);
+        if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
+        {
+            state( stateCodes::NODEVICE );
 
-            if(!stateLogged())
+            if( !stateLogged() )
             {
-               std::stringstream logs;
-               logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " no longer found in udev";
-               log<text_log>(logs.str());
+                std::stringstream logs;
+                logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " not found in udev";
+                log<text_log>( logs.str() );
             }
             return 0;
-         }
+        }
+        else
+        {
+            state( stateCodes::NOTCONNECTED );
+            if( !stateLogged() )
+            {
+                std::stringstream logs;
+                logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial << " found in udev as "
+                     << m_deviceName;
+                log<text_log>( logs.str() );
+            }
+        }
+    }
 
-         //if connect failed, and there is a device, then we have some other problem.
-         sleep(1); //wait to see if power state updates
-         if(m_powerState == 0) return 0;
+    if( state() == stateCodes::NOTCONNECTED )
+    {
+        int rv;
+        {
+            elevatedPrivileges elPriv( this );
+            rv = connect();
+        }
 
-         //Ok we can't figure this out, die.
-         state(stateCodes::FAILURE);
-         if(!stateLogged()) log<software_error>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
-         return -1;
+        if( rv < 0 )
+        {
+            int nrv = tty::usbDevice::getDeviceName();
+            if( nrv < 0 && nrv != TTY_E_DEVNOTFOUND && nrv != TTY_E_NODEVNAMES )
+            {
+                state( stateCodes::FAILURE );
+                if( !stateLogged() )
+                    log<software_critical>( { __FILE__, __LINE__, nrv, tty::ttyErrorString( nrv ) } );
+                return -1;
+            }
 
-      }
+            if( nrv == TTY_E_DEVNOTFOUND || nrv == TTY_E_NODEVNAMES )
+            {
+                state( stateCodes::NODEVICE );
 
+                if( !stateLogged() )
+                {
+                    std::stringstream logs;
+                    logs << "USB Device " << m_idVendor << ":" << m_idProduct << ":" << m_serial
+                         << " no longer found in udev";
+                    log<text_log>( logs.str() );
+                }
+                return 0;
+            }
 
+            // if connect failed, and there is a device, then we have some other problem.
+            sleep( 1 ); // wait to see if power state updates
+            if( m_powerState == 0 )
+                return 0;
 
-      if( getPos() == 0 ) state(stateCodes::CONNECTED);
-      else
-      {
-         return 0;
-      }
+            // Ok we can't figure this out, die.
+            state( stateCodes::FAILURE );
+            if( !stateLogged() )
+                log<software_error>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
+            return -1;
+        }
 
-      if(state() == stateCodes::CONNECTED)
-      {
-         std::stringstream logs;
-         logs << "Connected to filter wheel on " << m_deviceName;
-         log<text_log>(logs.str());
-      }
-
-   }
-
-   if( state() == stateCodes::CONNECTED )
-   {
-      int rv = onPowerOnConnect();
-
-      if(rv < 0)
-      {
-         log<software_error>({__FILE__,__LINE__});
-         state(stateCodes::ERROR);
-
-         return 0;
-      }
-
-      std::string landfill;
-      tty::ttyRead(landfill, "\r", m_fileDescrip, m_readTimeOut); //read to timeout to kill any missed chars.
-
-      if(m_powerOnHome)
-      {
-         std::lock_guard<std::mutex> guard(m_indiMutex);
-
-         if(startHoming()<0)
-         {
-            state(stateCodes::ERROR);
-            log<software_error>({__FILE__,__LINE__});
+        if( getPos() == 0 )
+            state( stateCodes::CONNECTED );
+        else
+        {
             return 0;
-         }
-      }
-      else state(stateCodes::NOTHOMED);
+        }
 
+        if( state() == stateCodes::CONNECTED )
+        {
+            std::stringstream logs;
+            logs << "Connected to filter wheel on " << m_deviceName;
+            log<text_log>( logs.str() );
+        }
+    }
 
-   }
+    if( state() == stateCodes::CONNECTED )
+    {
+        int rv = onPowerOnConnect();
 
-   if( state() == stateCodes::NOTHOMED || state() == stateCodes::READY || state() == stateCodes::OPERATING || state() == stateCodes::HOMING)
-   {
-      { //mutex scope
-         //Make sure we have exclusive attention of the device
-         std::lock_guard<std::mutex> guard(m_indiMutex);  //Lock the mutex before conducting any communications.
+        if( rv < 0 )
+        {
+            log<software_error>( { __FILE__, __LINE__ } );
+            state( stateCodes::ERROR );
 
-         int rv = getSwitch();
-
-         if(rv  != 0 )
-         {
-            state(stateCodes::NOTCONNECTED);
             return 0;
-         }
+        }
 
-         rv = getMoving();
+        std::string landfill;
+        tty::ttyRead( landfill, "\r", m_fileDescrip, m_readTimeOut ); // read to timeout to kill any missed chars.
 
-         if(rv  != 0 )
-         {
-            state(stateCodes::NOTCONNECTED);
+        if( m_powerOnHome )
+        {
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+
+            if( startHoming() < 0 )
+            {
+                state( stateCodes::ERROR );
+                log<software_error>( { __FILE__, __LINE__ } );
+                return 0;
+            }
+        }
+        else
+            state( stateCodes::NOTHOMED );
+    }
+
+    if( state() == stateCodes::NOTHOMED || state() == stateCodes::READY || state() == stateCodes::OPERATING ||
+        state() == stateCodes::HOMING )
+    {
+        { // mutex scope
+            // Make sure we have exclusive attention of the device
+            std::lock_guard<std::mutex> guard( m_indiMutex ); // Lock the mutex before conducting any communications.
+
+            int rv = getSwitch();
+
+            if( rv != 0 )
+            {
+                state( stateCodes::NOTCONNECTED );
+                return 0;
+            }
+
+            rv = getMoving();
+
+            if( rv != 0 )
+            {
+                state( stateCodes::NOTCONNECTED );
+                return 0;
+            }
+
+            rv = getPos();
+
+            if( rv != 0 )
+            {
+                state( stateCodes::NOTCONNECTED );
+                return 0;
+            }
+
+            recordPosition();
+        }
+
+        if( m_moving )
+        {
+            // Started moving but we don't know yet.
+            if( state() == stateCodes::READY )
+                state( stateCodes::OPERATING );
+        }
+        else
+        {
+            if( state() == stateCodes::OPERATING )
+            {
+                if( m_movingState == 1 )
+                {
+                    std::lock_guard<std::mutex> guard( m_indiMutex );
+                    if( moveToRawRelative( -20000 ) < 0 )
+                    {
+                        sleep( 1 );
+                        if( m_powerState == 0 )
+                            return 0;
+
+                        state( stateCodes::ERROR );
+                        return log<software_error, 0>( { __FILE__, __LINE__ } );
+                    }
+
+                    m_movingState = 2;
+                }
+                else if( m_movingState == 2 )
+                {
+                    std::lock_guard<std::mutex> guard( m_indiMutex );
+                    if( moveTo( m_preset_target ) < 0 )
+                    {
+                        sleep( 1 );
+                        if( m_powerState == 0 )
+                            return 0;
+
+                        state( stateCodes::ERROR );
+                        return log<software_error, 0>( { __FILE__, __LINE__ } );
+                    }
+
+                    m_movingState = 3;
+                }
+                else
+                {
+                    m_movingState = 0;
+                    state( stateCodes::READY ); // stopped moving but was just changing pos
+                }
+            }
+            else if( state() == stateCodes::HOMING ) // stopped moving but was in the homing sequence
+            {
+                if( m_homingState == 1 )
+                {
+                    std::lock_guard<std::mutex> guard( m_indiMutex );
+                    if( moveToRawRelative( -50000 ) < 0 )
+                    {
+                        sleep( 1 );
+                        if( m_powerState == 0 )
+                            return 0;
+
+                        state( stateCodes::ERROR );
+                        return log<software_error, 0>( { __FILE__, __LINE__ } );
+                    }
+
+                    m_homingState = 2;
+                }
+                else if( m_homingState == 2 )
+                {
+                    std::lock_guard<std::mutex> guard( m_indiMutex );
+                    if( home() < 0 )
+                    {
+                        sleep( 1 );
+                        if( m_powerState == 0 )
+                            return 0;
+
+                        state( stateCodes::ERROR );
+                        return log<software_error, 0>( { __FILE__, __LINE__ } );
+                    }
+                    m_homingState = 3;
+                }
+                else if( m_homingState == 3 )
+                {
+                    std::lock_guard<std::mutex> guard( m_indiMutex );
+                    if( moveToRaw( m_homeOffset ) < 0 )
+                    {
+                        sleep( 1 );
+                        if( m_powerState == 0 )
+                            return 0;
+
+                        state( stateCodes::ERROR );
+                        return log<software_error, 0>( { __FILE__, __LINE__ } );
+                    }
+                    m_homingState = 4;
+                }
+                else if( m_homingState == 4 )
+                {
+                    if( m_homePreset >= 0 )
+                    {
+                        m_preset_target = m_presetPositions[m_homePreset];
+                        updateIfChanged( m_indiP_preset, "target", m_preset_target, INDI_BUSY );
+
+                        moveTo( m_preset_target );
+                    }
+                    m_homingState = 5;
+                }
+                else
+                {
+                    m_homingState = 0;
+                    state( stateCodes::READY );
+
+                    m_preset_target = ( (double)m_rawPos - m_homeOffset ) / m_circleSteps * m_presetNames.size() + 1.0;
+                }
+            }
+        }
+
+        std::lock_guard<std::mutex> guard( m_indiMutex );
+
+        if( m_moving )
+        {
+            updateIfChanged( m_indiP_counts, "current", m_rawPos, INDI_BUSY );
+        }
+        else
+        {
+            updateIfChanged( m_indiP_counts, "current", m_rawPos, INDI_IDLE );
+        }
+
+        m_preset = ( (double)m_rawPos - m_homeOffset ) / m_circleSteps * m_presetNames.size() + 1.0;
+
+        stdMotionStage<filterWheelCtrl>::updateINDI();
+        recordStage();
+
+        if( telemeter<filterWheelCtrl>::appLogic() < 0 )
+        {
+            log<software_error>( { __FILE__, __LINE__ } );
             return 0;
-         }
+        }
 
-         rv = getPos();
+        return 0;
+    }
 
-         if(rv  != 0 )
-         {
-            state(stateCodes::NOTCONNECTED);
+    if( state() == stateCodes::ERROR )
+    {
+        sleep( 1 );
+        if( m_powerState == 0 )
             return 0;
-         }
 
-         recordPosition();
-      }
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "In state ERROR but no recovery implemented.  Terminating." } );
+    }
 
-      if(m_moving)
-      {
-         //Started moving but we don't know yet.
-         if(state() == stateCodes::READY) state(stateCodes::OPERATING);
-      }
-      else
-      {
-         if(state() == stateCodes::OPERATING)
-         {
-            if(m_movingState == 1)
-            {
-               std::lock_guard<std::mutex> guard(m_indiMutex);
-               if(moveToRawRelative(-20000) < 0)
-               {
-                  sleep(1);
-                  if(m_powerState == 0) return 0;
-
-                  state(stateCodes::ERROR);
-                  return log<software_error,0>({__FILE__,__LINE__});
-               }
-
-               m_movingState=2;
-            }
-            else if(m_movingState == 2)
-            {
-               std::lock_guard<std::mutex> guard(m_indiMutex);
-               if(moveTo(m_preset_target) < 0)
-               {
-                  sleep(1);
-                  if(m_powerState == 0) return 0;
-
-                  state(stateCodes::ERROR);
-                  return log<software_error,0>({__FILE__,__LINE__});
-               }
-
-               m_movingState=3;
-            }
-            else
-            {
-               m_movingState = 0;
-               state(stateCodes::READY); //stopped moving but was just changing pos
-            }
-
-         }
-         else if (state() == stateCodes::HOMING) //stopped moving but was in the homing sequence
-         {
-            if(m_homingState == 1)
-            {
-               std::lock_guard<std::mutex> guard(m_indiMutex);
-               if(moveToRawRelative(-50000) < 0)
-               {
-                  sleep(1);
-                  if(m_powerState == 0) return 0;
-
-                  state(stateCodes::ERROR);
-                  return log<software_error,0>({__FILE__,__LINE__});
-               }
-
-               m_homingState=2;
-            }
-            else if (m_homingState == 2)
-            {
-               std::lock_guard<std::mutex> guard(m_indiMutex);
-               if(home()<0)
-               {
-                  sleep(1);
-                  if(m_powerState == 0) return 0;
-
-                  state(stateCodes::ERROR);
-                  return log<software_error,0>({__FILE__,__LINE__});
-               }
-               m_homingState = 3;
-            }
-            else if(m_homingState == 3)
-            {
-               std::lock_guard<std::mutex> guard(m_indiMutex);
-               if(moveToRaw(m_homeOffset)<0)
-               {
-                  sleep(1);
-                  if(m_powerState == 0) return 0;
-
-                  state(stateCodes::ERROR);
-                  return log<software_error,0>({__FILE__,__LINE__});
-               }
-               m_homingState=4;
-            }
-            else if(m_homingState == 4)
-            {
-               if(m_homePreset >= 0)
-               {
-                  m_preset_target = m_presetPositions[m_homePreset];
-                  updateIfChanged(m_indiP_preset, "target",  m_preset_target, INDI_BUSY);
-
-                  moveTo(m_preset_target);
-               }
-               m_homingState = 5;
-            }
-            else
-            {
-               m_homingState = 0;
-               state(stateCodes::READY);
-
-               m_preset_target = ((double) m_rawPos-m_homeOffset)/m_circleSteps*m_presetNames.size() + 1.0;
-            }
-         }
-      }
-
-      std::lock_guard<std::mutex> guard(m_indiMutex);
-
-      if(m_moving)
-      {
-         updateIfChanged(m_indiP_counts, "current", m_rawPos, INDI_BUSY);
-      }
-      else
-      {
-         updateIfChanged(m_indiP_counts, "current", m_rawPos, INDI_IDLE);
-      }
-
-      m_preset = ((double) m_rawPos-m_homeOffset)/m_circleSteps*m_presetNames.size() + 1.0;
-
-      stdMotionStage<filterWheelCtrl>::updateINDI();
-      recordStage();
-
-      if(telemeter<filterWheelCtrl>::appLogic() < 0)
-      {
-         log<software_error>({__FILE__, __LINE__});
-         return 0;
-      }
-
-      return 0;
-   }
-
-   if(state() == stateCodes::ERROR)
-   {
-      sleep(1);
-      if(m_powerState == 0) return 0;
-
-      return log<software_error,-1>({__FILE__,__LINE__, "In state ERROR but no recovery implemented.  Terminating."});
-   }
-
-   return log<software_error,-1>({__FILE__,__LINE__, "appLogic fell through.  Terminating."});
-
+    return log<software_error, -1>( { __FILE__, __LINE__, "appLogic fell through.  Terminating." } );
 }
 
-
-
-inline
-int filterWheelCtrl::appShutdown()
+inline int filterWheelCtrl::appShutdown()
 {
-   //don't bother
-   return 0;
+    // don't bother
+    return 0;
 }
 
-inline
-int filterWheelCtrl::onPowerOff()
+inline int filterWheelCtrl::onPowerOff()
 {
-   if( stdMotionStage<filterWheelCtrl>::onPowerOff() < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-   }
+    if( stdMotionStage<filterWheelCtrl>::onPowerOff() < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+    }
 
-   recordStage(true);
-   recordPosition(true);
+    recordStage( true );
+    recordPosition( true );
 
-   return 0;
+    return 0;
 }
 
-inline
-int filterWheelCtrl::whilePowerOff()
+inline int filterWheelCtrl::whilePowerOff()
 {
-   if( stdMotionStage<filterWheelCtrl>::whilePowerOff() < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-   }
+    if( stdMotionStage<filterWheelCtrl>::whilePowerOff() < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+    }
 
-   //record telem if it's been longer than 10 sec:
-   if(telemeter<filterWheelCtrl>::appLogic() < 0)
-   {
-      log<software_error>({__FILE__, __LINE__});
-   }
+    // record telem if it's been longer than 10 sec:
+    if( telemeter<filterWheelCtrl>::appLogic() < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+    }
 
-   return 0;
+    return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(filterWheelCtrl, m_indiP_counts)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( filterWheelCtrl, m_indiP_counts )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(m_indiP_counts, ipRecv);
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_counts, ipRecv );
 
-    double counts = -1;
+    double counts     = -1;
     double target_abs = -1;
-    if(ipRecv.find("current"))
+    if( ipRecv.find( "current" ) )
     {
-       counts = ipRecv["current"].get<double>();
+        counts = ipRecv["current"].get<double>();
     }
-    if(ipRecv.find("target"))
+    if( ipRecv.find( "target" ) )
     {
-       target_abs = ipRecv["target"].get<double>();
+        target_abs = ipRecv["target"].get<double>();
     }
-    if(target_abs == -1) target_abs = counts;
+    if( target_abs == -1 )
+        target_abs = counts;
 
-
-    m_preset_target = ((double) target_abs - m_homeOffset)/m_circleSteps*m_presetNames.size() + 1.0;
-    std::lock_guard<std::mutex> guard(m_indiMutex);
-    return moveToRaw(target_abs);
-
+    clearPresetNameTracking();
+    m_movingState   = 0;
+    m_preset_target = ( (double)target_abs - m_homeOffset ) / m_circleSteps * m_presetNames.size() + 1.0;
+    std::lock_guard<std::mutex> guard( m_indiMutex );
+    return moveToRaw( target_abs );
 }
-
-
-
 
 int filterWheelCtrl::onPowerOnConnect()
 {
-   std::string com;
+    std::string com;
 
-   int rv;
+    int rv;
 
-   std::lock_guard<std::mutex> guard(m_indiMutex);
+    std::lock_guard<std::mutex> guard( m_indiMutex );
 
-   rv = tty::ttyWrite( "ANSW0\r", m_fileDescrip, m_writeTimeOut); //turn off replies and asynchronous comms.
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "ANSW0\r", m_fileDescrip, m_writeTimeOut ); // turn off replies and asynchronous comms.
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   //Send motor type
-   com = "MOTTYP" + std::to_string(m_motorType) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    // Send motor type
+    com = "MOTTYP" + std::to_string( m_motorType ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   //Set up acceleration and speed.
-   com = "AC" + std::to_string(m_acceleration) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    // Set up acceleration and speed.
+    com = "AC" + std::to_string( m_acceleration ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   //Set up acceleration and speed.
-   com = "DEC" + std::to_string(m_deceleration) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    // Set up acceleration and speed.
+    com = "DEC" + std::to_string( m_deceleration ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   com = "SP" + std::to_string(m_motorSpeed) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip,m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    com = "SP" + std::to_string( m_motorSpeed ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   return 0;
+    return 0;
 }
 
 int filterWheelCtrl::getSwitch()
 {
-   int rv;
-   std::string resp;
+    int         rv;
+    std::string resp;
 
-   rv = tty::ttyWriteRead( resp, "GAST\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut);
+    rv = tty::ttyWriteRead( resp, "GAST\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut );
 
-   if(rv == 0)
-   {
+    if( rv == 0 )
+    {
 
-      if(resp == "1011") m_switch=true;
-      else m_switch=false;
+        if( resp == "1011" )
+            m_switch = true;
+        else
+            m_switch = false;
 
-      return 0;
-   }
+        return 0;
+    }
 
-
-   return rv;
-
+    return rv;
 }
 
 int filterWheelCtrl::getMoving()
 {
-   int rv;
-   std::string resp;
+    int         rv;
+    std::string resp;
 
-   rv = tty::ttyWriteRead( resp, "GN\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut);
+    rv = tty::ttyWriteRead( resp, "GN\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut );
 
-   if(rv == 0)
-   {
-      int speed;
-      try{ speed = std::stol(resp.c_str());}
-      catch(...){speed=0;}
+    if( rv == 0 )
+    {
+        int speed;
+        try
+        {
+            speed = std::stol( resp.c_str() );
+        }
+        catch( ... )
+        {
+            speed = 0;
+        }
 
-      if(fabs(speed) > 0.1*m_motorSpeed)
-      {
-         if(m_homingState) m_moving = 2;
-         else m_moving = 1;
-      }
-      else m_moving = 0;
+        if( fabs( speed ) > 0.1 * m_motorSpeed )
+        {
+            if( m_homingState )
+                m_moving = 2;
+            else
+                m_moving = 1;
+        }
+        else
+            m_moving = 0;
 
-      return 0;
-   }
+        return 0;
+    }
 
-
-   return rv;
-
+    return rv;
 }
 
 int filterWheelCtrl::getPos()
 {
-   int rv;
-   std::string resp;
+    int         rv;
+    std::string resp;
 
-   rv = tty::ttyWriteRead( resp, "POS\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut);
+    rv = tty::ttyWriteRead( resp, "POS\r", "\r\n", false, m_fileDescrip, m_writeTimeOut, m_readTimeOut );
 
-   if(rv == 0)
-   {
-      try{ m_rawPos = std::stol(resp.c_str());}
-      catch(...){m_rawPos=0;}
-   }
+    if( rv == 0 )
+    {
+        try
+        {
+            m_rawPos = std::stol( resp.c_str() );
+        }
+        catch( ... )
+        {
+            m_rawPos = 0;
+        }
+    }
 
-
-   return rv;
-
+    return rv;
 }
 
 int filterWheelCtrl::startHoming()
 {
-   m_homingState = 1;
-   m_moving = 2;
-   recordStage(true);
-   recordPosition(true);
+    m_homingState = 1;
+    m_moving      = 2;
+    recordStage( true );
+    recordPosition( true );
 
-   updateSwitchIfChanged(m_indiP_home, "request", pcf::IndiElement::Off, INDI_IDLE);
-   return home();
+    updateSwitchIfChanged( m_indiP_home, "request", pcf::IndiElement::Off, INDI_IDLE );
+    return home();
 }
 
 int filterWheelCtrl::presetNumber()
 {
-   //First we calculate current preset name
-   int n = floor(m_preset + 0.5) - 1;
-   if(n < 0)
-   {
-      while(n < 0) n += m_presetNames.size();
-   }
-   if( n > (long) m_presetNames.size()-1 )
-   {
-      while( n > (long) m_presetNames.size()-1 ) n -= m_presetNames.size();
-   }
+    // First we calculate current preset name
+    int n = floor( m_preset + 0.5 ) - 1;
+    if( n < 0 )
+    {
+        while( n < 0 )
+            n += m_presetNames.size();
+    }
+    if( n > (long)m_presetNames.size() - 1 )
+    {
+        while( n > (long)m_presetNames.size() - 1 )
+            n -= m_presetNames.size();
+    }
 
-   if( n < 0)
-   {
-      log<software_error>({__FILE__,__LINE__, "error calculating " + m_presetNotation + " index, n < 0"});
-      return -1;
-   }
+    if( n < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__, "error calculating " + m_presetNotation + " index, n < 0" } );
+        return -1;
+    }
 
-   return n;
+    return n;
 }
 
 int filterWheelCtrl::home()
 {
 
-   state(stateCodes::HOMING);
+    state( stateCodes::HOMING );
 
-   int rv;
+    int rv;
 
-   rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "HA4\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "HA4\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "HL4\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "HL4\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "CAHOSEQ\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "CAHOSEQ\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "HP0\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "HP0\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   std::string com = "HOSP" + std::to_string(m_motorSpeed) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    std::string com = "HOSP" + std::to_string( m_motorSpeed ) + "\r";
+    rv              = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "GOHOSEQ\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "GOHOSEQ\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-
-
-   return 0;
+    return 0;
 }
 
 int filterWheelCtrl::stop()
 {
-   m_homingState = 0;
-   //First try without locking
-   tty::ttyWrite( "DI\r", m_fileDescrip, m_writeTimeOut);
+    m_homingState = 0;
+    // First try without locking
+    tty::ttyWrite( "DI\r", m_fileDescrip, m_writeTimeOut );
 
-   //Now make sure it goes through
-   std::lock_guard<std::mutex> guard(m_indiMutex);
-   int rv = tty::ttyWrite( "DI\r", m_fileDescrip, m_writeTimeOut);
+    // Now make sure it goes through
+    std::lock_guard<std::mutex> guard( m_indiMutex );
+    int                         rv = tty::ttyWrite( "DI\r", m_fileDescrip, m_writeTimeOut );
 
-   updateSwitchIfChanged(m_indiP_stop, "request", pcf::IndiElement::Off, INDI_IDLE);
+    updateSwitchIfChanged( m_indiP_stop, "request", pcf::IndiElement::Off, INDI_IDLE );
 
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   return 0;
+    return 0;
 }
 
-int filterWheelCtrl::moveToRaw( const long & counts )
+int filterWheelCtrl::moveToRaw( const long &counts )
 {
 
-   std::string com;
-   int rv;
+    std::string com;
+    int         rv;
 
-   m_moving = 1;
-   recordStage(true);
-   recordPosition(true);
+    m_moving = 1;
+    recordStage( true );
+    recordPosition( true );
 
-   rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   com = "LA" + std::to_string(counts) + "\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    com = "LA" + std::to_string( counts ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "M\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "M\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   updateIfChanged(m_indiP_counts, "target", counts, pcf::IndiProperty::Busy);
+    updateIfChanged( m_indiP_counts, "target", counts, pcf::IndiProperty::Busy );
 
-   return 0;
+    return 0;
 }
 
-int filterWheelCtrl::moveToRawRelative( const long & counts_relative )
+int filterWheelCtrl::moveToRawRelative( const long &counts_relative )
 {
 
-   std::string com;
-   int rv;
+    std::string com;
+    int         rv;
 
-   m_moving = 1;
-   recordStage(true);
-   recordPosition(true);
+    m_moving = 1;
+    recordStage( true );
+    recordPosition( true );
 
-   rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "EN\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   com = "LR" + std::to_string(counts_relative) +"\r";
-   rv = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    com = "LR" + std::to_string( counts_relative ) + "\r";
+    rv  = tty::ttyWrite( com, m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-   rv = tty::ttyWrite( "M\r", m_fileDescrip, m_writeTimeOut);
-   if(rv < 0) return log<software_error,-1>({__FILE__,__LINE__,rv, tty::ttyErrorString(rv)});
+    rv = tty::ttyWrite( "M\r", m_fileDescrip, m_writeTimeOut );
+    if( rv < 0 )
+        return log<software_error, -1>( { __FILE__, __LINE__, rv, tty::ttyErrorString( rv ) } );
 
-
-
-   return 0;
+    return 0;
 }
 
-int filterWheelCtrl::moveTo( const double & filters )
+int filterWheelCtrl::moveTo( const double &filters )
 {
-   long counts;
+    long counts;
 
-   if(m_circleSteps ==0 || m_presetNames.size() == 0) counts = filters;
-   else counts = m_homeOffset + m_circleSteps/m_presetNames.size() * (filters-1);
+    if( m_circleSteps == 0 || m_presetNames.size() == 0 )
+        counts = filters;
+    else
+        counts = m_homeOffset + m_circleSteps / m_presetNames.size() * ( filters - 1 );
 
-   return moveToRaw(counts);
-
+    return moveToRaw( counts );
 }
 
 int filterWheelCtrl::checkRecordTimes()
 {
-   return dev::telemeter<filterWheelCtrl>::checkRecordTimes(telem_stage(), telem_position());
+    return dev::telemeter<filterWheelCtrl>::checkRecordTimes( telem_stage(), telem_position() );
 }
 
 int filterWheelCtrl::recordTelem( const telem_stage * )
 {
-   return recordStage(true);
+    return recordStage( true );
 }
 
 int filterWheelCtrl::recordTelem( const telem_position * )
 {
-   return recordPosition(true);
+    return recordPosition( true );
 }
 
-int filterWheelCtrl::recordStage(bool force)
+int filterWheelCtrl::recordStage( bool force )
 {
-   return dev::stdMotionStage<filterWheelCtrl>::recordStage(force);
+    return dev::stdMotionStage<filterWheelCtrl>::recordStage( force );
 }
 
-int filterWheelCtrl::recordPosition(bool force)
+int filterWheelCtrl::recordPosition( bool force )
 {
-   static long last_pos = 999999999999;
+    static long last_pos = 999999999999;
 
-   if( m_rawPos != last_pos || force )
-   {
-      float fpos = m_rawPos;
+    if( m_rawPos != last_pos || force )
+    {
+        float fpos = m_rawPos;
 
-      telem<telem_position>(fpos);
+        telem<telem_position>( fpos );
 
-      last_pos = m_rawPos;
-   }
+        last_pos = m_rawPos;
+    }
 
-   return 0;
+    return 0;
 }
 
-} //namespace app
-} //namespace MagAOX
+} // namespace app
+} // namespace MagAOX
 
-#endif //filterWheelCtrl_hpp
+#endif // filterWheelCtrl_hpp

--- a/apps/zaberCtrl/tests/zaberCtrl_test.cpp
+++ b/apps/zaberCtrl/tests/zaberCtrl_test.cpp
@@ -69,6 +69,42 @@ class zaberCtrl_test : public zaberCtrl
         m_preset_target = presetTarget;
     }
 
+    /// Set the current motion-state classification for testing.
+    void setMovingState( int8_t movingState )
+    {
+        m_movingState = movingState;
+    }
+
+    /// Track a specific preset-name alias for testing.
+    int setPresetAliasIndex( int presetNameIndex )
+    {
+        return setPresetNameTracking( presetNameIndex );
+    }
+
+    /// Clear any tracked preset-name alias for testing.
+    void clearPresetAliasIndex()
+    {
+        clearPresetNameTracking();
+    }
+
+    /// Resolve the active preset-name index for the current position.
+    int activeAliasIndex()
+    {
+        return activePresetNameIndex( presetNumber() );
+    }
+
+    /// Resolve the active preset name for the current position.
+    std::string activeAliasName()
+    {
+        return activePresetName( presetNumber() );
+    }
+
+    /// Invoke the base-class power-off handling under test.
+    int stageOnPowerOff()
+    {
+        return dev::stdMotionStage<zaberCtrl>::onPowerOff();
+    }
+
     /// Invoke the powered-off telemetry sync under test.
     int syncPoweredOffTelemetry()
     {
@@ -136,6 +172,53 @@ SCENARIO( "Power-off stage telemetry", "[zaberCtrl]" )
         REQUIRE( zct.syncPoweredOffTelemetry() == 0 );
         REQUIRE( zct.presetValue() == 0 );
         REQUIRE( zct.presetTargetValue() == 0 );
+    }
+}
+
+SCENARIO( "Preset-name aliases follow the selected shared-position preset", "[zaberCtrl]" )
+{
+    zaberCtrl_test zct( "stest" );
+
+    zct.setPresets( { -1, 10, 20, 20 }, { "none", "open", "science", "focus" } );
+    zct.setStagePosition( 20.0, 1000.0 );
+    zct.setStageTelemetry( 0, 3, 3 );
+
+    WHEN( "a specific alias was selected for a shared preset position" )
+    {
+        REQUIRE( zct.setPresetAliasIndex( 3 ) == 0 );
+
+        REQUIRE( zct.activeAliasIndex() == 3 );
+        REQUIRE( zct.activeAliasName() == "focus" );
+    }
+
+    WHEN( "the stage is moving toward a selected alias" )
+    {
+        REQUIRE( zct.setPresetAliasIndex( 3 ) == 0 );
+        zct.setMovingState( 1 );
+        zct.setStageTelemetry( 1, 2, 3 );
+
+        REQUIRE( zct.activeAliasIndex() == 3 );
+        REQUIRE( zct.activeAliasName() == "focus" );
+    }
+
+    WHEN( "no alias is being tracked" )
+    {
+        zct.clearPresetAliasIndex();
+
+        REQUIRE( zct.activeAliasIndex() == 2 );
+        REQUIRE( zct.activeAliasName() == "science" );
+    }
+
+    WHEN( "the alias tracking is cleared on power off" )
+    {
+        REQUIRE( zct.setPresetAliasIndex( 3 ) == 0 );
+
+        REQUIRE( zct.stageOnPowerOff() == 0 );
+        REQUIRE( zct.movingState() == -2 );
+        REQUIRE( zct.presetValue() == 0 );
+        REQUIRE( zct.presetTargetValue() == 0 );
+        REQUIRE( zct.activeAliasIndex() == 2 );
+        REQUIRE( zct.activeAliasName() == "science" );
     }
 }
 

--- a/apps/zaberCtrl/tests/zaberCtrl_test.cpp
+++ b/apps/zaberCtrl/tests/zaberCtrl_test.cpp
@@ -99,6 +99,12 @@ class zaberCtrl_test : public zaberCtrl
         return activePresetName( presetNumber() );
     }
 
+    /// Resolve the preset name that telemetry should record.
+    std::string telemetryAliasName()
+    {
+        return telemetryPresetName();
+    }
+
     /// Invoke the base-class power-off handling under test.
     int stageOnPowerOff()
     {
@@ -215,10 +221,11 @@ SCENARIO( "Preset-name aliases follow the selected shared-position preset", "[za
 
         REQUIRE( zct.stageOnPowerOff() == 0 );
         REQUIRE( zct.movingState() == -2 );
-        REQUIRE( zct.presetValue() == 0 );
-        REQUIRE( zct.presetTargetValue() == 0 );
-        REQUIRE( zct.activeAliasIndex() == 2 );
-        REQUIRE( zct.activeAliasName() == "science" );
+        REQUIRE( zct.presetValue() == 3 );
+        REQUIRE( zct.presetTargetValue() == 3 );
+        REQUIRE( zct.activeAliasIndex() == 3 );
+        REQUIRE( zct.activeAliasName() == "focus" );
+        REQUIRE( zct.telemetryAliasName() == "focus" );
     }
 }
 

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -645,6 +645,8 @@ INDI_NEWCALLBACK_DEFN( zaberCtrl, m_indiP_pos )( const pcf::IndiProperty &ipRecv
     std::lock_guard<std::mutex> guard( m_indiMutex );
 
     m_tgtPos = target;
+    clearPresetNameTracking();
+    m_movingState = 0;
 
     moveTo( m_tgtPos );
     updateIfChanged( m_indiP_pos, "target", m_tgtPos, INDI_BUSY );
@@ -684,6 +686,8 @@ INDI_NEWCALLBACK_DEFN( zaberCtrl, m_indiP_rawPos )( const pcf::IndiProperty &ipR
     log<text_log>( "moving stage by " + std::to_string( target ) );
 
     std::lock_guard<std::mutex> guard( m_indiMutex );
+    clearPresetNameTracking();
+    m_movingState = 0;
 
     pcf::IndiProperty indiP_stageTgtPos = pcf::IndiProperty( pcf::IndiProperty::Text );
     indiP_stageTgtPos.setDevice( m_lowLevelName );

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -378,7 +378,10 @@ int zaberCtrl::appLogic()
             }
         }
 
-        recordStage();
+        if( dev::stdMotionStage<zaberCtrl>::updateINDI() < 0 )
+        {
+            log<software_error>( { __FILE__, __LINE__ } );
+        }
 
         // record telem if it's been longer than 10 sec:
         if( telemeter<zaberCtrl>::appLogic() < 0 )
@@ -731,6 +734,7 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageState )( const pcf::IndiProperty 
         state( stateCodes::POWEROFF );
         m_moving = -2;
         syncPowerOffStageTelemetry();
+        dev::stdMotionStage<zaberCtrl>::updateINDI();
         dev::stdMotionStage<zaberCtrl>::recordStage( true );
     }
     else if( sstr == "POWERON" )
@@ -935,6 +939,7 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageParked )( const pcf::IndiProperty
     if( state() == stateCodes::POWEROFF )
     {
         syncPowerOffStageTelemetry();
+        dev::stdMotionStage<zaberCtrl>::updateINDI();
         dev::stdMotionStage<zaberCtrl>::recordStage( true );
     }
 

--- a/libMagAOX/app/dev/stdMotionStage.hpp
+++ b/libMagAOX/app/dev/stdMotionStage.hpp
@@ -276,10 +276,18 @@ class stdMotionStage
     std::string
     activePresetName( int presetIndex /**< [in] the current preset index reported by the derived stage */ ) const;
 
+    /// Resolve the preset name that should be recorded in telemetry.
+    std::string telemetryPresetName();
+
   private:
     derivedT &derived()
     {
         return *static_cast<derivedT *>( this );
+    }
+
+    const derivedT &derived() const
+    {
+        return *static_cast<const derivedT *>( this );
     }
 };
 
@@ -429,10 +437,7 @@ int stdMotionStage<derivedT>::appLogic()
 template <class derivedT>
 int stdMotionStage<derivedT>::onPowerOff()
 {
-    m_moving        = -2;
-    m_preset        = 0;
-    m_preset_target = 0;
-    clearPresetNameTracking();
+    m_moving = -2;
 
     return 0;
 }
@@ -650,9 +655,7 @@ int stdMotionStage<derivedT>::recordStage( bool force )
     static float       last_preset;
     static std::string last_presetName;
 
-    int n = derived().presetNumber();
-
-    std::string presetName = activePresetName( n );
+    std::string presetName = telemetryPresetName();
 
     if( m_moving != last_moving || m_preset != last_preset || presetName != last_presetName || force )
     {
@@ -720,6 +723,17 @@ std::string stdMotionStage<derivedT>::activePresetName( int presetIndex ) const
     }
 
     return "";
+}
+
+template <class derivedT>
+std::string stdMotionStage<derivedT>::telemetryPresetName()
+{
+    if( m_preset <= 0 )
+    {
+        return "";
+    }
+
+    return activePresetName( derived().presetNumber() );
 }
 
 } // namespace dev

--- a/libMagAOX/app/dev/stdMotionStage.hpp
+++ b/libMagAOX/app/dev/stdMotionStage.hpp
@@ -1,14 +1,13 @@
 /** \file stdMotionStage.hpp
-  * \brief Standard motion stage interface
-  *
-  * \author Jared R. Males (jaredmales@gmail.com)
-  *
-  * \ingroup app_files
-  */
+ * \brief Standard motion stage interface
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup app_files
+ */
 
 #ifndef stdMotionStage_hpp
 #define stdMotionStage_hpp
-
 
 namespace MagAOX
 {
@@ -16,7 +15,6 @@ namespace app
 {
 namespace dev
 {
-
 
 /// MagAO-X standard motion stage interface
 /** Implements the standard interface to a MagAO-X motion stage.
@@ -34,7 +32,8 @@ namespace dev
     int moveTo(float); //INDI mutex will be locked on this call.
     \endcode
   *
-  * In addition the derived class is responsible for setting m_moving and m_preset. m_preset_target should also be set if the wheel
+  * In addition the derived class is responsible for setting m_moving and m_preset. m_preset_target should also be set
+  if the wheel
   * is moved via a low-level position command.
   *
   * The derived class `derivedT` must be a MagAOXApp\<true\>, and should declare this class a friend like so:
@@ -49,569 +48,682 @@ namespace dev
   *
   * \ingroup appdev
   */
-template<class derivedT>
+template <class derivedT>
 class stdMotionStage
 {
-protected:
-
-   /** \name Configurable Parameters
-    * @{
-    */
-
-   bool m_powerOnHome {false}; ///< If true, then the motor is homed at startup (by this software or actual power on)
-
-   int m_homePreset {-1}; ///< If >=0, this preset position is moved to after homing
-
-   std::vector<std::string> m_presetNames; ///< The names of each position on the stage.
-
-   std::vector<float> m_presetPositions; ///< The positions, in arbitrary units, of each preset.  If 0, then the integer position number (starting from 1) is used to calculate.
-
-   ///@}
-
-   std::string m_presetNotation {"preset"}; ///< Notation used to refer to a preset, should be singular, as in "preset" or "filter".
-
-   bool m_fractionalPresets {true}; ///< Flag to set in constructor determining if fractional presets are allowed.  Used for INDI/GUIs.
-
-   bool m_defaultPositions {true}; ///< Flag controlling whether the default preset positions (the vector index) are set in loadConfig.
-
-   int8_t m_moving {0}; ///< Whether or not the stage is moving.  -2 means powered off, -1 means not homed, 0 means not moving, 1 means moving, 2 means homing.
-   int8_t m_movingState {0}; ///< Used to track the type of command.  If > 1 this is a command to move to a preset.  If 0 then it is a move to an arbitrary position.
-
-   float m_preset {0}; ///< The current numerical preset position [1.0 is index 0 in the preset name vector]
-   float m_preset_target {0}; ///< The target numerical preset position [1.0 is index 0 in the preset name vector]
-
-public:
-
-   ///Destructor
-   ~stdMotionStage() noexcept;
-
-   /// Setup the configuration system
-   /**
-     * This should be called in `derivedT::setupConfig` as
-     * \code
-       stdMotionStage<derivedT>::setupConfig(config);
-       \endcode
-     * with appropriate error checking.
+  protected:
+    /** \name Configurable Parameters
+     * @{
      */
-   int setupConfig(mx::app::appConfigurator & config /**< [out] the derived classes configurator*/);
 
-   /// load the configuration system results
-   /**
-     * This should be called in `derivedT::loadConfig` as
-     * \code
-       stdMotionStage<derivedT>::loadConfig(config);
-       \endcode
-     * with appropriate error checking.
-     */
-   int loadConfig(mx::app::appConfigurator & config /**< [in] the derived classes configurator*/);
+    bool m_powerOnHome{ false }; ///< If true, then the motor is homed at startup (by this software or actual power on)
 
-   /// Startup function
-   /**
-     * This should be called in `derivedT::appStartup` as
-     * \code
-       stdMotionStage<derivedT>::appStartup();
-       \endcode
-     * with appropriate error checking.
-     *
-     * \returns 0 on success
-     * \returns -1 on error, which is logged.
-     */
-   int appStartup();
+    int m_homePreset{ -1 }; ///< If >=0, this preset position is moved to after homing
 
-   /// Application logic
-   /** Checks the stdMotionStage thread
-     *
-     * This should be called from the derived's appLogic() as in
-     * \code
-       stdMotionStage<derivedT>::appLogic();
-       \endcode
-     * with appropriate error checking.
-     *
-     * \returns 0 on success
-     * \returns -1 on error, which is logged.
-     */
-   int appLogic();
+    std::vector<std::string> m_presetNames; ///< The names of each position on the stage.
 
-   /// Actions on power off
-   /**
-     * This should be called from the derived's onPowerOff() as in
-     * \code
-       stdMotionStage<derivedT>::onPowerOff();
-       \endcode
-     * with appropriate error checking.
-     *
-     * \returns 0 on success
-     * \returns -1 on error, which is logged.
-     */
-   int onPowerOff();
+    std::vector<float> m_presetPositions; ///< The positions, in arbitrary units, of each preset.  If 0, then the
+                                          ///< integer position number (starting from 1) is used to calculate.
 
-   /// Actions while powered off
-   /**
-     * This should be called from the derived's whilePowerOff() as in
-     * \code
-       stdMotionStage<derivedT>::whilePowerOff();
-       \endcode
-     * with appropriate error checking.
-     *
-     * \returns 0 on success
-     * \returns -1 on error, which is logged.
-     */
-   int whilePowerOff();
+    ///@}
 
-   /// Application the shutdown
-   /** Shuts down the stdMotionStage thread
-     *
-     * \code
-       stdMotionStage<derivedT>::appShutdown();
-       \endcode
-     * with appropriate error checking.
-     *
-     * \returns 0 on success
-     * \returns -1 on error, which is logged.
-     */
-   int appShutdown();
+    std::string m_presetNotation{
+        "preset" }; ///< Notation used to refer to a preset, should be singular, as in "preset" or "filter".
 
-protected:
+    bool m_fractionalPresets{
+        true }; ///< Flag to set in constructor determining if fractional presets are allowed.  Used for INDI/GUIs.
 
+    bool m_defaultPositions{
+        true }; ///< Flag controlling whether the default preset positions (the vector index) are set in loadConfig.
 
-    /** \name INDI
-      *
-      *@{
+    int8_t m_moving{ 0 }; ///< Whether or not the stage is moving.  -2 means powered off, -1 means not homed, 0 means
+                          ///< not moving, 1 means moving, 2 means homing.
+    int8_t m_movingState{ 0 }; ///< Used to track the type of command.  If 1 this is a command to move to a named
+                               ///< preset.  If 0 then it is a move to an arbitrary position.
+
+    float m_preset{ 0 };        ///< The current numerical preset position [1.0 is index 0 in the preset name vector]
+    float m_preset_target{ 0 }; ///< The target numerical preset position [1.0 is index 0 in the preset name vector]
+    int   m_presetNameIndex{
+        -1 }; ///< The selected preset-name alias index when the active command identifies a specific preset name.
+
+  public:
+    /// Destructor
+    ~stdMotionStage() noexcept;
+
+    /// Setup the configuration system
+    /**
+      * This should be called in `derivedT::setupConfig` as
+      * \code
+        stdMotionStage<derivedT>::setupConfig(config);
+        \endcode
+      * with appropriate error checking.
       */
-protected:
-   //declare our properties
+    int setupConfig( mx::app::appConfigurator &config /**< [out] the derived classes configurator*/ );
 
-   ///The position of the stage in presets
-   pcf::IndiProperty m_indiP_preset;
+    /// load the configuration system results
+    /**
+      * This should be called in `derivedT::loadConfig` as
+      * \code
+        stdMotionStage<derivedT>::loadConfig(config);
+        \endcode
+      * with appropriate error checking.
+      */
+    int loadConfig( mx::app::appConfigurator &config /**< [in] the derived classes configurator*/ );
 
-   ///The name of the nearest preset for this position
-   pcf::IndiProperty m_indiP_presetName;
+    /// Startup function
+    /**
+      * This should be called in `derivedT::appStartup` as
+      * \code
+        stdMotionStage<derivedT>::appStartup();
+        \endcode
+      * with appropriate error checking.
+      *
+      * \returns 0 on success
+      * \returns -1 on error, which is logged.
+      */
+    int appStartup();
 
-   ///Command the stage to home. .
-   pcf::IndiProperty m_indiP_home;
+    /// Application logic
+    /** Checks the stdMotionStage thread
+      *
+      * This should be called from the derived's appLogic() as in
+      * \code
+        stdMotionStage<derivedT>::appLogic();
+        \endcode
+      * with appropriate error checking.
+      *
+      * \returns 0 on success
+      * \returns -1 on error, which is logged.
+      */
+    int appLogic();
 
-   ///Command the stage to halt.
-   pcf::IndiProperty m_indiP_stop;
+    /// Actions on power off
+    /**
+      * This should be called from the derived's onPowerOff() as in
+      * \code
+        stdMotionStage<derivedT>::onPowerOff();
+        \endcode
+      * with appropriate error checking.
+      *
+      * \returns 0 on success
+      * \returns -1 on error, which is logged.
+      */
+    int onPowerOff();
 
-public:
+    /// Actions while powered off
+    /**
+      * This should be called from the derived's whilePowerOff() as in
+      * \code
+        stdMotionStage<derivedT>::whilePowerOff();
+        \endcode
+      * with appropriate error checking.
+      *
+      * \returns 0 on success
+      * \returns -1 on error, which is logged.
+      */
+    int whilePowerOff();
 
-   /// The static callback function to be registered for stdMotionStage properties
-   /** Dispatches to the relevant handler
+    /// Application the shutdown
+    /** Shuts down the stdMotionStage thread
+      *
+      * \code
+        stdMotionStage<derivedT>::appShutdown();
+        \endcode
+      * with appropriate error checking.
+      *
+      * \returns 0 on success
+      * \returns -1 on error, which is logged.
+      */
+    int appShutdown();
+
+  protected:
+    /** \name INDI
+     *
+     *@{
+     */
+  protected:
+    // declare our properties
+
+    /// The position of the stage in presets
+    pcf::IndiProperty m_indiP_preset;
+
+    /// The name of the active preset selection
+    pcf::IndiProperty m_indiP_presetName;
+
+    /// Command the stage to home. .
+    pcf::IndiProperty m_indiP_home;
+
+    /// Command the stage to halt.
+    pcf::IndiProperty m_indiP_stop;
+
+  public:
+    /// The static callback function to be registered for stdMotionStage properties
+    /** Dispatches to the relevant handler
      *
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   static int st_newCallBack_stdMotionStage( void * app, ///< [in] a pointer to this, will be static_cast-ed to derivedT.
-                                             const pcf::IndiProperty &ipRecv ///< [in] the INDI property sent with the the new property request.
-                                           );
+    static int st_newCallBack_stdMotionStage(
+        void                    *app,   ///< [in] a pointer to this, will be static_cast-ed to derivedT.
+        const pcf::IndiProperty &ipRecv ///< [in] the INDI property sent with the the new property request.
+    );
 
-   /// Callback to process a NEW preset position request
-   /**
+    /// Callback to process a NEW preset position request
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int newCallBack_m_indiP_preset( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/);
+    int newCallBack_m_indiP_preset(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
-   /// Callback to process a NEW preset name request
-   /**
+    /// Callback to process a NEW preset name request
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int newCallBack_m_indiP_presetName( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/);
+    int newCallBack_m_indiP_presetName(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
-   /// Callback to process a NEW home request switch toggle
-   /**
+    /// Callback to process a NEW home request switch toggle
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int newCallBack_m_indiP_home( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/);
+    int newCallBack_m_indiP_home(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
-   /// Callback to process a NEW stop request switch toggle
-   /**
+    /// Callback to process a NEW stop request switch toggle
+    /**
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int newCallBack_m_indiP_stop( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/);
+    int newCallBack_m_indiP_stop(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
-   /// Update the INDI properties for this device controller
-   /** You should call this once per main loop.
+    /// Update the INDI properties for this device controller
+    /** You should call this once per main loop.
      * It is not called automatically.
      *
      * \returns 0 on success.
      * \returns -1 on error.
      */
-   int updateINDI();
+    int updateINDI();
 
     ///@}
 
-   /** \name Telemeter Interface
+    /** \name Telemeter Interface
      * @{
      */
 
-   int recordStage( bool force = false );
+    /// Record the stage telemetry state.
+    int recordStage( bool force /**< [in] force telemetry recording even when no stage state changed */ = false );
 
-   ///@}
+    ///@}
 
-private:
-   derivedT & derived()
-   {
-      return *static_cast<derivedT *>(this);
-   }
+  protected:
+    /// Clear any tracked preset-name alias selection.
+    void clearPresetNameTracking();
+
+    /// Record the active preset-name alias index.
+    int setPresetNameTracking(
+        int presetNameIndex /**< [in] the preset-name index to associate with the current command */ );
+
+    /// Resolve the preset-name alias index that should be reported.
+    int
+    activePresetNameIndex( int presetIndex /**< [in] the current preset index reported by the derived stage */ ) const;
+
+    /// Resolve the preset name that should be reported.
+    std::string
+    activePresetName( int presetIndex /**< [in] the current preset index reported by the derived stage */ ) const;
+
+  private:
+    derivedT &derived()
+    {
+        return *static_cast<derivedT *>( this );
+    }
 };
 
-template<class derivedT>
+template <class derivedT>
 stdMotionStage<derivedT>::~stdMotionStage() noexcept
 {
-   return;
+    return;
 }
 
-
-
-template<class derivedT>
-int stdMotionStage<derivedT>::setupConfig(mx::app::appConfigurator & config)
+template <class derivedT>
+int stdMotionStage<derivedT>::setupConfig( mx::app::appConfigurator &config )
 {
-   static_cast<void>(config);
+    static_cast<void>( config );
 
-   config.add("stage.powerOnHome", "", "stage.powerOnHome", argType::Required, "stage", "powerOnHome", false, "bool", "If true, home at startup/power-on.  Default=false.");
+    config.add( "stage.powerOnHome",
+                "",
+                "stage.powerOnHome",
+                argType::Required,
+                "stage",
+                "powerOnHome",
+                false,
+                "bool",
+                "If true, home at startup/power-on.  Default=false." );
 
-   config.add("stage.homePreset", "", "stage.homePreset", argType::Required, "stage", "homePreset", false, "int", "If >=0, this preset number is moved to after homing.");
+    config.add( "stage.homePreset",
+                "",
+                "stage.homePreset",
+                argType::Required,
+                "stage",
+                "homePreset",
+                false,
+                "int",
+                "If >=0, this preset number is moved to after homing." );
 
-   config.add(m_presetNotation + "s.names", "", m_presetNotation + "s.names",  argType::Required, m_presetNotation+"s", "names", false, "vector<string>", "The names of the " + m_presetNotation+ "s.");
-   config.add(m_presetNotation + "s.positions", "", m_presetNotation + "s.positions",  argType::Required, m_presetNotation+"s", "positions", false, "vector<float>", "The positions of the " + m_presetNotation + "s.  If omitted or 0 then order is used.");
+    config.add( m_presetNotation + "s.names",
+                "",
+                m_presetNotation + "s.names",
+                argType::Required,
+                m_presetNotation + "s",
+                "names",
+                false,
+                "vector<string>",
+                "The names of the " + m_presetNotation + "s." );
+    config.add( m_presetNotation + "s.positions",
+                "",
+                m_presetNotation + "s.positions",
+                argType::Required,
+                m_presetNotation + "s",
+                "positions",
+                false,
+                "vector<float>",
+                "The positions of the " + m_presetNotation + "s.  If omitted or 0 then order is used." );
 
-   return 0;
+    return 0;
 }
 
-template<class derivedT>
-int stdMotionStage<derivedT>::loadConfig(mx::app::appConfigurator & config)
+template <class derivedT>
+int stdMotionStage<derivedT>::loadConfig( mx::app::appConfigurator &config )
 {
-   config(m_powerOnHome, "stage.powerOnHome");
-   config(m_homePreset, "stage.homePreset");
+    config( m_powerOnHome, "stage.powerOnHome" );
+    config( m_homePreset, "stage.homePreset" );
 
-   config(m_presetNames, m_presetNotation + "s.names");
+    config( m_presetNames, m_presetNotation + "s.names" );
 
-   if(m_defaultPositions)
-   {
-      m_presetPositions.resize(m_presetNames.size(), 0);
-      for(size_t n=0;n<m_presetPositions.size();++n) m_presetPositions[n] = n+1;
-   }
+    if( m_defaultPositions )
+    {
+        m_presetPositions.resize( m_presetNames.size(), 0 );
+        for( size_t n = 0; n < m_presetPositions.size(); ++n )
+            m_presetPositions[n] = n + 1;
+    }
 
-   config(m_presetPositions, m_presetNotation + "s.positions");
+    config( m_presetPositions, m_presetNotation + "s.positions" );
 
-   if(m_defaultPositions)
-   {
-      for(size_t n=0;n<m_presetPositions.size();++n) if(m_presetPositions[n] == 0) m_presetPositions[n] = n+1;
-   }
+    if( m_defaultPositions )
+    {
+        for( size_t n = 0; n < m_presetPositions.size(); ++n )
+            if( m_presetPositions[n] == 0 )
+                m_presetPositions[n] = n + 1;
+    }
 
-   return 0;
+    return 0;
 }
 
-
-
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::appStartup()
 {
-   double step = 0.0;
-   std::string format = "%.4f";
-   if(!m_fractionalPresets)
-   {
-      step = 1.0;
-      format = "%d";
-   }
+    double      step   = 0.0;
+    std::string format = "%.4f";
+    if( !m_fractionalPresets )
+    {
+        step   = 1.0;
+        format = "%d";
+    }
 
-   derived().createStandardIndiNumber( m_indiP_preset, m_presetNotation, 1.0, (double) m_presetNames.size(), step, format);
-   m_indiP_preset["current"].set(0);
-   m_indiP_preset["target"].set(0);
-   if( derived().registerIndiPropertyNew( m_indiP_preset, st_newCallBack_stdMotionStage) < 0)
-   {
-      #ifndef STDFILTERWHEEL_TEST_NOLOG
-      derivedT::template log<software_error>({__FILE__,__LINE__});
-      #endif
-      return -1;
-   }
+    derived().createStandardIndiNumber(
+        m_indiP_preset, m_presetNotation, 1.0, (double)m_presetNames.size(), step, format );
+    m_indiP_preset["current"].set( 0 );
+    m_indiP_preset["target"].set( 0 );
+    if( derived().registerIndiPropertyNew( m_indiP_preset, st_newCallBack_stdMotionStage ) < 0 )
+    {
+#ifndef STDFILTERWHEEL_TEST_NOLOG
+        derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+        return -1;
+    }
 
-   if(derived().createStandardIndiSelectionSw( m_indiP_presetName, m_presetNotation + "Name", m_presetNames) < 0)
-   {
-      derivedT::template log<software_critical>({__FILE__, __LINE__});
-      return -1;
-   }
-   if( derived().registerIndiPropertyNew( m_indiP_presetName, st_newCallBack_stdMotionStage) < 0)
-   {
-      #ifndef STDFILTERWHEEL_TEST_NOLOG
-      derivedT::template log<software_error>({__FILE__,__LINE__});
-      #endif
-      return -1;
-   }
+    if( derived().createStandardIndiSelectionSw( m_indiP_presetName, m_presetNotation + "Name", m_presetNames ) < 0 )
+    {
+        derivedT::template log<software_critical>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+    if( derived().registerIndiPropertyNew( m_indiP_presetName, st_newCallBack_stdMotionStage ) < 0 )
+    {
+#ifndef STDFILTERWHEEL_TEST_NOLOG
+        derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+        return -1;
+    }
 
-   derived().createStandardIndiRequestSw( m_indiP_home, "home");
-   if( derived().registerIndiPropertyNew( m_indiP_home, st_newCallBack_stdMotionStage) < 0)
-   {
-      #ifndef STDFILTERWHEEL_TEST_NOLOG
-      derivedT::template log<software_error>({__FILE__,__LINE__});
-      #endif
-      return -1;
-   }
+    derived().createStandardIndiRequestSw( m_indiP_home, "home" );
+    if( derived().registerIndiPropertyNew( m_indiP_home, st_newCallBack_stdMotionStage ) < 0 )
+    {
+#ifndef STDFILTERWHEEL_TEST_NOLOG
+        derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+        return -1;
+    }
 
-   derived().createStandardIndiRequestSw( m_indiP_stop, "stop");
-   if( derived().registerIndiPropertyNew( m_indiP_stop, st_newCallBack_stdMotionStage) < 0)
-   {
-      #ifndef STDFILTERWHEEL_TEST_NOLOG
-      derivedT::template log<software_error>({__FILE__,__LINE__});
-      #endif
-      return -1;
-   }
+    derived().createStandardIndiRequestSw( m_indiP_stop, "stop" );
+    if( derived().registerIndiPropertyNew( m_indiP_stop, st_newCallBack_stdMotionStage ) < 0 )
+    {
+#ifndef STDFILTERWHEEL_TEST_NOLOG
+        derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+        return -1;
+    }
 
-   return 0;
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::appLogic()
 {
-   return 0;
-
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::onPowerOff()
 {
-   m_moving = -2;
-   m_preset = 0;
-   m_preset_target = 0;
+    m_moving        = -2;
+    m_preset        = 0;
+    m_preset_target = 0;
+    clearPresetNameTracking();
 
-   return 0;
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::whilePowerOff()
 {
-   return 0;
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::appShutdown()
 {
-   return 0;
+    return 0;
 }
 
-
-template<class derivedT>
-int stdMotionStage<derivedT>::st_newCallBack_stdMotionStage( void * app,
-                                                             const pcf::IndiProperty &ipRecv
-                                                           )
+template <class derivedT>
+int stdMotionStage<derivedT>::st_newCallBack_stdMotionStage( void *app, const pcf::IndiProperty &ipRecv )
 {
-   std::string name = ipRecv.getName();
-   derivedT * _app = static_cast<derivedT *>(app);
+    std::string name = ipRecv.getName();
+    derivedT   *_app = static_cast<derivedT *>( app );
 
-   if(name == "stop") return _app->newCallBack_m_indiP_stop(ipRecv); //Check this first to make sure it
-   if(name == "home") return _app->newCallBack_m_indiP_home(ipRecv);
-   if(name == _app->m_presetNotation) return _app->newCallBack_m_indiP_preset(ipRecv);
-   if(name == _app->m_presetNotation + "Name") return _app->newCallBack_m_indiP_presetName (ipRecv);
+    if( name == "stop" )
+        return _app->newCallBack_m_indiP_stop( ipRecv ); // Check this first to make sure it
+    if( name == "home" )
+        return _app->newCallBack_m_indiP_home( ipRecv );
+    if( name == _app->m_presetNotation )
+        return _app->newCallBack_m_indiP_preset( ipRecv );
+    if( name == _app->m_presetNotation + "Name" )
+        return _app->newCallBack_m_indiP_presetName( ipRecv );
 
-   return -1;
+    return -1;
 }
 
-template<class derivedT>
-int stdMotionStage<derivedT>::newCallBack_m_indiP_preset ( const pcf::IndiProperty &ipRecv )
+template <class derivedT>
+int stdMotionStage<derivedT>::newCallBack_m_indiP_preset( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS_DERIVED(m_indiP_preset, ipRecv);
+    INDI_VALIDATE_CALLBACK_PROPS_DERIVED( m_indiP_preset, ipRecv );
 
     float target;
 
-    if( derived().indiTargetUpdate( m_indiP_preset, target, ipRecv, true) < 0)
+    if( derived().indiTargetUpdate( m_indiP_preset, target, ipRecv, true ) < 0 )
     {
-        derivedT::template log<software_error>({__FILE__,__LINE__});
+        derivedT::template log<software_error>( { __FILE__, __LINE__ } );
         return -1;
     }
 
     m_preset_target = target;
 
-    std::lock_guard<std::mutex> guard(derived().m_indiMutex);
-    m_movingState = 0; //this is not a preset move
-    return derived().moveTo(target);
-
+    std::lock_guard<std::mutex> guard( derived().m_indiMutex );
+    clearPresetNameTracking();
+    m_movingState = 0; // this is not a preset move
+    return derived().moveTo( target );
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::newCallBack_m_indiP_presetName( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS_DERIVED(m_indiP_presetName, ipRecv);
+    INDI_VALIDATE_CALLBACK_PROPS_DERIVED( m_indiP_presetName, ipRecv );
 
-   std::string newName = "";
-   int newn = -1;
+    std::string newName = "";
+    int         newn    = -1;
 
-   size_t i;
-   for(i=0; i< m_presetNames.size(); ++i)
-   {
-      if(!ipRecv.find(m_presetNames[i])) continue;
+    size_t i;
+    for( i = 0; i < m_presetNames.size(); ++i )
+    {
+        if( !ipRecv.find( m_presetNames[i] ) )
+            continue;
 
-      if(ipRecv[m_presetNames[i]].getSwitchState() == pcf::IndiElement::On)
-      {
-         if(newName != "")
-         {
-            derivedT::template log<text_log>("More than one " + m_presetNotation + " selected", logPrio::LOG_ERROR);
-            return -1;
-         }
+        if( ipRecv[m_presetNames[i]].getSwitchState() == pcf::IndiElement::On )
+        {
+            if( newName != "" )
+            {
+                derivedT::template log<text_log>( "More than one " + m_presetNotation + " selected",
+                                                  logPrio::LOG_ERROR );
+                return -1;
+            }
 
-         newName = m_presetNames[i];
-         newn = i;
-      }
-   }
+            newName = m_presetNames[i];
+            newn    = i;
+        }
+    }
 
-   if(newName == "" || newn < 0)
-   {
-      return 0; //This is just an reset of current probably
-   }
+    if( newName == "" || newn < 0 )
+    {
+        return 0; // This is just an reset of current probably
+    }
 
-   std::lock_guard<std::mutex> guard(derived().m_indiMutex);
+    std::lock_guard<std::mutex> guard( derived().m_indiMutex );
 
-   m_preset_target = m_presetPositions[newn];
-   derived().updateIfChanged(m_indiP_preset, "target",  m_preset_target, INDI_BUSY);
+    setPresetNameTracking( newn );
+    m_preset_target = m_presetPositions[newn];
+    derived().updateIfChanged( m_indiP_preset, "target", m_preset_target, INDI_BUSY );
 
-   m_movingState = 1; //This is a preset move
-   return derived().moveTo(m_preset_target);
-
+    m_movingState = 1; // This is a preset move
+    return derived().moveTo( m_preset_target );
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::newCallBack_m_indiP_home( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS_DERIVED(m_indiP_home, ipRecv);
+    INDI_VALIDATE_CALLBACK_PROPS_DERIVED( m_indiP_home, ipRecv );
 
-   if(!ipRecv.find("request")) return 0;
+    if( !ipRecv.find( "request" ) )
+        return 0;
 
-   if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On)
-   {
-      indi::updateSwitchIfChanged(m_indiP_home, "request", pcf::IndiElement::On, derived().m_indiDriver, INDI_BUSY);
+    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+    {
+        indi::updateSwitchIfChanged( m_indiP_home, "request", pcf::IndiElement::On, derived().m_indiDriver, INDI_BUSY );
 
-      std::lock_guard<std::mutex> guard(derived().m_indiMutex);
-      m_movingState = 0;
-      return derived().startHoming();
-   }
-   return 0;
+        std::lock_guard<std::mutex> guard( derived().m_indiMutex );
+        m_movingState = 0;
+        return derived().startHoming();
+    }
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::newCallBack_m_indiP_stop( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS_DERIVED(m_indiP_stop, ipRecv);
+    INDI_VALIDATE_CALLBACK_PROPS_DERIVED( m_indiP_stop, ipRecv );
 
-   if(ipRecv.getName() != m_indiP_stop.getName())
-   {
-      derivedT::template log<software_error>({__FILE__,__LINE__, "wrong INDI property received."});
-      return -1;
-   }
+    if( ipRecv.getName() != m_indiP_stop.getName() )
+    {
+        derivedT::template log<software_error>( { __FILE__, __LINE__, "wrong INDI property received." } );
+        return -1;
+    }
 
-   if(!ipRecv.find("request")) return 0;
+    if( !ipRecv.find( "request" ) )
+        return 0;
 
-   if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On)
-   {
-      indi::updateSwitchIfChanged(m_indiP_stop, "request", pcf::IndiElement::On, derived().m_indiDriver, INDI_BUSY);
+    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+    {
+        indi::updateSwitchIfChanged( m_indiP_stop, "request", pcf::IndiElement::On, derived().m_indiDriver, INDI_BUSY );
 
-      //-->do not lock mutex!
-      m_movingState = 0;
-      return derived().stop();
-   }
-   return 0;
+        //-->do not lock mutex!
+        m_movingState = 0;
+        return derived().stop();
+    }
+    return 0;
 }
 
-template<class derivedT>
+template <class derivedT>
 int stdMotionStage<derivedT>::updateINDI()
 {
-   if( !derived().m_indiDriver ) return 0;
+    if( !derived().m_indiDriver )
+        return 0;
 
-   int n = derived().presetNumber();
+    int n = derived().presetNumber();
 
-   size_t nn = n;
+    // Check for changes and update the filterNames
+    bool changed = false;
 
-   //Check for changes and update the filterNames
-   bool changed = false;
+    static int8_t last_moving       = -1; // Initialize so we always update first time through.
+    int           activePresetIndex = activePresetNameIndex( n );
 
-   static int8_t last_moving = -1; //Initialize so we always update first time through.
+    if( last_moving != m_moving )
+    {
+        changed     = true;
+        last_moving = m_moving;
+    }
 
-   if(last_moving != m_moving)
-   {
-      changed = true;
-      last_moving = m_moving;
-   }
+    for( size_t i = 0; i < m_presetNames.size(); ++i )
+    {
+        if( static_cast<int>( i ) == activePresetIndex )
+        {
+            if( m_indiP_presetName[m_presetNames[i]] != pcf::IndiElement::On )
+            {
+                changed                              = true;
+                m_indiP_presetName[m_presetNames[i]] = pcf::IndiElement::On;
+            }
+        }
+        else
+        {
+            if( m_indiP_presetName[m_presetNames[i]] != pcf::IndiElement::Off )
+            {
+                changed                              = true;
+                m_indiP_presetName[m_presetNames[i]] = pcf::IndiElement::Off;
+            }
+        }
+    }
+    if( changed )
+    {
+        if( m_moving > 0 )
+        {
+            m_indiP_presetName.setState( INDI_BUSY );
+        }
+        else
+        {
+            m_indiP_presetName.setState( INDI_IDLE );
+        }
 
-   for(size_t i =0; i < m_presetNames.size(); ++i)
-   {
-      if( i == nn )
-      {
-         if(m_indiP_presetName[m_presetNames[i]] != pcf::IndiElement::On)
-         {
-            changed = true;
-            m_indiP_presetName[m_presetNames[i]] = pcf::IndiElement::On;
-         }
-      }
-      else
-      {
-         if(m_indiP_presetName[m_presetNames[i]] != pcf::IndiElement::Off)
-         {
-            changed = true;
-            m_indiP_presetName[m_presetNames[i]] = pcf::IndiElement::Off;
-         }
-      }
-   }
-   if(changed)
-   {
-      if(m_moving > 0)
-      {
-         m_indiP_presetName.setState(INDI_BUSY);
-      }
-      else
-      {
-         m_indiP_presetName.setState(INDI_IDLE);
-      }
+        m_indiP_presetName.setTimeStamp( pcf::TimeStamp() );
+        derived().m_indiDriver->sendSetProperty( m_indiP_presetName );
+    }
 
-      m_indiP_presetName.setTimeStamp(pcf::TimeStamp());
-      derived().m_indiDriver->sendSetProperty(m_indiP_presetName);
-   }
+    if( m_moving && m_movingState < 1 )
+    {
+        indi::updateIfChanged( m_indiP_preset, "current", m_preset, derived().m_indiDriver, INDI_BUSY );
+        indi::updateIfChanged( m_indiP_preset, "target", m_preset_target, derived().m_indiDriver, INDI_BUSY );
+    }
+    else
+    {
+        indi::updateIfChanged( m_indiP_preset, "current", m_preset, derived().m_indiDriver, INDI_IDLE );
+        indi::updateIfChanged( m_indiP_preset, "target", m_preset_target, derived().m_indiDriver, INDI_IDLE );
+    }
 
-
-
-   if(m_moving && m_movingState < 1)
-   {
-      indi::updateIfChanged(m_indiP_preset, "current", m_preset, derived().m_indiDriver,INDI_BUSY);
-      indi::updateIfChanged(m_indiP_preset, "target", m_preset_target, derived().m_indiDriver,INDI_BUSY);
-   }
-   else
-   {
-      indi::updateIfChanged(m_indiP_preset, "current", m_preset, derived().m_indiDriver,INDI_IDLE);
-      indi::updateIfChanged(m_indiP_preset, "target", m_preset_target, derived().m_indiDriver,INDI_IDLE);
-   }
-
-   return recordStage();
+    return recordStage();
 }
 
-template<class derivedT>
-int stdMotionStage<derivedT>::recordStage(bool force)
+template <class derivedT>
+int stdMotionStage<derivedT>::recordStage( bool force )
 {
-   static int8_t last_moving = m_moving + 100; //guarantee first run
-   static float last_preset;
-   static std::string last_presetName;
+    static int8_t      last_moving = m_moving + 100; // guarantee first run
+    static float       last_preset;
+    static std::string last_presetName;
 
-   size_t n = derived().presetNumber();
+    int n = derived().presetNumber();
 
-   std::string presetName;
-   if(n < m_presetNames.size()) presetName = m_presetNames[n];
+    std::string presetName = activePresetName( n );
 
-   if( m_moving != last_moving || m_preset != last_preset || presetName != last_presetName || force)
-   {
-      derived().template telem<telem_stage>({m_moving, m_preset, presetName});
-      last_moving = m_moving;
-      last_preset = m_preset;
-      last_presetName = presetName;
+    if( m_moving != last_moving || m_preset != last_preset || presetName != last_presetName || force )
+    {
+        derived().template telem<telem_stage>( { m_moving, m_preset, presetName } );
+        last_moving     = m_moving;
+        last_preset     = m_preset;
+        last_presetName = presetName;
+    }
 
-   }
-
-
-   return 0;
+    return 0;
 }
 
+template <class derivedT>
+void stdMotionStage<derivedT>::clearPresetNameTracking()
+{
+    m_presetNameIndex = -1;
+}
 
-} //namespace dev
-} //namespace app
-} //namespace MagAOX
+template <class derivedT>
+int stdMotionStage<derivedT>::setPresetNameTracking( int presetNameIndex )
+{
+    if( presetNameIndex < 0 || presetNameIndex >= static_cast<int>( m_presetNames.size() ) )
+    {
+        clearPresetNameTracking();
+        return -1;
+    }
 
-#endif //stdMotionStage_hpp
+    m_presetNameIndex = presetNameIndex;
+    return 0;
+}
+
+template <class derivedT>
+int stdMotionStage<derivedT>::activePresetNameIndex( int presetIndex ) const
+{
+    if( m_presetNameIndex >= 0 && m_presetNameIndex < static_cast<int>( m_presetPositions.size() ) )
+    {
+        if( m_moving != 0 && m_movingState == 1 )
+        {
+            return m_presetNameIndex;
+        }
+
+        if( presetIndex >= 0 && presetIndex < static_cast<int>( m_presetPositions.size() ) &&
+            m_presetPositions[presetIndex] == m_presetPositions[m_presetNameIndex] )
+        {
+            return m_presetNameIndex;
+        }
+    }
+
+    if( presetIndex >= 0 && presetIndex < static_cast<int>( m_presetNames.size() ) )
+    {
+        return presetIndex;
+    }
+
+    return -1;
+}
+
+template <class derivedT>
+std::string stdMotionStage<derivedT>::activePresetName( int presetIndex ) const
+{
+    int presetNameIndex = activePresetNameIndex( presetIndex );
+
+    if( presetNameIndex >= 0 && presetNameIndex < static_cast<int>( m_presetNames.size() ) )
+    {
+        return m_presetNames[presetNameIndex];
+    }
+
+    return "";
+}
+
+} // namespace dev
+} // namespace app
+} // namespace MagAOX
+
+#endif // stdMotionStage_hpp


### PR DESCRIPTION
This work was performed by Codex (GPT-5.

## Summary

This PR updates `stdMotionStage` and `zaberCtrl` to preserve intended preset aliases when multiple preset names share the same position, and to keep powered-off telemetry and INDI state consistent with the parked stage state.

## What Changed

- Added preset-alias tracking in `stdMotionStage` so a name-selected preset continues to report the selected alias instead of collapsing to the first preset with the same position.
- Cleared alias tracking on arbitrary/raw position moves so stale aliases are not reused incorrectly.
- Preserved parked preset telemetry across power-off instead of clearing the snapped preset state in the base `onPowerOff()` path.
- Updated `zaberCtrl` so powered-off restart paths republish the `presetName` switch state to INDI when the stage is already off.
- Added/updated `zaberCtrl` tests covering:
  - duplicate-position preset aliases
  - alias reporting while moving
  - power-off telemetry preservation
  - telemetry-facing alias handling

## Verification

- Ran `clang-format` on touched C++ files.
- Ran `git diff --check`.
- Built:
  - `make -C apps/zaberCtrl`
  - `make -C apps/filterWheelCtrl`

- New behavior verified on instrument.
- 
## Notes

- For `zaberCtrl`, powered-off behavior now distinguishes:
  - parked: preserve preset number and alias
  - not parked: report no valid preset
- `filterWheelCtrl` now preserves the last cached preset state across power-off because the base class no longer clears it.
