### PR TITLE
Refresh warnings overlay on list changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ clean: libs_clean apps_clean pythonapps_clean guis_clean utils_clean tests_clean
 
 #Clean everything.
 .PHONY: all_clean
-all_clean: indi_clean libs_clean flatlogs_clean libs_clean apps_clean guis_clean utils_clean doc_clean tests_clean
+all_clean: indi_clean libs_clean flatlogs_clean libs_clean apps_clean guis_clean rtimv_plugins_clean utils_clean doc_clean tests_clean
 
 flatlogs/bin/flatlogcodes: flatlogs/src/flatlogcodes.cpp
 	cd flatlogs/src/ && ${MAKE} install

--- a/gui/rtimv/plugins/warnings/warnings.cpp
+++ b/gui/rtimv/plugins/warnings/warnings.cpp
@@ -48,6 +48,10 @@ int warnings::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &
              SIGNAL( warningLevel( rtimv::warningLevel ) ),
              m_roa.m_mainWindowObject,
              SLOT( borderWarningLevel( rtimv::warningLevel ) ) );
+    connect( this,
+             SIGNAL( textOverlayRefreshRequested( char ) ),
+             m_roa.m_mainWindowObject,
+             SLOT( textOverlayRefreshRequested( char ) ) );
 
     if( m_roa.m_dictionary != nullptr )
     {
@@ -85,9 +89,22 @@ int warnings::updateOverlay()
     if( m_roa.m_graphicsView == nullptr )
         return 0;
 
-    bool caution = anyOn( m_cautionKeys, ".caution." );
-    bool warn    = anyOn( m_warningKeys, ".warning." );
-    bool alert   = anyOn( m_alertKeys, ".alert." );
+    std::vector<std::string> activeCautions = activeKeys( m_cautionKeys, ".caution." );
+    std::vector<std::string> activeWarnings = activeKeys( m_warningKeys, ".warning." );
+    std::vector<std::string> activeAlerts   = activeKeys( m_alertKeys, ".alert." );
+
+    if( activeCautions != m_activeCautions || activeWarnings != m_activeWarnings || activeAlerts != m_activeAlerts )
+    {
+        m_activeCautions = std::move( activeCautions );
+        m_activeWarnings = std::move( activeWarnings );
+        m_activeAlerts   = std::move( activeAlerts );
+
+        emit textOverlayRefreshRequested( textOverlayKey() );
+    }
+
+    bool caution = !m_activeCautions.empty();
+    bool warn    = !m_activeWarnings.empty();
+    bool alert   = !m_activeAlerts.empty();
 
     if( alert )
     {
@@ -158,11 +175,17 @@ void warnings::enableOverlay()
 
 void warnings::disableOverlay()
 {
-    for( size_t n = 0; n < m_roa.m_graphicsView->statusTextNo(); ++n )
+    if( m_roa.m_graphicsView != nullptr )
     {
-        m_roa.m_graphicsView->statusTextText( n, "" );
+        for( size_t n = 0; n < m_roa.m_graphicsView->statusTextNo(); ++n )
+        {
+            m_roa.m_graphicsView->statusTextText( n, "" );
+        }
     }
 
+    m_activeCautions.clear();
+    m_activeWarnings.clear();
+    m_activeAlerts.clear();
     m_enabled = false;
 }
 
@@ -201,6 +224,21 @@ bool warnings::anyOn( const std::vector<std::string> &keys, const std::string &p
     }
 
     return false;
+}
+
+std::vector<std::string> warnings::activeKeys( const std::vector<std::string> &keys, const std::string &prefix )
+{
+    std::vector<std::string> active;
+
+    for( size_t n = 0; n < keys.size(); ++n )
+    {
+        if( keyOn( m_deviceName + prefix + keys[n] ) )
+        {
+            active.push_back( keys[n] );
+        }
+    }
+
+    return active;
 }
 
 void warnings::appendActive( std::string                    &text,

--- a/gui/rtimv/plugins/warnings/warnings.hpp
+++ b/gui/rtimv/plugins/warnings/warnings.hpp
@@ -44,6 +44,15 @@ class warnings : public rtimvOverlayInterface
     /// Dictionary keys checked at alert severity.
     std::vector<std::string> m_alertKeys;
 
+    /// Cached active caution keys used to trigger overlay refresh only on changes.
+    std::vector<std::string> m_activeCautions;
+
+    /// Cached active warning keys used to trigger overlay refresh only on changes.
+    std::vector<std::string> m_activeWarnings;
+
+    /// Cached active alert keys used to trigger overlay refresh only on changes.
+    std::vector<std::string> m_activeAlerts;
+
     char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
 
   public:
@@ -99,6 +108,12 @@ class warnings : public rtimvOverlayInterface
                 const std::string &prefix /**< [in] severity-specific key prefix inserted after the device name */
     );
 
+    /// Return the active keys in one severity group.
+    std::vector<std::string>
+    activeKeys( const std::vector<std::string> &keys, /**< [in] configured leaf keys for one severity group */
+                const std::string &prefix /**< [in] severity-specific key prefix inserted after the device name */
+    );
+
     /// Append all active keys from one severity group to the overlay text.
     void
     appendActive( std::string                    &text,    /**< [in,out] accumulated overlay text */
@@ -110,6 +125,9 @@ class warnings : public rtimvOverlayInterface
   signals:
     /// Emit the highest currently active warning level.
     void warningLevel( rtimv::warningLevel lvl /**< [in] highest active warning severity */ );
+
+    /// Request a refresh of the warnings full-screen text overlay.
+    void textOverlayRefreshRequested( char key /**< [in] shortcut key identifying the overlay to refresh */ );
 };
 
 #endif // warnings_hpp


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "now we're on the MagAO-X repo. Let's implement dynamic updates for the warning plugin."

## Summary

This change makes the MagAO-X `warnings` rtimv plugin refresh its `w` text overlay whenever the displayed warning content changes.

Previously the overlay could go stale while still visible. In particular, if one caution, warning, or alert entry changed while other entries at the same severity remained active, the overlay list would not necessarily update until it was toggled off and back on.

## What Changed

- connected the plugin to `rtimvMainWindow`'s `textOverlayRefreshRequested(char)` slot through the existing `rtimvOverlayAccess::m_mainWindowObject`
- added cached active-key lists for cautions, warnings, and alerts
- changed `updateOverlay()` to compare the current active-key lists against the cached lists
- emit a refresh request for the `w` overlay whenever any displayed entry is added or removed
- preserved existing warning-border behavior and severity selection

## Why

The initial dynamic-refresh implementation only tracked whether each severity bucket was empty or non-empty. That was not sufficient for cases where one item changed inside a still-active severity group, for example when one caution turned off while other cautions remained on.

## User Impact

- the `w` warnings overlay now updates live when:
  - a severity group becomes active or inactive
  - an individual item is added within an already-active severity
  - an individual item is removed while other items in that severity remain active
- users no longer need to retoggle the overlay to see an accurate warning list

## Validation

- ran `clang-format` on:
  - `gui/rtimv/plugins/warnings/warnings.hpp`
  - `gui/rtimv/plugins/warnings/warnings.cpp`
- rebuilt successfully with:
  - `make -C /home/jrmales/Source/MagAOX/gui/rtimv/plugins/warnings`
