### PR TITLE
Fix zaber state propagation after homing and power-off

### DIFF
--- a/apps/zaberCtrl/tests/zaberCtrl_test.cpp
+++ b/apps/zaberCtrl/tests/zaberCtrl_test.cpp
@@ -23,6 +23,7 @@ class zaberCtrl_test : public zaberCtrl
     zaberCtrl_test( const std::string &device )
     {
         m_configName = device;
+        m_stageName  = "stage";
 
         XWCTEST_SETUP_INDI_NEW_PROP( pos );
         XWCTEST_SETUP_INDI_NEW_PROP( rawPos );
@@ -75,6 +76,12 @@ class zaberCtrl_test : public zaberCtrl
         m_movingState = movingState;
     }
 
+    /// Set the configured home-preset index for testing.
+    void setHomePresetIndex( int homePresetIndex )
+    {
+        m_homePreset = homePresetIndex;
+    }
+
     /// Track a specific preset-name alias for testing.
     int setPresetAliasIndex( int presetNameIndex )
     {
@@ -115,6 +122,30 @@ class zaberCtrl_test : public zaberCtrl
     int syncPoweredOffTelemetry()
     {
         return syncPowerOffStageTelemetry();
+    }
+
+    /// Apply a stage-state INDI update for the configured test stage.
+    int applyStageState( const std::string &stageState )
+    {
+        pcf::IndiProperty ip;
+        ip.setDevice( "stest" );
+        ip.setName( "curr_state" );
+        ip.add( pcf::IndiElement( m_stageName ) );
+        ip[m_stageName].set( stageState );
+
+        return setCallBack_m_indiP_stageState( ip );
+    }
+
+    /// Get the current FSM state.
+    stateCodes::stateCodeT fsmState()
+    {
+        return state();
+    }
+
+    /// Get the current homing bookkeeping state.
+    int homingState() const
+    {
+        return m_homingState;
     }
 
     /// Get the current logged moving state.
@@ -178,6 +209,37 @@ SCENARIO( "Power-off stage telemetry", "[zaberCtrl]" )
         REQUIRE( zct.syncPoweredOffTelemetry() == 0 );
         REQUIRE( zct.presetValue() == 0 );
         REQUIRE( zct.presetTargetValue() == 0 );
+    }
+}
+
+SCENARIO( "Homing READY transitions update the controller FSM promptly", "[zaberCtrl]" )
+{
+    zaberCtrl_test zct( "stest" );
+
+    WHEN( "homing completes without a configured post-home preset move" )
+    {
+        zct.setHomePresetIndex( -1 );
+
+        REQUIRE( zct.applyStageState( "HOMING" ) == 0 );
+        REQUIRE( zct.fsmState() == stateCodes::HOMING );
+        REQUIRE( zct.homingState() == 1 );
+
+        REQUIRE( zct.applyStageState( "READY" ) == 0 );
+        REQUIRE( zct.fsmState() == stateCodes::READY );
+        REQUIRE( zct.homingState() == 0 );
+    }
+
+    WHEN( "homing completes and a post-home preset move is still pending" )
+    {
+        zct.setHomePresetIndex( 1 );
+
+        REQUIRE( zct.applyStageState( "HOMING" ) == 0 );
+        REQUIRE( zct.fsmState() == stateCodes::HOMING );
+        REQUIRE( zct.homingState() == 1 );
+
+        REQUIRE( zct.applyStageState( "READY" ) == 0 );
+        REQUIRE( zct.fsmState() == stateCodes::HOMING );
+        REQUIRE( zct.homingState() == 2 );
     }
 }
 

--- a/apps/zaberCtrl/zaberCtrl.hpp
+++ b/apps/zaberCtrl/zaberCtrl.hpp
@@ -770,8 +770,9 @@ INDI_SETCALLBACK_DEFN( zaberCtrl, m_indiP_stageState )( const pcf::IndiProperty 
     }
     else if( sstr == "READY" )
     {
-        if( m_homingState == 0 )
+        if( m_homingState == 0 || m_homePreset < 0 )
         {
+            m_homingState = 0;
             state( stateCodes::READY );
         }
         else

--- a/apps/zaberLowLevel/tests/zaberLowLevel_test.cpp
+++ b/apps/zaberLowLevel/tests/zaberLowLevel_test.cpp
@@ -1,15 +1,17 @@
 /** \file zaberLowLevel_test.cpp
-  * \brief Catch2 tests for the zaberLowLevel app.
-  * \author Jared R. Males (jaredmales@gmail.com)
-  *
-  * History:
-  */
+ * \brief Catch2 tests for the zaberLowLevel app.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * History:
+ */
 
+#include <filesystem>
+#include <fstream>
 
-//Direct include to avoid having to link separately
+// Direct include to avoid having to link separately
 extern "C"
 {
-    #include "../za_serial.c"
+#include "../za_serial.c"
 }
 
 #include "../../../tests/catch2/catch.hpp"
@@ -24,31 +26,152 @@ namespace ZLLTEST
 
 class zaberLowLevel_test : public zaberLowLevel
 {
-
-public:
-    zaberLowLevel_test(const std::string device)
+  public:
+    /// Construct a testable low-level controller instance.
+    zaberLowLevel_test( const std::string &device )
     {
         m_configName = device;
 
-        XWCTEST_SETUP_INDI_NEW_PROP(tgt_pos);
-        XWCTEST_SETUP_INDI_NEW_PROP(tgt_relpos);
-        XWCTEST_SETUP_INDI_NEW_PROP(req_home);
-        XWCTEST_SETUP_INDI_NEW_PROP(req_halt);
-        XWCTEST_SETUP_INDI_NEW_PROP(req_ehalt);
+        XWCTEST_SETUP_INDI_NEW_PROP( tgt_pos );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_home );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_home_all );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_halt );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_ehalt );
+        XWCTEST_SETUP_INDI_NEW_PROP( knob_enable );
+        XWCTEST_SETUP_INDI_NEW_PROP( led_enable );
     }
+
+    /// Set up a single staged snapshot and INDI transport for power-off tests.
+    int setupPowerOffSnapshot( const std::string &stageName, long rawPos, bool parked, long maxPos, time_t lastHomed )
+    {
+        std::error_code ec;
+
+        m_testRoot = std::filesystem::temp_directory_path() / ( "zaberLowLevel_test_" + m_configName );
+        std::filesystem::remove_all( m_testRoot, ec );
+
+        m_basePath = m_testRoot.string();
+        m_sysPath  = ( m_testRoot / "sys" ).string();
+
+        std::filesystem::create_directories( m_testRoot / MAGAOX_driverFIFORelPath );
+        std::filesystem::create_directories( std::filesystem::path( m_sysPath ) / m_configName );
+
+        m_stages.emplace_back( this );
+        m_stages.back().name( stageName );
+        m_stages.back().serial( "serial0" );
+
+        {
+            std::ofstream stateOut( std::filesystem::path( m_sysPath ) / m_configName / stageName );
+            stateOut << rawPos << '\n' << parked << '\n' << maxPos << '\n' << lastHomed << '\n';
+        }
+
+        if( appStartup() < 0 )
+        {
+            return -1;
+        }
+
+        if( createINDIFIFOS() < 0 )
+        {
+            return -1;
+        }
+
+        m_indiDriver = new indiDriver<MagAOXAppT>( this, m_configName, "0", "0" );
+
+        return ( m_indiDriver && m_indiDriver->good() ) ? 0 : -1;
+    }
+
+    /// Read the value of a text or number element from a test property.
+    std::string propertyValue( const pcf::IndiProperty &property, const std::string &element ) const
+    {
+        return property[element].getValue();
+    }
+
+    /// Get the current-position property value for a stage.
+    std::string currPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_curr_pos, stageName );
+    }
+
+    /// Get the target-position property value for a stage.
+    std::string tgtPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_tgt_pos, stageName );
+    }
+
+    /// Get the parked-state property value for a stage.
+    std::string parkedValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_parked, stageName );
+    }
+
+    /// Get the last-homed property value for a stage.
+    std::string lastHomedValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_lastHomed, stageName );
+    }
+
+    /// Get the max-position property value for a stage.
+    std::string maxPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_max_pos, stageName );
+    }
+
+    /// Get the current-state property value for a stage.
+    std::string currStateValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_curr_state, stageName );
+    }
+
+    /// Get the warning-switch property value for a stage.
+    std::string warnValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_warn, stageName );
+    }
+
+    /// Invoke the power-off handling under test.
+    int doOnPowerOff()
+    {
+        return onPowerOff();
+    }
+
+    ~zaberLowLevel_test() noexcept
+    {
+        std::error_code ec;
+
+        delete m_indiDriver;
+        m_indiDriver = nullptr;
+        std::filesystem::remove_all( m_testRoot, ec );
+    }
+
+  private:
+    std::filesystem::path m_testRoot; ///< Temporary directory backing the test FIFOs and state snapshot.
 };
-
-//#define QUOTE(s) #s
-
 
 SCENARIO( "INDI Callbacks", "[zaberLowLevel]" )
 {
-    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, tgt_pos);
-    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, tgt_relpos);
-    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_home);
-    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_halt);
-    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_ehalt);
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, tgt_pos );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_home );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_home_all );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_halt );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, req_ehalt );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, knob_enable );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevel, led_enable );
 }
 
+SCENARIO( "Power-off INDI snapshot retains stage state", "[zaberLowLevel]" )
+{
+    zaberLowLevel_test zllt( "zlltest" );
 
-} //namespace zaberLowLevel_test
+    REQUIRE( zllt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+
+    REQUIRE( zllt.doOnPowerOff() == 0 );
+
+    REQUIRE( zllt.currPosValue( "stageA" ) == "12345" );
+    REQUIRE( zllt.tgtPosValue( "stageA" ) == "12345" );
+    REQUIRE( zllt.parkedValue( "stageA" ) == "1" );
+    REQUIRE( zllt.lastHomedValue( "stageA" ) == "77" );
+    REQUIRE( zllt.maxPosValue( "stageA" ) == "54321" );
+    REQUIRE( zllt.currStateValue( "stageA" ) == "POWEROFF" );
+    REQUIRE( zllt.warnValue( "stageA" ) == "Off" );
+}
+
+} // namespace ZLLTEST

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -770,6 +770,7 @@ int zaberLowLevel::appLogic()
                             log<software_error>( std::format( "error writing state file for {}", m_stages[i].name() ) );
                         }
 
+                        updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
                         updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "READY" ) );
                     }
                 }
@@ -902,12 +903,23 @@ inline int zaberLowLevel::onPowerOff()
 
     for( size_t i = 0; i < m_stages.size(); ++i )
     {
-        updateIfChanged( m_indiP_temp, m_stages[i].name(), std::string( "" ) );
-
         m_stages[i].onPowerOff();
 
+        // Publish the retained stage snapshot before advertising POWEROFF so
+        // subscribers can consume the last known parked/position state first.
+        updateIfChanged( m_indiP_max_pos, m_stages[i].name(), m_stages[i].maxPos() );
+        updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
+        updateIfChanged( m_indiP_lastHomed, m_stages[i].name(), m_stages[i].lastHomed() );
+        updateIfChanged( m_indiP_curr_pos, m_stages[i].name(), m_stages[i].rawPos() );
+        updateIfChanged( m_indiP_tgt_pos, m_stages[i].name(), m_stages[i].tgtPos() );
+        updateSwitchIfChanged( m_indiP_knob_enable,
+                               m_stages[i].name(),
+                               ( m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off ) );
+        updateSwitchIfChanged( m_indiP_led_enable,
+                               m_stages[i].name(),
+                               ( m_stages[i].ledEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off ) );
+        updateIfChanged( m_indiP_temp, m_stages[i].name(), std::string( "" ) );
         updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "POWEROFF" ) );
-
         updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::Off );
     }
 

--- a/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
+++ b/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
@@ -144,6 +144,38 @@ class zaberLowLevelBinary_test : public zaberLowLevelBinary
     std::filesystem::path m_testRoot; ///< Temporary directory backing the test FIFOs and state snapshot.
 };
 
+class zaberBinaryStage_test : public zaberBinaryStage<zaberLowLevelBinary_test>
+{
+  public:
+    /// Construct a test binary-stage helper.
+    zaberBinaryStage_test( zaberLowLevelBinary_test *parent ) : zaberBinaryStage<zaberLowLevelBinary_test>( parent )
+    {
+    }
+
+    /// Set the fields used to detect homing completion.
+    void setHomeState( bool homing, bool warnWR, long tgtPos, long rawPos, time_t lastHomed )
+    {
+        m_homing            = homing;
+        m_warnWR            = warnWR;
+        m_tgtPos            = tgtPos;
+        m_rawPos            = rawPos;
+        m_lastHomed.tv_sec  = lastHomed;
+        m_lastHomed.tv_nsec = 0;
+    }
+
+    /// Invoke the last-home timestamp refresh logic under test.
+    int refreshLastHomed( bool wasHoming )
+    {
+        return updateLastHomed( wasHoming );
+    }
+
+    /// Get the stored last-home seconds value.
+    time_t lastHomedSec() const
+    {
+        return m_lastHomed.tv_sec;
+    }
+};
+
 SCENARIO( "INDI Callbacks", "[zaberLowLevelBinary]" )
 {
     XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, tgt_pos );
@@ -169,6 +201,28 @@ SCENARIO( "Power-off INDI snapshot retains stage state", "[zaberLowLevelBinary]"
     REQUIRE( zllbt.maxPosValue( "stageA" ) == "54321" );
     REQUIRE( zllbt.currStateValue( "stageA" ) == "POWEROFF" );
     REQUIRE( zllbt.warnValue( "stageA" ) == "Off" );
+}
+
+SCENARIO( "Binary last-home timestamps refresh after homing completes", "[zaberLowLevelBinary]" )
+{
+    zaberLowLevelBinary_test zllbt( "zllbtest" );
+    zaberBinaryStage_test    stage( &zllbt );
+
+    WHEN( "a homing sequence completes with a stale stored timestamp" )
+    {
+        stage.setHomeState( false, false, 0, 0, 77 );
+
+        REQUIRE( stage.refreshLastHomed( true ) == 0 );
+        REQUIRE( stage.lastHomedSec() != 77 );
+    }
+
+    WHEN( "the stage is merely idle at home with an existing timestamp" )
+    {
+        stage.setHomeState( false, false, 0, 0, 77 );
+
+        REQUIRE( stage.refreshLastHomed( false ) == 0 );
+        REQUIRE( stage.lastHomedSec() == 77 );
+    }
 }
 
 } // namespace ZLLBTEST

--- a/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
+++ b/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
@@ -5,6 +5,9 @@
  * \ingroup zaberLowLevelBinary_files
  */
 
+#include <filesystem>
+#include <fstream>
+
 extern "C"
 {
 #include "../zb_serial.c"
@@ -30,17 +33,142 @@ class zaberLowLevelBinary_test : public zaberLowLevelBinary
 
         XWCTEST_SETUP_INDI_NEW_PROP( tgt_pos );
         XWCTEST_SETUP_INDI_NEW_PROP( req_home );
+        XWCTEST_SETUP_INDI_NEW_PROP( req_home_all );
         XWCTEST_SETUP_INDI_NEW_PROP( req_halt );
         XWCTEST_SETUP_INDI_NEW_PROP( req_ehalt );
+        XWCTEST_SETUP_INDI_NEW_PROP( knob_enable );
     }
+
+    /// Set up a single staged snapshot and INDI transport for power-off tests.
+    int setupPowerOffSnapshot( const std::string &stageName, long rawPos, bool parked, long maxPos, time_t lastHomed )
+    {
+        std::error_code ec;
+
+        m_testRoot = std::filesystem::temp_directory_path() / ( "zaberLowLevelBinary_test_" + m_configName );
+        std::filesystem::remove_all( m_testRoot, ec );
+
+        m_basePath = m_testRoot.string();
+        m_sysPath  = ( m_testRoot / "sys" ).string();
+
+        std::filesystem::create_directories( m_testRoot / MAGAOX_driverFIFORelPath );
+        std::filesystem::create_directories( std::filesystem::path( m_sysPath ) / m_configName );
+
+        m_stages.emplace_back( this );
+        m_stages.back().name( stageName );
+        m_stages.back().serial( "serial0" );
+
+        {
+            std::ofstream stateOut( std::filesystem::path( m_sysPath ) / m_configName / stageName );
+            stateOut << rawPos << '\n' << parked << '\n' << maxPos << '\n' << lastHomed << '\n';
+        }
+
+        if( appStartup() < 0 )
+        {
+            return -1;
+        }
+
+        if( createINDIFIFOS() < 0 )
+        {
+            return -1;
+        }
+
+        m_indiDriver = new indiDriver<MagAOXAppT>( this, m_configName, "0", "0" );
+
+        return ( m_indiDriver && m_indiDriver->good() ) ? 0 : -1;
+    }
+
+    /// Read the value of a text, number, or switch element from a test property.
+    std::string propertyValue( const pcf::IndiProperty &property, const std::string &element ) const
+    {
+        return property[element].getValue();
+    }
+
+    /// Get the current-position property value for a stage.
+    std::string currPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_curr_pos, stageName );
+    }
+
+    /// Get the target-position property value for a stage.
+    std::string tgtPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_tgt_pos, stageName );
+    }
+
+    /// Get the parked-state property value for a stage.
+    std::string parkedValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_parked, stageName );
+    }
+
+    /// Get the last-homed property value for a stage.
+    std::string lastHomedValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_lastHomed, stageName );
+    }
+
+    /// Get the max-position property value for a stage.
+    std::string maxPosValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_max_pos, stageName );
+    }
+
+    /// Get the current-state property value for a stage.
+    std::string currStateValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_curr_state, stageName );
+    }
+
+    /// Get the warning-switch property value for a stage.
+    std::string warnValue( const std::string &stageName ) const
+    {
+        return propertyValue( m_indiP_warn, stageName );
+    }
+
+    /// Invoke the power-off handling under test.
+    int doOnPowerOff()
+    {
+        return onPowerOff();
+    }
+
+    ~zaberLowLevelBinary_test() noexcept
+    {
+        std::error_code ec;
+
+        delete m_indiDriver;
+        m_indiDriver = nullptr;
+        std::filesystem::remove_all( m_testRoot, ec );
+    }
+
+  private:
+    std::filesystem::path m_testRoot; ///< Temporary directory backing the test FIFOs and state snapshot.
 };
 
 SCENARIO( "INDI Callbacks", "[zaberLowLevelBinary]" )
 {
     XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, tgt_pos );
     XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_home );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_home_all );
     XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_halt );
     XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, req_ehalt );
+    XWCTEST_INDI_NEW_CALLBACK( zaberLowLevelBinary, knob_enable );
+}
+
+SCENARIO( "Power-off INDI snapshot retains stage state", "[zaberLowLevelBinary]" )
+{
+    zaberLowLevelBinary_test zllbt( "zllbtest" );
+
+    REQUIRE( zllbt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+
+    REQUIRE( zllbt.doOnPowerOff() == 0 );
+
+    REQUIRE( zllbt.currPosValue( "stageA" ) == "12345" );
+    REQUIRE( zllbt.tgtPosValue( "stageA" ) == "12345" );
+    REQUIRE( zllbt.parkedValue( "stageA" ) == "1" );
+    REQUIRE( zllbt.lastHomedValue( "stageA" ) == "77" );
+    REQUIRE( zllbt.maxPosValue( "stageA" ) == "54321" );
+    REQUIRE( zllbt.currStateValue( "stageA" ) == "POWEROFF" );
+    REQUIRE( zllbt.warnValue( "stageA" ) == "Off" );
 }
 
 } // namespace ZLLBTEST

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -304,7 +304,7 @@ class zaberBinaryStage
     int getParked( z_port port /**< [in] the port with which to communicate */ );
 
     /// Get the knob enabled status
-    int getKnob( z_port port  /**< [in] the port with which to communicate */ );
+    int getKnob( z_port port /**< [in] the port with which to communicate */ );
 
     /// Update the current position and derived motion state.
     int updatePos( z_port port /**< [in] the port with which to communicate */ );
@@ -355,6 +355,9 @@ class zaberBinaryStage
 
     /// Refresh warning-equivalent state from firmware 5.xx information.
     int getWarnings( z_port port /**< [in] the port with which to communicate */ );
+
+    /// Refresh the stored last-home timestamp when a home completion is detected.
+    int updateLastHomed( bool wasHoming /**< [in] whether the stage was homing before the latest status refresh */ );
 
     /// Clear transient state on power-off.
     int onPowerOff();
@@ -745,7 +748,7 @@ int zaberBinaryStage<parentT>::getParked( z_port )
 }
 
 template <class parentT>
-int zaberBinaryStage<parentT>::getKnob( z_port port)
+int zaberBinaryStage<parentT>::getKnob( z_port port )
 {
     int32_t value;
     int     rv = getSetting( value, port, cmdSetDeviceMode );
@@ -753,14 +756,16 @@ int zaberBinaryStage<parentT>::getKnob( z_port port)
     {
         return rv;
     }
-    m_knobEnabled = !(value & modeDisablePotentiometer);
-    
+    m_knobEnabled = !( value & modeDisablePotentiometer );
+
     return 0;
 }
 
 template <class parentT>
 int zaberBinaryStage<parentT>::updatePos( z_port port )
 {
+    bool wasHoming = m_homing;
+
     int32_t status;
     int     rv = queryCommand( status, port, cmdReturnStatus, 0, cmdReturnStatus );
     if( rv < 0 )
@@ -788,16 +793,13 @@ int zaberBinaryStage<parentT>::updatePos( z_port port )
 
     m_rawPos = pos;
 
-    if( status == 0 && m_homing == false && m_warnWR == false && m_tgtPos == 0 && m_rawPos == 0 &&
-        m_lastHomed.tv_sec == 0 )
+    rv = getWarnings( port );
+    if( rv < 0 )
     {
-        if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
-        {
-            MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
-        }
+        return rv;
     }
 
-    return getWarnings( port );
+    return updateLastHomed( wasHoming );
 }
 
 template <class parentT>
@@ -818,15 +820,16 @@ int zaberBinaryStage<parentT>::enableKnob( z_port port, bool enable )
     }
 
     mode |= modeDisableAutoReply;
-    if (enable) mode &= ~modeDisablePotentiometer;  // clear the bit to enable
-    else mode |= modeDisablePotentiometer;   // set the bit to disable
+    if( enable )
+        mode &= ~modeDisablePotentiometer; // clear the bit to enable
+    else
+        mode |= modeDisablePotentiometer; // set the bit to disable
 
     rv = sendCommandNoReply( port, cmdSetDeviceMode, mode );
     if( rv < 0 )
     {
         return rv;
     }
-
 
     int32_t appliedMode;
     rv = getSetting( appliedMode, port, cmdSetDeviceMode );
@@ -835,14 +838,13 @@ int zaberBinaryStage<parentT>::enableKnob( z_port port, bool enable )
         return rv;
     }
 
-    bool knobOk = enable
-        ? !(appliedMode & modeDisablePotentiometer)   // bit should be 0
-        :  (appliedMode & modeDisablePotentiometer);  // bit should be 1
+    bool knobOk = enable ? !( appliedMode & modeDisablePotentiometer ) // bit should be 0
+                         : ( appliedMode & modeDisablePotentiometer ); // bit should be 1
 
-    if (!knobOk || !(appliedMode & modeDisableAutoReply))
+    if( !knobOk || !( appliedMode & modeDisableAutoReply ) )
     {
         return MagAOXAppT::log<software_error, -1>(
-            std::format("device {} did not apply requested device mode {}, got {}", m_name, mode, appliedMode));
+            std::format( "device {} did not apply requested device mode {}, got {}", m_name, mode, appliedMode ) );
     }
 
     return 0;
@@ -1095,11 +1097,17 @@ int zaberBinaryStage<parentT>::getWarnings( z_port port )
         m_warnWR = true;
     }
 
-    if( m_warnWR == false && m_homing == false && m_tgtPos == 0 && m_rawPos == 0 && m_lastHomed.tv_sec == 0 )
+    return 0;
+}
+
+template <class parentT>
+int zaberBinaryStage<parentT>::updateLastHomed( bool wasHoming )
+{
+    if( !m_homing && !m_warnWR && m_tgtPos == 0 && m_rawPos == 0 && ( wasHoming || m_lastHomed.tv_sec == 0 ) )
     {
-        if( clock_gettime( CLOCK_REALTIME, &m_lastHomed ) < 0 )
+        if( clock_gettime( CLOCK_ISIO, &m_lastHomed ) < 0 )
         {
-            MagAOXAppT::log<software_error>( { errno, 0, "clock_gettime for last homed" } );
+            return MagAOXAppT::log<software_error, -1>( { errno, 0, "clock_gettime for last homed" } );
         }
     }
 

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -559,7 +559,8 @@ int zaberLowLevelBinary::appStartup()
         m_indiP_parked[m_stages[n].name()].set( m_stages[n].parked() );
         m_indiP_lastHomed[m_stages[n].name()].set( m_stages[n].lastHomed() );
         m_indiP_max_pos[m_stages[n].name()].set( m_stages[n].maxPos() );
-        m_indiP_knob_enable[m_stages[n].name()].set( m_stages[n].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off );
+        m_indiP_knob_enable[m_stages[n].name()].set( m_stages[n].knobEnabled() ? pcf::IndiElement::On
+                                                                               : pcf::IndiElement::Off );
     }
 
     return 0;
@@ -764,11 +765,9 @@ int zaberLowLevelBinary::appLogic()
             updateIfChanged( m_indiP_curr_pos, m_stages[i].name(), m_stages[i].rawPos() );
             updateIfChanged( m_indiP_tgt_pos, m_stages[i].name(), m_stages[i].tgtPos() );
 
-            updateSwitchIfChanged( 
-                m_indiP_knob_enable, 
-                m_stages[i].name(), 
-                m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off 
-            );
+            updateSwitchIfChanged( m_indiP_knob_enable,
+                                   m_stages[i].name(),
+                                   m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off );
 
             if( m_stages[i].deviceStatus() == 'B' )
             {
@@ -920,8 +919,19 @@ inline int zaberLowLevelBinary::onPowerOff()
     std::lock_guard<std::mutex> lock( m_indiMutex );
     for( size_t i = 0; i < m_stages.size(); ++i )
     {
-        updateIfChanged( m_indiP_temp, m_stages[i].name(), std::string( "" ) );
         m_stages[i].onPowerOff();
+
+        // Publish the retained stage snapshot before advertising POWEROFF so
+        // subscribers can consume the last known parked/position state first.
+        updateIfChanged( m_indiP_max_pos, m_stages[i].name(), m_stages[i].maxPos() );
+        updateIfChanged( m_indiP_parked, m_stages[i].name(), m_stages[i].parked() );
+        updateIfChanged( m_indiP_lastHomed, m_stages[i].name(), m_stages[i].lastHomed() );
+        updateIfChanged( m_indiP_curr_pos, m_stages[i].name(), m_stages[i].rawPos() );
+        updateIfChanged( m_indiP_tgt_pos, m_stages[i].name(), m_stages[i].tgtPos() );
+        updateSwitchIfChanged( m_indiP_knob_enable,
+                               m_stages[i].name(),
+                               ( m_stages[i].knobEnabled() ? pcf::IndiElement::On : pcf::IndiElement::Off ) );
+        updateIfChanged( m_indiP_temp, m_stages[i].name(), std::string( "" ) );
         updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "POWEROFF" ) );
         updateIfChanged( m_indiP_warn, m_stages[i].name(), pcf::IndiElement::Off );
     }
@@ -1185,12 +1195,12 @@ INDI_NEWCALLBACK_DEFN( zaberLowLevelBinary, m_indiP_knob_enable )( const pcf::In
     {
         return log<software_error, -1>( "no valid stage specified in req_knob, rejecting request" );
     }
-    
+
     bool enable_knob = ipRecv[m_stages[stageno].name()].getSwitchState() == pcf::IndiElement::On;
-    
+
     std::lock_guard<std::mutex> guard( m_indiMutex );
 
-    if( m_stages[stageno].enableKnob(m_port, enable_knob) < 0 )
+    if( m_stages[stageno].enableKnob( m_port, enable_knob ) < 0 )
     {
         return log<software_error, -1>( std::format( "error from enable knob for {}", m_stages[stageno].name() ) );
     }


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to the prompt: "Investigate zaberLowLevel/zaberCtrl INDI notification delays, especially powered-off stages, HOMING fsm.state lag, and binary last_homed issues; fix and apply similar fixes to zaberLowLevelBinary."

## Summary

- fix delayed `fsm.state` transitions in the `zaberLowLevel` + `zaberCtrl` path after homing
- publish retained stage snapshot data before `POWEROFF` in both `zaberLowLevel` and `zaberLowLevelBinary`
- refresh binary `last_homed` timestamps when a homing sequence actually completes instead of leaving stale persisted values in place
- add regression coverage for the low-level power-off snapshot paths and the `zaberCtrl` homing transition logic

## Root Cause

There were three separate issues contributing to stale or delayed high-level stage state:

1. `zaberCtrl` could remain in `HOMING` after receiving the first `READY` from the low-level app when no post-home preset move was configured, effectively waiting for a second `READY` that never arrived.
2. `zaberLowLevel` only republished a narrow subset of properties during `onPowerOff()`, so consumers could enter `POWEROFF` with stale parked/position context until a later subscription refresh.
3. The binary low-level implementation treated `last_homed` like a one-time initializer, so an old value loaded from disk could persist across later successful homes.

## User and Developer Impact

- `zaberCtrl.fsm.state` updates propagate promptly out of `HOMING` when homing completes without a follow-on preset move.
- consumers of both low-level Zaber apps receive consistent retained state during powered-off transitions, reducing lag and stale metadata.
- binary-protocol stages now refresh `last_homed` after successful homing, matching the expected behavior of the ASCII path.

## Validation

- `clang-format -i apps/zaberCtrl/zaberCtrl.hpp apps/zaberCtrl/tests/zaberCtrl_test.cpp apps/zaberLowLevel/zaberLowLevel.hpp apps/zaberLowLevel/tests/zaberLowLevel_test.cpp apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp apps/zaberLowLevelBinary/zaberBinaryStage.hpp apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp`
- `make -C apps/zaberCtrl`
- `make -C apps/zaberLowLevel`
- `make -C apps/zaberLowLevelBinary`
- compiled updated test translation units for `zaberCtrl`, `zaberLowLevel`, and `zaberLowLevelBinary`
