### PR TITLE
Harden acquisition overlay lifetime and INDI dictionary updates

### DIFF
--- a/gui/rtimv/plugins/acquisition/acquisition.cpp
+++ b/gui/rtimv/plugins/acquisition/acquisition.cpp
@@ -109,6 +109,38 @@ int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurato
              m_roa.m_mainWindowObject,
              SLOT( addStretchCircle( StretchCircle * ) ) );
 
+    {
+        std::lock_guard<std::mutex> guard( m_starCircleMutex );
+
+        m_starCircles.resize( c_maxTrackedStars, nullptr );
+        m_starLabels.resize( c_maxTrackedStars, nullptr );
+
+        for( size_t n = 0; n < c_maxTrackedStars; ++n )
+        {
+            // Pre-create the full bounded overlay set so delayed INDI updates only
+            // show and hide items instead of tearing down Qt objects mid-stream.
+            m_starCircles[n] = new StretchCircle;
+            m_starCircles[n]->setPenColor( m_color.c_str() );
+            m_starCircles[n]->setPenWidth( 0 );
+            m_starCircles[n]->setVisible( false );
+            m_starCircles[n]->setStretchable( false );
+            m_starCircles[n]->setRemovable( false );
+            connect( m_starCircles[n],
+                     SIGNAL( remove( StretchCircle * ) ),
+                     this,
+                     SLOT( stretchCircleRemove( StretchCircle * ) ) );
+            emit newStretchCircle( m_starCircles[n] );
+
+            m_starLabels[n] = new QTextEdit( m_roa.m_graphicsView );
+            QFont qf        = m_starLabels[n]->currentFont();
+            qf.setPixelSize( m_fontSize );
+            m_starLabels[n]->setCurrentFont( qf );
+            m_starLabels[n]->setVisible( false );
+            m_starLabels[n]->setTextColor( m_color.c_str() );
+            m_roa.m_graphicsView->textEditSetup( m_starLabels[n] );
+        }
+    }
+
     if( m_enabled )
         enableOverlay();
     else
@@ -220,48 +252,13 @@ int acquisition::updateOverlay()
 
     size_t nstars = std::min( static_cast<size_t>( rawStarCount ), c_maxTrackedStars );
 
-    if( m_nStars != nstars )
-    {
-        m_nStars = nstars;
-
-        std::lock_guard<std::mutex> guard( m_starCircleMutex );
-        clearStarOverlays( m_starCircles, m_starLabels );
-
-        m_starCircles.resize( m_nStars, nullptr );
-        m_starLabels.resize( m_nStars, nullptr );
-
-        for( size_t n = 0; n < m_nStars; ++n )
-        {
-            // create circle
-            m_starCircles[n] = new StretchCircle;
-            m_starCircles[n]->setPenColor( m_color.c_str() );
-            m_starCircles[n]->setPenWidth( 0 );
-            m_starCircles[n]->setVisible( false );
-            m_starCircles[n]->setStretchable( false );
-            m_starCircles[n]->setRemovable( false );
-            connect( m_starCircles[n],
-                     SIGNAL( remove( StretchCircle * ) ),
-                     this,
-                     SLOT( stretchCircleRemove( StretchCircle * ) ) );
-            emit newStretchCircle( m_starCircles[n] );
-
-            // create label
-            m_starLabels[n] = new QTextEdit( m_roa.m_graphicsView );
-            QFont qf;
-            qf = m_starLabels[n]->currentFont();
-            qf.setPixelSize( m_fontSize );
-            m_starLabels[n]->setCurrentFont( qf );
-            m_starLabels[n]->setVisible( false );
-            m_starLabels[n]->setTextColor( m_color.c_str() );
-            m_roa.m_graphicsView->textEditSetup( m_starLabels[n] );
-        }
-    }
+    m_nStars = nstars;
 
     if( m_width <= 0 || m_height <= 0 )
     {
         std::lock_guard<std::mutex> guard( m_starCircleMutex );
 
-        for( size_t n = 0; n < m_nStars; ++n )
+        for( size_t n = 0; n < m_starCircles.size(); ++n )
         {
             hideStarOverlay( m_starCircles[n], m_starLabels[n] );
         }
@@ -269,17 +266,8 @@ int acquisition::updateOverlay()
         return 0;
     }
 
-    std::vector<float> xs( m_nStars, -1 );
-    std::vector<float> ys( m_nStars, -1 );
-
-    for( size_t n = 0; n < m_nStars; ++n )
+    for( size_t n = 0; n < m_starCircles.size(); ++n )
     {
-        std::string star = "star_" + std::to_string( n );
-
-        xs[n] = getBlobVal<float>( star + ".x", -1 );
-        ys[n] = getBlobVal<float>( star + ".y", -1 );
-
-        // Now for each valid star position, set up the overlay
         std::lock_guard<std::mutex> guard( m_starCircleMutex );
 
         StretchCircle *sc = m_starCircles[n];
@@ -290,11 +278,22 @@ int acquisition::updateOverlay()
             continue;
         }
 
-        if( xs[n] >= 0 && ys[n] >= 0 )
+        if( n >= m_nStars )
+        {
+            hideStarOverlay( sc, te );
+            continue;
+        }
+
+        std::string star = "star_" + std::to_string( n );
+
+        float x = getBlobVal<float>( star + ".x", -1 );
+        float y = getBlobVal<float>( star + ".y", -1 );
+
+        if( x >= 0 && y >= 0 )
         {
             // Move the circle
-            float xc = xs[n] - 0.5 * ( m_circRad );
-            float yc = ( m_height - ys[n] ) - 0.5 * ( m_circRad );
+            float xc = x - 0.5 * ( m_circRad );
+            float yc = ( m_height - y ) - 0.5 * ( m_circRad );
 
             sc->setRect( xc, yc, m_circRad, m_circRad );
             sc->setVisible( true );

--- a/gui/rtimv/plugins/acquisition/acquisition.cpp
+++ b/gui/rtimv/plugins/acquisition/acquisition.cpp
@@ -25,7 +25,8 @@ void hideStarOverlay( StretchCircle *sc, QTextEdit *te )
     }
 }
 
-void clearStarOverlays( std::vector<StretchCircle *> &starCircles, std::vector<QTextEdit *> &starLabels )
+void clearStarOverlays( std::vector<QPointer<StretchCircle>> &starCircles,
+                        std::vector<QPointer<QTextEdit>>     &starLabels )
 {
     for( size_t s = 0; s < starCircles.size(); ++s )
     {
@@ -57,6 +58,39 @@ acquisition::~acquisition()
 {
     std::lock_guard<std::mutex> guard( m_starCircleMutex );
     clearStarOverlays( m_starCircles, m_starLabels );
+}
+
+void acquisition::ensureStarOverlay( size_t n )
+{
+    if( n >= m_starCircles.size() || n >= m_starLabels.size() )
+    {
+        return;
+    }
+
+    if( m_starCircles[n].isNull() )
+    {
+        StretchCircle *sc = new StretchCircle;
+        sc->setPenColor( m_color.c_str() );
+        sc->setPenWidth( 0 );
+        sc->setVisible( false );
+        sc->setStretchable( false );
+        sc->setRemovable( false );
+        connect( sc, SIGNAL( remove( StretchCircle * ) ), this, SLOT( stretchCircleRemove( StretchCircle * ) ) );
+        emit newStretchCircle( sc );
+        m_starCircles[n] = sc;
+    }
+
+    if( m_starLabels[n].isNull() )
+    {
+        QTextEdit *te = new QTextEdit( m_roa.m_graphicsView );
+        QFont      qf = te->currentFont();
+        qf.setPixelSize( m_fontSize );
+        te->setCurrentFont( qf );
+        te->setVisible( false );
+        te->setTextColor( m_color.c_str() );
+        m_roa.m_graphicsView->textEditSetup( te );
+        m_starLabels[n] = te;
+    }
 }
 
 int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &config )
@@ -119,25 +153,7 @@ int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurato
         {
             // Pre-create the full bounded overlay set so delayed INDI updates only
             // show and hide items instead of tearing down Qt objects mid-stream.
-            m_starCircles[n] = new StretchCircle;
-            m_starCircles[n]->setPenColor( m_color.c_str() );
-            m_starCircles[n]->setPenWidth( 0 );
-            m_starCircles[n]->setVisible( false );
-            m_starCircles[n]->setStretchable( false );
-            m_starCircles[n]->setRemovable( false );
-            connect( m_starCircles[n],
-                     SIGNAL( remove( StretchCircle * ) ),
-                     this,
-                     SLOT( stretchCircleRemove( StretchCircle * ) ) );
-            emit newStretchCircle( m_starCircles[n] );
-
-            m_starLabels[n] = new QTextEdit( m_roa.m_graphicsView );
-            QFont qf        = m_starLabels[n]->currentFont();
-            qf.setPixelSize( m_fontSize );
-            m_starLabels[n]->setCurrentFont( qf );
-            m_starLabels[n]->setVisible( false );
-            m_starLabels[n]->setTextColor( m_color.c_str() );
-            m_roa.m_graphicsView->textEditSetup( m_starLabels[n] );
+            ensureStarOverlay( n );
         }
     }
 
@@ -270,6 +286,8 @@ int acquisition::updateOverlay()
     {
         std::lock_guard<std::mutex> guard( m_starCircleMutex );
 
+        ensureStarOverlay( n );
+
         StretchCircle *sc = m_starCircles[n];
         QTextEdit     *te = m_starLabels[n];
 
@@ -375,26 +393,16 @@ void acquisition::disableOverlay()
 
 void acquisition::stretchCircleRemove( StretchCircle *sb )
 {
-    static_cast<void>( sb );
-    /*
-    std::cerr << "acquisition::stretchBoxRemove 1\n";
-    std::lock_guard<std::mutex> guard(m_roiBoxMutex);
-    if(!m_roiBox)
+    std::lock_guard<std::mutex> guard( m_starCircleMutex );
+
+    for( size_t n = 0; n < m_starCircles.size(); ++n )
     {
-        return;
+        if( m_starCircles[n] == sb )
+        {
+            m_starCircles[n] = nullptr;
+            return;
+        }
     }
-
-    std::cerr << "acquisition::stretchBoxRemove 2\n";
-
-    if(sb != m_roiBox)
-    {
-        return;
-    }
-
-    std::cerr << "acquisition::stretchBoxRemove 3\n";
-
-    m_roiBox = nullptr;
-    */
 }
 
 std::vector<std::string> acquisition::info()

--- a/gui/rtimv/plugins/acquisition/acquisition.cpp
+++ b/gui/rtimv/plugins/acquisition/acquisition.cpp
@@ -1,7 +1,53 @@
+/** \file acquisition.cpp
+ * \brief Implements the acquisition overlay for detected-star annotations.
+ */
 
 #include "acquisition.hpp"
 
+#include <algorithm>
+
 #define errPrint( expl ) std::cerr << "acquisition: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
+
+namespace
+{
+constexpr size_t c_maxTrackedStars{ 128 };
+
+void hideStarOverlay( StretchCircle *sc, QTextEdit *te )
+{
+    if( sc != nullptr )
+    {
+        sc->setVisible( false );
+    }
+
+    if( te != nullptr )
+    {
+        te->setVisible( false );
+    }
+}
+
+void clearStarOverlays( std::vector<StretchCircle *> &starCircles, std::vector<QTextEdit *> &starLabels )
+{
+    for( size_t s = 0; s < starCircles.size(); ++s )
+    {
+        if( starCircles[s] != nullptr )
+        {
+            starCircles[s]->remove();
+        }
+    }
+
+    for( size_t s = 0; s < starLabels.size(); ++s )
+    {
+        if( starLabels[s] != nullptr )
+        {
+            starLabels[s]->setVisible( false );
+            starLabels[s]->deleteLater();
+        }
+    }
+
+    starCircles.clear();
+    starLabels.clear();
+}
+} // namespace
 
 acquisition::acquisition() : rtimvOverlayInterface()
 {
@@ -9,6 +55,8 @@ acquisition::acquisition() : rtimvOverlayInterface()
 
 acquisition::~acquisition()
 {
+    std::lock_guard<std::mutex> guard( m_starCircleMutex );
+    clearStarOverlays( m_starCircles, m_starLabels );
 }
 
 int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurator &config )
@@ -20,14 +68,14 @@ int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurato
 
     if( m_deviceName == "" )
     {
-        pluginLogInfo("not configured");
+        pluginLogInfo( "not configured" );
 
         m_enableable = false;
         disableOverlay();
         return 1; // Tell rtimv to unload me since not configured.
     }
 
-    pluginLogInfo(std::format("enabling for {}", m_deviceName));
+    pluginLogInfo( std::format( "enabling for {}", m_deviceName ) );
 
     config.configUnused( m_cameraName, mx::app::iniFile::makeKey( "acquisition", "camera" ) );
     config.configUnused( m_circRad, mx::app::iniFile::makeKey( "acquisition", "radius" ) );
@@ -35,20 +83,25 @@ int acquisition::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurato
     config.configUnused( m_fontSize, mx::app::iniFile::makeKey( "acquisition", "fontSize" ) );
 
     m_enableable = true;
-    m_enabled = true;
+    m_enabled    = true;
 
     if( m_roa.m_dictionary != nullptr )
     {
-        // Register these
+        // Register the camera size and a bounded number of star properties up front
+        // so remote update jitter cannot force runtime growth of the shared dictionary.
         ( *m_roa.m_dictionary )[m_cameraName + ".fg_frameSize.width"].setBlob( nullptr, 0 );
         ( *m_roa.m_dictionary )[m_cameraName + ".fg_frameSize.height"].setBlob( nullptr, 0 );
         ( *m_roa.m_dictionary )[m_deviceName + ".num_stars.current"].setBlob( nullptr, 0 );
-        /*( *m_roa.m_dictionary )[m_deviceName + ".star_0.x"].setBlob( nullptr, 0 );
-        ( *m_roa.m_dictionary )[m_deviceName + ".star_0.y"].setBlob( nullptr, 0 );
-        ( *m_roa.m_dictionary )[m_deviceName + ".star_1.x"].setBlob( nullptr, 0 );
-        ( *m_roa.m_dictionary )[m_deviceName + ".star_1.y"].setBlob( nullptr, 0 );*/
 
-        //(*m_roa.m_dictionary)[m_deviceName + ""].setBlob(nullptr, 0);
+        for( size_t n = 0; n < c_maxTrackedStars; ++n )
+        {
+            std::string star = ".star_" + std::to_string( n );
+
+            ( *m_roa.m_dictionary )[m_deviceName + star + ".x"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_deviceName + star + ".y"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_deviceName + star + ".peak"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_deviceName + star + ".fwhm"].setBlob( nullptr, 0 );
+        }
     }
 
     connect( this,
@@ -155,53 +208,31 @@ int acquisition::updateOverlay()
     if( m_roa.m_graphicsView == nullptr )
         return 0;
 
-    std::string sstr;
-
     // Get curr size
-    m_width = getBlobVal<int>( m_cameraName, "fg_frameSize.width", -1 );
+    m_width  = getBlobVal<int>( m_cameraName, "fg_frameSize.width", -1 );
     m_height = getBlobVal<int>( m_cameraName, "fg_frameSize.height", -1 );
 
-    size_t nstars = getBlobVal<int>("num_stars.current", 0);
+    int rawStarCount = getBlobVal<int>( "num_stars.current", 0 );
+    if( rawStarCount < 0 )
+    {
+        rawStarCount = 0;
+    }
 
-    if(m_nStars != nstars)
+    size_t nstars = std::min( static_cast<size_t>( rawStarCount ), c_maxTrackedStars );
+
+    if( m_nStars != nstars )
     {
         m_nStars = nstars;
-        for( size_t n = 0; n < m_nStars; ++n )
-        {
-            std::string star = ".star_" + std::to_string( n );
-
-            ( *m_roa.m_dictionary )[m_deviceName + star + ".x"].setBlob( nullptr, 0 );
-            ( *m_roa.m_dictionary )[m_deviceName + star + ".y"].setBlob( nullptr, 0 );
-            ( *m_roa.m_dictionary )[m_deviceName + star + ".peak"].setBlob( nullptr, 0 );
-            ( *m_roa.m_dictionary )[m_deviceName + star + ".fwhm"].setBlob( nullptr, 0 );
-        }
 
         std::lock_guard<std::mutex> guard( m_starCircleMutex );
-
-        //deallocate circles
-        for( size_t s = 0; s < m_starCircles.size(); ++s )
-        {
-            if( m_starCircles[s] != nullptr )
-            {
-                m_starCircles[s]->remove();
-            }
-        }
-
-        //deallocate labels
-        for( size_t s = 0; s < m_starLabels.size(); ++s )
-        {
-            if( m_starLabels[s] != nullptr )
-            {
-                m_starLabels[s]->deleteLater();
-            }
-        }
+        clearStarOverlays( m_starCircles, m_starLabels );
 
         m_starCircles.resize( m_nStars, nullptr );
         m_starLabels.resize( m_nStars, nullptr );
 
         for( size_t n = 0; n < m_nStars; ++n )
         {
-            //create circle
+            // create circle
             m_starCircles[n] = new StretchCircle;
             m_starCircles[n]->setPenColor( m_color.c_str() );
             m_starCircles[n]->setPenWidth( 0 );
@@ -214,7 +245,7 @@ int acquisition::updateOverlay()
                      SLOT( stretchCircleRemove( StretchCircle * ) ) );
             emit newStretchCircle( m_starCircles[n] );
 
-            //create label
+            // create label
             m_starLabels[n] = new QTextEdit( m_roa.m_graphicsView );
             QFont qf;
             qf = m_starLabels[n]->currentFont();
@@ -222,8 +253,20 @@ int acquisition::updateOverlay()
             m_starLabels[n]->setCurrentFont( qf );
             m_starLabels[n]->setVisible( false );
             m_starLabels[n]->setTextColor( m_color.c_str() );
-            m_roa.m_graphicsView->textEditSetup(m_starLabels[n]);
+            m_roa.m_graphicsView->textEditSetup( m_starLabels[n] );
         }
+    }
+
+    if( m_width <= 0 || m_height <= 0 )
+    {
+        std::lock_guard<std::mutex> guard( m_starCircleMutex );
+
+        for( size_t n = 0; n < m_nStars; ++n )
+        {
+            hideStarOverlay( m_starCircles[n], m_starLabels[n] );
+        }
+
+        return 0;
     }
 
     std::vector<float> xs( m_nStars, -1 );
@@ -236,41 +279,50 @@ int acquisition::updateOverlay()
         xs[n] = getBlobVal<float>( star + ".x", -1 );
         ys[n] = getBlobVal<float>( star + ".y", -1 );
 
-        //Now for each valid star position, set up the overlay
-        if( xs[n] >= 0 && ys[n] >= 0)
+        // Now for each valid star position, set up the overlay
+        std::lock_guard<std::mutex> guard( m_starCircleMutex );
+
+        StretchCircle *sc = m_starCircles[n];
+        QTextEdit     *te = m_starLabels[n];
+
+        if( sc == nullptr || te == nullptr )
         {
-            std::lock_guard<std::mutex> guard( m_starCircleMutex );
+            continue;
+        }
 
-            StretchCircle *sc = m_starCircles[n]; //Just for convenience
-            QTextEdit * te = m_starLabels[n];
-
-            //Move the circle
+        if( xs[n] >= 0 && ys[n] >= 0 )
+        {
+            // Move the circle
             float xc = xs[n] - 0.5 * ( m_circRad );
             float yc = ( m_height - ys[n] ) - 0.5 * ( m_circRad );
 
             sc->setRect( xc, yc, m_circRad, m_circRad );
             sc->setVisible( true );
 
-            //Format the number
+            // Format the number
             char tmp[32];
             snprintf( tmp, sizeof( tmp ), "%ld", n );
             te->setText( tmp );
 
-            //Set size based on the font size
-            QFontMetrics fm(te->currentFont());
-            QSize textSize = fm.size(0, tmp);
-            te->resize( textSize.width()+5,textSize.height()+5 );
+            // Set size based on the font size
+            QFontMetrics fm( te->currentFont() );
+            QSize        textSize = fm.size( 0, tmp );
+            te->resize( textSize.width() + 5, textSize.height() + 5 );
 
-            //Place the number
-            //Take scene coordinates to viewport coordinates.
-            QRectF sbr = sc->sceneBoundingRect();
-            float qpf_x = sbr.x() + sc->rect().width() * 0.5 - sc->radius();
-            float qpf_y = sbr.y() + sc->rect().height() * 0.5 - sc->radius();
-            QPoint qr = m_roa.m_graphicsView->mapFromScene(QPointF( qpf_x , qpf_y ));
+            // Place the number
+            // Take scene coordinates to viewport coordinates.
+            QRectF sbr   = sc->sceneBoundingRect();
+            float  qpf_x = sbr.x() + sc->rect().width() * 0.5 - sc->radius();
+            float  qpf_y = sbr.y() + sc->rect().height() * 0.5 - sc->radius();
+            QPoint qr    = m_roa.m_graphicsView->mapFromScene( QPointF( qpf_x, qpf_y ) );
 
             te->move( qr.x(), qr.y() );
 
             te->setVisible( true );
+        }
+        else
+        {
+            hideStarOverlay( sc, te );
         }
     }
 
@@ -279,6 +331,11 @@ int acquisition::updateOverlay()
 
 void acquisition::keyPressEvent( QKeyEvent *ke )
 {
+    if( ke == nullptr || ke->text().isEmpty() )
+    {
+        return;
+    }
+
     char key = ke->text()[0].toLatin1();
 
     if( key == 'A' )
@@ -307,17 +364,11 @@ void acquisition::enableOverlay()
 
 void acquisition::disableOverlay()
 {
+    std::lock_guard<std::mutex> guard( m_starCircleMutex );
+
     for( size_t n = 0; n < m_nStars; ++n )
     {
-        if(m_starCircles[n] != nullptr)
-        {
-            m_starCircles[n]->setVisible(false);
-        }
-        if(m_starLabels[n] != nullptr)
-        {
-            m_starLabels[n]->setVisible(false);
-        }
-
+        hideStarOverlay( m_starCircles[n], m_starLabels[n] );
     }
 
     m_enabled = false;

--- a/gui/rtimv/plugins/acquisition/acquisition.hpp
+++ b/gui/rtimv/plugins/acquisition/acquisition.hpp
@@ -1,3 +1,7 @@
+/** \file acquisition.hpp
+ * \brief Declares the acquisition overlay for detected-star annotations.
+ */
+
 #ifndef acquisition_hpp
 #define acquisition_hpp
 
@@ -5,6 +9,7 @@
 #include <rtimv/StretchBox.hpp>
 
 #include <QObject>
+#include <QPointer>
 #include <QtPlugin>
 #include <QTextEdit>
 // #include <QGraphicsLineItem>
@@ -14,88 +19,112 @@
 class acquisition : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
-    Q_INTERFACES(rtimvOverlayInterface)
+    Q_PLUGIN_METADATA( IID "rtimv.overlayInterface/1.4" )
+    Q_INTERFACES( rtimvOverlayInterface )
 
-protected:
-
+  protected:
     /** \name Configurable Parameters
-      * @{
-      */
-    std::string m_deviceName; ///< INDI device name of the acquisition program
+     * @{
+     */
+    std::string m_deviceName; ///< INDI device name of the acquisition program.
 
-    std::string m_cameraName; ///< INDI device name of the associated camera
+    std::string m_cameraName; ///< INDI device name of the associated camera.
 
-    int m_circRad {10};  ///< Radius of the circle to draw around the star
+    int m_circRad{ 10 }; ///< Radius of the circle to draw around each tracked star.
 
-    std::string m_color {"cyan"}; ///< Color name or RGB spec for the overlay
+    std::string m_color{ "cyan" }; ///< Color name or RGB spec used for circles and labels.
 
-    int m_fontSize {18}; ///< The font size for the overlay
+    int m_fontSize{ 18 }; ///< Pixel font size for the star-number labels.
 
     ///@}
 
-    rtimvOverlayAccess m_roa;
+    rtimvOverlayAccess m_roa; ///< Access to rtimv scene, view, and shared dictionary services.
 
-    bool m_enabled{false};
+    bool m_enabled{ false }; ///< Whether the overlay is currently enabled.
 
-    bool m_enableable{false};
+    bool m_enableable{ false }; ///< Whether configuration succeeded enough to allow enabling.
 
+    QGraphicsScene *m_qgs{ nullptr }; ///< Cached graphics scene from rtimv.
 
-    QGraphicsScene *m_qgs{nullptr};
+    size_t m_nStars{ 0 }; ///< Number of active stars reported by the acquisition process.
 
-    size_t m_nStars {0};
-    std::vector<StretchCircle *> m_starCircles;
-    std::vector<QTextEdit *> m_starLabels;
+    std::vector<QPointer<StretchCircle>>
+                                     m_starCircles; ///< Circle overlays, nulled automatically if rtimv deletes them.
+    std::vector<QPointer<QTextEdit>> m_starLabels;  ///< Text labels paired with the circle overlays.
 
-    std::mutex m_starCircleMutex;
+    std::mutex m_starCircleMutex; ///< Protects star-overlay container access and lazy recreation.
 
-    int m_width {-1};
-    int m_height {-1};
+    int m_width{ -1 };  ///< Current camera frame width from the dictionary.
+    int m_height{ -1 }; ///< Current camera frame height from the dictionary.
 
-    char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
+    char m_blob[512]; ///< Scratch buffer for copying rtimvDictionary blobs as strings.
 
-public:
+    /// Ensure a star overlay exists at the requested index.
+    void ensureStarOverlay( size_t n /**< [in] zero-based tracked-star index to create if missing */ );
+
+  public:
+    /// Construct the acquisition overlay.
     acquisition();
 
+    /// Destroy the acquisition overlay and tear down any local label objects.
     virtual ~acquisition();
 
-    virtual int attachOverlay(rtimvOverlayAccess &,
-                              mx::app::appConfigurator &config);
+    /// Attach the overlay to rtimv.
+    virtual int attachOverlay( rtimvOverlayAccess       &roa, /**< [in] rtimv access bundle for scene/view/dictionary */
+                               mx::app::appConfigurator &config /**< [in] configurator providing overlay settings */
+    );
 
+    /// Update the tracked-star overlay state.
     virtual int updateOverlay();
 
-    virtual void keyPressEvent(QKeyEvent *ke);
+    /// Handle overlay key presses.
+    virtual void keyPressEvent( QKeyEvent *ke /**< [in] key event forwarded from rtimv */ );
 
+    /// Report whether the overlay is enabled.
     virtual bool overlayEnabled();
 
-    bool blobExists(const std::string & propel);
+    /// Check whether a property blob exists for the acquisition device.
+    bool blobExists( const std::string &propel /**< [in] property.element suffix to inspect */ );
 
-    bool getBlobStr(const std::string &deviceName,
-                    const std::string &propel);
+    /// Copy a property blob string for an arbitrary device.
+    bool getBlobStr( const std::string &deviceName, /**< [in] INDI device name owning the property */
+                     const std::string &propel      /**< [in] property.element suffix to read */
+    );
 
-    bool getBlobStr(const std::string &propel);
+    /// Copy a property blob string for the configured acquisition device.
+    bool getBlobStr( const std::string &propel /**< [in] property.element suffix to read */ );
 
+    /// Read a typed blob value for an arbitrary device.
     template <typename realT>
-    realT getBlobVal(const std::string &device, const std::string &propel, realT defVal);
+    realT getBlobVal( const std::string &device, /**< [in] INDI device name owning the property */
+                      const std::string &propel, /**< [in] property.element suffix to read */
+                      realT              defVal  /**< [in] fallback value when no blob is available */
+    );
 
+    /// Read a typed blob value for the configured acquisition device.
     template <typename realT>
-    realT getBlobVal(const std::string &propel, realT defVal);
+    realT getBlobVal( const std::string &propel, /**< [in] property.element suffix to read */
+                      realT              defVal  /**< [in] fallback value when no blob is available */
+    );
 
+    /// Enable the overlay.
     virtual void enableOverlay();
 
+    /// Disable the overlay.
     virtual void disableOverlay();
 
-signals:
+  signals:
+    /// Request that rtimv add a new stretch circle to the scene.
+    void newStretchCircle( StretchCircle *sc /**< [in] new circle item to register with rtimv */ );
 
-    void newStretchCircle(StretchCircle *);
+    void savingState( rtimv::savingState );
 
-    void savingState(rtimv::savingState);
+  public slots:
+    /// Handle removal requests emitted by a managed stretch circle.
+    void stretchCircleRemove( StretchCircle *sb /**< [in] circle being removed by rtimv or Qt */ );
 
-public slots:
-
-    void stretchCircleRemove(StretchCircle * );
-
-public:
+  public:
+    /// Report plugin status for display in rtimv.
     virtual std::vector<std::string> info();
 };
 

--- a/gui/rtimv/plugins/indiDictionary/indiDictionary.cpp
+++ b/gui/rtimv/plugins/indiDictionary/indiDictionary.cpp
@@ -5,23 +5,43 @@
  */
 
 #include <set>
+#include <utility>
+#include <vector>
 
 #include "indiDictionary.hpp"
 
+namespace
+{
+bool dictionaryElementKeyToPropertyKey( const std::string &elKey, std::string &device, std::string &property )
+{
+    size_t np = elKey.find( '.', 0 );
+    if( np == std::string::npos )
+    {
+        return false;
+    }
+
+    size_t ap = elKey.find( '.', np + 1 );
+    if( ap == std::string::npos )
+    {
+        return false;
+    }
+
+    device   = elKey.substr( 0, np );
+    property = elKey.substr( np + 1, ap - ( np + 1 ) );
+
+    return true;
+}
+} // namespace
+
 class rtimvIndiClient : public pcf::IndiClient
 {
-  protected:
-    bool m_shutdown{ false };
-    bool m_connectionLost{ false };
-
   public:
     std::set<std::string> m_subscribed;
-    std::mutex            m_subscribedMutex;
+    std::mutex            m_subscribedMutex; ///< Protects the subscribed-property set.
 
   protected:
-    dictionaryT *m_dict{ nullptr };
-
-    float m_northAngle{ 0 };
+    dictionaryT *m_dict{ nullptr };      ///< Shared rtimv dictionary populated from INDI updates.
+    std::mutex  *m_dictMutex{ nullptr }; ///< Protects dictionary structure while keys are inserted or snapshotted.
 
   public:
     rtimvIndiClient( const std::string &szName,
@@ -29,96 +49,142 @@ class rtimvIndiClient : public pcf::IndiClient
                      const std::string &szProtocolVersion,
                      const std::string &ipAddress,
                      const int          port,
-                     dictionaryT       *dict )
-        : pcf::IndiClient( szName, szVersion, szProtocolVersion, ipAddress, port ) //"127.0.0.1", 7624)
+                     dictionaryT       *dict,
+                     std::mutex        *dictMutex );
+
+    ~rtimvIndiClient();
+
+    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv );
+
+    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv );
+
+    virtual void handleMessage( const pcf::IndiProperty &ipRecv );
+
+    virtual void handleSetProperty( const pcf::IndiProperty &ipRecv );
+
+    virtual void execute();
+};
+
+rtimvIndiClient::rtimvIndiClient( const std::string &szName,
+                                  const std::string &szVersion,
+                                  const std::string &szProtocolVersion,
+                                  const std::string &ipAddress,
+                                  const int          port,
+                                  dictionaryT       *dict,
+                                  std::mutex        *dictMutex )
+    : pcf::IndiClient( szName, szVersion, szProtocolVersion, ipAddress, port )
+{
+    m_dict      = dict;
+    m_dictMutex = dictMutex;
+}
+
+rtimvIndiClient::~rtimvIndiClient()
+{
+    quitProcess();
+    deactivate();
+}
+
+void rtimvIndiClient::handleDefProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( m_dict == nullptr || m_dictMutex == nullptr )
     {
-        m_dict = dict;
+        return;
     }
 
-    ~rtimvIndiClient()
-    {
-        quitProcess();
-        deactivate();
-    }
+    std::string key = ipRecv.createUniqueKey();
 
-    virtual void handleDefProperty( const pcf::IndiProperty &ipRecv )
     {
-        if( m_dict == nullptr )
+        std::lock_guard<std::mutex> guard( m_subscribedMutex );
+        if( m_subscribed.count( key ) == 0 )
+        {
             return;
-
-        std::string key = ipRecv.createUniqueKey();
-
-        {
-            std::lock_guard<std::mutex> guard( m_subscribedMutex );
-            if( m_subscribed.count( key ) == 0 )
-                return;
         }
+    }
 
-        auto elIt = ipRecv.getElements().begin();
+    std::vector<std::pair<std::string, std::string>> updates;
+    updates.reserve( ipRecv.getElements().size() );
 
-        while( elIt != ipRecv.getElements().end() )
+    bool  updateNorthAngle{ false };
+    float northAngle{ 0 };
+
+    auto elIt = ipRecv.getElements().begin();
+
+    while( elIt != ipRecv.getElements().end() )
+    {
+        std::string elName = elIt->second.getName();
+        std::string elKey  = key + "." + elName;
+
+        std::string val;
+
+        if( ipRecv.getType() == pcf::IndiProperty::Switch )
         {
-            std::string elKey = key + "." + elIt->second.getName();
-
-            std::string val;
-
-            if( ipRecv.getType() == pcf::IndiProperty::Switch )
+            if( ipRecv[elName].getSwitchState() == pcf::IndiElement::On )
             {
-                if( ipRecv[elIt->second.getName()].getSwitchState() == pcf::IndiElement::On )
-                    val = "on";
-                else if( ipRecv[elIt->second.getName()].getSwitchState() == pcf::IndiElement::Off )
-                    val = "off";
-                else
-                    val = "unk";
+                val = "on";
+            }
+            else if( ipRecv[elName].getSwitchState() == pcf::IndiElement::Off )
+            {
+                val = "off";
             }
             else
             {
-                val = ipRecv[elIt->second.getName()].get();
+                val = "unk";
             }
-
-            // Subscribed properties can expose dynamic elements. Keep those
-            // element keys populated so overlays can discover active presets.
-            ( *m_dict )[elKey].setBlob( val.c_str(), val.size() + 1 );
-
-            if( elKey == "tcsi.teldata.pa" )
-            {
-                m_northAngle = ipRecv[elIt->second.getName()].get<float>();
-                auto nit     = m_dict->find( "rtimv.north.angle" );
-                if( nit != m_dict->end() )
-                {
-                    nit->second.setBlob( &m_northAngle, sizeof( float ) );
-                }
-            }
-
-            ++elIt;
         }
-    }
-
-    virtual void handleDelProperty( const pcf::IndiProperty &ipRecv )
-    {
-        if( m_dict == nullptr )
+        else
         {
-            return;
+            val = ipRecv[elName].get();
         }
 
-        static_cast<void>( ipRecv );
+        updates.emplace_back( elKey, val );
+
+        if( elKey == "tcsi.teldata.pa" )
+        {
+            northAngle       = ipRecv[elName].get<float>();
+            updateNorthAngle = true;
+        }
+
+        ++elIt;
     }
 
-    virtual void handleMessage( const pcf::IndiProperty &ipRecv )
+    std::lock_guard<std::mutex> guard( *m_dictMutex );
+
+    for( const auto &update : updates )
     {
-        static_cast<void>( ipRecv );
+        // Subscribed properties can expose dynamic elements. Keep those
+        // element keys populated so overlays can discover active presets.
+        ( *m_dict )[update.first].setBlob( update.second.c_str(), update.second.size() + 1 );
     }
 
-    virtual void handleSetProperty( const pcf::IndiProperty &ipRecv )
+    if( updateNorthAngle )
     {
-        handleDefProperty( ipRecv );
+        auto nit = m_dict->find( "rtimv.north.angle" );
+        if( nit != m_dict->end() )
+        {
+            nit->second.setBlob( &northAngle, sizeof( float ) );
+        }
     }
+}
 
-    virtual void execute()
-    {
-        processIndiRequests( false );
-    }
-};
+void rtimvIndiClient::handleDelProperty( const pcf::IndiProperty &ipRecv )
+{
+    static_cast<void>( ipRecv );
+}
+
+void rtimvIndiClient::handleMessage( const pcf::IndiProperty &ipRecv )
+{
+    static_cast<void>( ipRecv );
+}
+
+void rtimvIndiClient::handleSetProperty( const pcf::IndiProperty &ipRecv )
+{
+    handleDefProperty( ipRecv );
+}
+
+void rtimvIndiClient::execute()
+{
+    processIndiRequests( false );
+}
 
 indiDictionary::indiDictionary() : rtimvDictionaryInterface()
 {
@@ -163,6 +229,7 @@ int indiDictionary::attachDictionary( dictionaryT *dict, mx::app::appConfigurato
 
         if( m_dict )
         {
+            std::lock_guard<std::mutex> guard( m_dictMutex );
             ( *m_dict )["tcsi.teldata.pa"].setBlob( nullptr, 0 );
             ( *m_dict )["rtimv.north.angle"].setBlob( nullptr, 0 );
         }
@@ -182,7 +249,8 @@ void indiDictionary::checkConnection()
     {
         try
         {
-            m_client = new rtimvIndiClient( "rtimvIndiClient", "1.7", "1.7", m_ipAddress, m_port, m_dict );
+            m_client =
+                new rtimvIndiClient( "rtimvIndiClient", "1.7", "1.7", m_ipAddress, m_port, m_dict, &m_dictMutex );
         }
         catch( ... )
         {
@@ -205,31 +273,45 @@ void indiDictionary::checkConnection()
     if( !m_client )
         return;
 
-    // Well if we're here we're connected, so now check if we're listening to our props
-    for( auto it = m_dict->begin(); it != m_dict->end(); ++it )
+    std::set<std::pair<std::string, std::string>> propertyKeys;
+
     {
-        std::string elKey = it->first;
+        std::lock_guard<std::mutex> guard( m_dictMutex );
 
-        size_t      np  = elKey.find( '.', 0 );
-        std::string dev = elKey.substr( 0, np );
+        if( m_dict == nullptr )
+        {
+            return;
+        }
 
-        size_t      ap   = elKey.find( '.', np + 1 );
-        std::string prop = elKey.substr( np + 1, ap - ( np + 1 ) );
+        // Well if we're here we're connected, so now check if we're listening to our props.
+        for( auto it = m_dict->begin(); it != m_dict->end(); ++it )
+        {
+            std::string dev;
+            std::string prop;
 
-        std::string key = dev + "." + prop;
+            if( !dictionaryElementKeyToPropertyKey( it->first, dev, prop ) )
+            {
+                continue;
+            }
 
+            propertyKeys.insert( std::make_pair( dev, prop ) );
+        }
+    }
+
+    for( const auto &propertyKey : propertyKeys )
+    {
         bool shouldSnoop = false;
         {
             std::lock_guard<std::mutex> guard( m_client->m_subscribedMutex );
-            auto                        res = m_client->m_subscribed.insert( key );
-            shouldSnoop                     = res.second;
+            auto res    = m_client->m_subscribed.insert( propertyKey.first + "." + propertyKey.second );
+            shouldSnoop = res.second;
         }
 
         if( shouldSnoop == true ) // If we have inserted it, we snoop it
         {
             pcf::IndiProperty ipSend;
-            ipSend.setDevice( dev );
-            ipSend.setName( prop );
+            ipSend.setDevice( propertyKey.first );
+            ipSend.setName( propertyKey.second );
             m_client->sendGetProperties( ipSend );
         }
     }

--- a/gui/rtimv/plugins/indiDictionary/indiDictionary.hpp
+++ b/gui/rtimv/plugins/indiDictionary/indiDictionary.hpp
@@ -1,7 +1,15 @@
+/** \file indiDictionary.hpp
+ * \brief Declares the rtimv INDI-backed dictionary plugin.
+ *
+ * \author Jared Males
+ */
+
 #ifndef indiDictionary_hpp
 #define indiDictionary_hpp
 
 #include <rtimv/rtimvInterfaces.hpp>
+
+#include <mutex>
 
 #include <QObject>
 #include <QtPlugin>
@@ -11,55 +19,57 @@
 
 #include <IndiClient.hpp>
 
-//Forward decl:
+// Forward decl:
 class rtimvIndiClient;
 
 /// rtimv dictionary using the INDI protocol
 /**
-  *
-  */
+ *
+ */
 class indiDictionary : public rtimvDictionaryInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.dictionaryInterface/1.4")
-    Q_INTERFACES(rtimvDictionaryInterface)
+    Q_PLUGIN_METADATA( IID "rtimv.dictionaryInterface/1.4" )
+    Q_INTERFACES( rtimvDictionaryInterface )
 
-protected:
-    std::string m_ipAddress {""}; ///< The IP address of the INDI server
-    int m_port {0};               ///< The port of the INDI server
-    int m_checkTimeout {1000};    ///< The timeout for checking the INDI connection, in msec
+  protected:
+    std::string m_ipAddress{ "" };      ///< The IP address of the INDI server.
+    int         m_port{ 0 };            ///< The port of the INDI server.
+    int         m_checkTimeout{ 1000 }; ///< The timeout for checking the INDI connection, in msec.
 
-    dictionaryT * m_dict {nullptr}; ///< The rtimv INDI dictionary.
+    dictionaryT *m_dict{ nullptr }; ///< Shared rtimv INDI dictionary backing overlay state.
 
-    rtimvIndiClient * m_client {nullptr}; ///< The INDI client, which is destroyed each time connection is lost
+    std::mutex m_dictMutex; ///< Protects dictionary structure while threads add or snapshot keys.
 
-    std::mutex m_clientMutex; ///< Protection for access to client.
+    rtimvIndiClient *m_client{ nullptr }; ///< INDI client, recreated when the connection is lost.
 
-    bool m_enabled {false}; ///< Whether or not this plugin is enabled
+    std::mutex m_clientMutex; ///< Protects access to the INDI client pointer and its lifecycle.
 
-    QTimer m_connTimer; ///< Time for checking the connection.
+    bool m_enabled{ false }; ///< Whether or not this plugin is enabled.
 
-public:
+    QTimer m_connTimer; ///< Timer used to periodically check the INDI connection.
 
-    /// c'tor
+  public:
+    /// Construct the plugin.
     indiDictionary();
 
-    /// d'tor
+    /// Destroy the plugin and shut down the INDI client.
     virtual ~indiDictionary();
 
-    /// Attach this plugin to rtimv
-    virtual int attachDictionary( dictionaryT * dict,               ///< [in] pointer to the rtimv dictionary, a std::map
-                                  mx::app::appConfigurator & config ///< [in] app configurator from which to config the connection
-                                );
+    /// Attach this plugin to rtimv.
+    virtual int
+    attachDictionary( dictionaryT              *dict,  ///< [in] pointer to the rtimv dictionary, a std::map
+                      mx::app::appConfigurator &config ///< [in] app configurator from which to config the connection
+    );
 
-public slots:
+  public slots:
 
     /// Check the status of the INDI connection.
     void checkConnection();
 
-public:
+  public:
+    /// Report plugin status for display in rtimv.
     virtual std::vector<std::string> info();
-
 };
 
-#endif //indiDictionary_hpp
+#endif // indiDictionary_hpp


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "seeing segfaults from gui/rtimv/plugins/acquisition. seems most pronounced on remote connections, so laggy INDI subscriptions may be implicated. please investigate."

## Summary

This PR hardens the `rtimv` acquisition overlay and related INDI dictionary handling to address segfaults seen when the acquisition plugin is enabled.

The crash investigation narrowed the main failure down to `acquisition::updateOverlay()`, where the plugin could retain `StretchCircle *` pointers after `rtimv` removed and deleted those items from its internal user-circle container. A reproduced coredump showed the crash occurring in `QGraphicsEllipseItem::setRect()` from `acquisition::updateOverlay()`.

## Changes

- Pre-register bounded acquisition star dictionary keys during overlay attach instead of growing them dynamically during updates.
- Clamp tracked star count to a fixed maximum of 128.
- Stop tearing down and recreating acquisition overlay items when the reported star count changes.
- Track acquisition circles and labels with `QPointer` so they null automatically if `rtimv` deletes them.
- Lazily recreate missing acquisition overlay items before use.
- Add a dictionary-structure mutex in `indiDictionary` so the timer thread and INDI client thread do not concurrently iterate and insert into the shared dictionary map.
- Snapshot subscribed property roots before issuing INDI `GetProperties` requests.

## Files

- `gui/rtimv/plugins/acquisition/acquisition.hpp`
- `gui/rtimv/plugins/acquisition/acquisition.cpp`
- `gui/rtimv/plugins/indiDictionary/indiDictionary.hpp`
- `gui/rtimv/plugins/indiDictionary/indiDictionary.cpp`

## Verification

- `make -C gui/rtimv/plugins/acquisition`
- `make -C gui/rtimv/plugins/indiDictionary`

## Notes

This fixes the acquisition-plugin crash path without requiring immediate changes in the sibling `rtimv` repository. The remaining long-term cleanup would be to separate plugin-owned overlay items from `rtimv`'s reset-prone user-item container so plugins do not need to recover from host-side deletion.
