### PR TITLE
moved xt1121s to AOC from ICC; build xInstGraph on AOC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,8 @@ apps/xt1121Ctrl/xt1121Ctrl
 
 apps/xt1121DCDU/xt1121DCDU
 
+apps/xInstGraph/xInstGraph
+
 #z
 apps/zaberCtrl/zaberCtrl
 apps/zaberLowLevel/zaberLowLevel

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,17 @@ apps_common = \
 
 apps_aoc = \
 	trippLitePDU \
+	xt1121Ctrl \
+	xt1121DCDU \
 	tcsInterface \
 	adcTracker \
 	hwpTracker \
 	kTracker \
 	koolanceCtrl \
 	observerCtrl \
-	stateRuleEngine
+	stateRuleEngine \
+	xInstGraph
+
 pythonapps_aoc = \
 	audibleAlerts
 
@@ -83,8 +87,6 @@ apps_icc = \
 	filterWheelCtrl \
 	smc100ccCtrl \
 	usbtempMon \
-	xt1121Ctrl \
-	xt1121DCDU \
 	koolanceCtrl \
 	corAlign \
 	adcCtrl \


### PR DESCRIPTION
xt1121 apps now run on AOC for safety reasons.  So they are built on AOC not ICC.