### PR TITLE
add sync stream to ocam2KCtrl output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,11 @@ Follow these code style and documentation rules exactly.
   - Make formatting-only cleanup a separate final commit when needed.
 
 20) Application Unit Test Documentation
-  - For application unit tests, place Doxygen grouping under `app_unit_test` in `tests/groups.dox`.
+  - For application unit tests, place Doxygen grouping under `application_unit_test` in `tests/groups.dox`.
+  - Reserve `app_unit_test` for tests of the `libMagAOX` app namespace, not end applications.
   - Prefer the structure:
   - `namespace libXWCTest { namespace <appName>Test { ... } }`
-  - Add a `\defgroup <appName>_unit_test` block and `\ingroup app_unit_test`.
+  - Add a `\defgroup <appName>_unit_test` block and `\ingroup application_unit_test`.
   - Add a brief Doxygen block for each `TEST_CASE`, not just the file header.
 
 21) Test Doxygen Link Preservation

--- a/Make/magAOX.mk
+++ b/Make/magAOX.mk
@@ -75,3 +75,14 @@ clean:
 	rm -f $(SELF_DIR)/../magaox_git_version.h
 	rm -f *.o
 	rm -f *~
+
+.PHONY: test_clean
+test_clean: clean
+	rm -f tests/$(TARGETNAME)_test
+	rm -f tests/*.o
+	rm -f tests/*~
+
+.PHONE: coverage_clean
+coverage_clean: clean test_clean
+	rm -f *.gc*
+	rm -f tests/*.gc*

--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,7 @@ print_role:
 	@echo "MAGAOX_ROLE=$(MAGAOX_ROLE)"
 
 .PHONY: coverage
-coverage:
+coverage: coverage_clean
 	${MAKE} all COVERAGE=1 ALL_APPS=1 NO_GUIS=1
 
 .PHONY: coverage_clean
@@ -549,6 +549,8 @@ coverage_clean:
 	find . -name '*.gcda' -delete
 	find . -name '*.gcov' -delete
 	${MAKE} all_clean COVERAGE=1 ALL_APPS=1
+	cd tests && ${MAKE} realclean COVERAGE=1 || exit 1;
+	cd libMagAOX/logger/tests && ${MAKE} really_clean COVERAGE=1 || exit 1;
 
 .PHONY: valgrind
 valgrind:

--- a/agents/plans/2026-04/ocam2K-sync-stream-tests.md
+++ b/agents/plans/2026-04/ocam2K-sync-stream-tests.md
@@ -1,7 +1,7 @@
-We need to add a 2nd ImageStreamIO stream as an output of ocam2KCtrl.  It will be an empty, or minimum size, stream.  The reason to do so is to have a 2nd meta-data, namely semaphore, only stream structure that can be used to synchronize operations across computers.  It should be initialized and prepared in parallel to the main dev::framegrabber setup, and the semaphores should be incremented immediately after the main stream semaphores are incremented.
+We need to add a 2nd ImageStreamIO stream as an output of ocam2KCtrl.  It will be an empty, or minimum size, stream.  The reason to do so is to have a 2nd meta-data, namely semaphore, only stream structure that can be used to synchronize operations across computers.  It should be initialized, prepared, and maintained as part of the main dev::framegrabber setup, and the semaphores should be incremented immediately after the main stream semaphores are incremented.
 
-As a 2nd pass to this effort, we need to add tests for ocam2KCtrl.  Currently only the ocamUtils parsers are tested.  
+As a 2nd pass to this effort, we need to add tests for ocam2KCtrl.  Currently only the ocamUtils parsers are tested.  Please follow the standards recently developed for flowRPM and adcTracker and elliptecCtrl (the last two are on feature branches).
 
-Please update this document with a plan, below.  Do not alter this prompt, and do not being executing until I have reviewed the plan.
+Review AGENTS.md, then lease update this document with a plan, below.  Do not alter this prompt, and do not being executing until I have reviewed the plan.  Use the feature branch jrmales/ocam2k-sync.
 
 Plan:

--- a/agents/plans/2026-04/ocam2K-sync-stream-tests.md
+++ b/agents/plans/2026-04/ocam2K-sync-stream-tests.md
@@ -1,0 +1,7 @@
+We need to add a 2nd ImageStreamIO stream as an output of ocam2KCtrl.  It will be an empty, or minimum size, stream.  The reason to do so is to have a 2nd meta-data, namely semaphore, only stream structure that can be used to synchronize operations across computers.  It should be initialized and prepared in parallel to the main dev::framegrabber setup, and the semaphores should be incremented immediately after the main stream semaphores are incremented.
+
+As a 2nd pass to this effort, we need to add tests for ocam2KCtrl.  Currently only the ocamUtils parsers are tested.  
+
+Please update this document with a plan, below.  Do not alter this prompt, and do not being executing until I have reviewed the plan.
+
+Plan:

--- a/agents/plans/2026-04/ocam2K-sync-stream-tests.md
+++ b/agents/plans/2026-04/ocam2K-sync-stream-tests.md
@@ -5,3 +5,46 @@ As a 2nd pass to this effort, we need to add tests for ocam2KCtrl.  Currently on
 Review AGENTS.md, then lease update this document with a plan, below.  Do not alter this prompt, and do not being executing until I have reviewed the plan.  Use the feature branch jrmales/ocam2k-sync.
 
 Plan:
+1. Review the `ocam2KCtrl` framegrabber lifecycle and the `dev::frameGrabber` ownership model to identify the smallest app-local change that adds a second `ImageStreamIO` stream without changing existing image-stream behavior.
+   - Add app-local state for the sync-only stream name, `IMAGE` handle, ownership, and helper routines to create, resize, initialize, and destroy the secondary stream.
+   - Keep the secondary stream prepared and maintained in the same startup, reconfigure, power-off, and shutdown phases as the main framegrabber stream.
+
+2. Wire sync-stream semaphore publication into the acquisition path.
+   - After the main stream metadata update and semaphore post complete, update the sync-only stream metadata needed for consumers and post its semaphores immediately afterward.
+   - Use a `1x1` `uint8` sync-only stream so the stream stays minimal while remaining well-formed for downstream applications, and keep that choice explicitly documented in code.
+
+3. Add `ocam2KCtrl` unit tests following the newer application-test patterns used by `flowRPM`, `adcTracker`, and `elliptecCtrl`.
+   - Create `apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp`.
+   - Use the `libXWCTest` namespace structure, a dedicated Doxygen test group, `tests/testXWC.hpp`, and a focused test harness class that exposes only the protected helpers needed for test coverage.
+   - Keep `ocamUtils_test.cpp` for parser coverage and add new tests for app-level configuration, helper logic, and any sync-stream behavior that can be exercised without camera hardware.
+
+4. Update test registration and Doxygen grouping.
+   - Add the new `ocam2KCtrl` test target to `tests/tests.list`.
+   - Update `tests/groups.dox` as needed to provide the `application_unit_test` Doxygen group expected for application tests.
+   - Bring touched test files up to the current Doxygen style across the full changed file, not just the new lines.
+
+5. Verify and document the implementation.
+   - Run `clang-format` on all touched files.
+   - Build and run the targeted `ocam2KCtrl` tests, plus any nearby regression checks needed for confidence.
+   - Update this plan file with implementation notes if the final design differs from the outline above.
+
+Resolved convention note:
+- For MagAOX applications, use `application_unit_test`; `app_unit_test` is reserved for the `libMagAOX` app namespace rather than end applications.
+- For this change, the secondary sync stream should be implemented as a `1x1` `uint8` ImageStreamIO stream rather than a zero-sized or otherwise special-case buffer.
+
+Implementation notes:
+- Added a small optional `dev::frameGrabber` post-publication hook so `ocam2KCtrl` can post the sync stream immediately after the main framegrabber stream semaphore post.
+- Implemented the sync stream in `ocam2KCtrl` as a dedicated `1x1x1` circular-buffer ImageStreamIO stream with `uint8` pixels, `cnt1 = 0`, and mirrored `atime`, `writetime`, and `cnt0` metadata from the main stream.
+- Added `framegrabber.syncShmimName` config support in `ocam2KCtrl`; when omitted it defaults to `framegrabber.shmimName + "_sync"`.
+- Kept the sync-stream lifecycle local to `ocam2KCtrl` with helper methods to create, validate, repair, publish, and destroy the stream.
+- Dropped the initial per-frame sync-stream mutex after reviewing the call graph: `configureAcquisition()` and `frameGrabberPostPublish()` both run on the framegrabber thread, and `destroySyncStream()` runs only after `frameGrabber::appShutdown()` joins that thread, so a null check is sufficient on the hot path.
+- Added `apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp` covering sync-stream creation, sync-stream publication metadata and semaphore behavior, and selected hardware-free app helpers.
+- Added a local test-only `apps/ocam2KCtrl/tests/edtinc.h` stub header plus OCAM/EDT stub definitions in the test translation unit so the new unit test can build without the real EDT SDK.
+- Registered the new test in `tests/tests.list` and updated `tests/Makefile.one` so `ocam2KCtrl_test` can use the local EDT stub while still compiling the real `dev::edtCamera` path.
+
+Verification notes:
+- `clang-format -i libMagAOX/app/dev/frameGrabber.hpp apps/ocam2KCtrl/ocam2KCtrl.hpp apps/ocam2KCtrl/tests/edtinc.h apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp`
+- `make -B -f Makefile.one t=../apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp COVERAGE=1` from `tests/`
+- `../apps/ocam2KCtrl/tests/ocam2KCtrl_test` from `tests/` with shared-memory write permission: passed
+- `make -B -f Makefile.one t=../apps/ocam2KCtrl/tests/ocamUtils_test.cpp COVERAGE=1` from `tests/`
+- `../apps/ocam2KCtrl/tests/ocamUtils_test` from `tests/`: passed

--- a/apps/ocam2KCtrl/ocam2KCtrl.hpp
+++ b/apps/ocam2KCtrl/ocam2KCtrl.hpp
@@ -1,21 +1,20 @@
 /** \file ocam2KCtrl.hpp
-  * \brief The MagAO-X OCAM2K EMCCD camera controller.
-  *
-  * \ingroup ocam2KCtrl_files
-  */
+ * \brief The MagAO-X OCAM2K EMCCD camera controller.
+ *
+ * \ingroup ocam2KCtrl_files
+ */
 
 #ifndef ocam2KCtrl_hpp
 #define ocam2KCtrl_hpp
 
-
+#include <fcntl.h>
 #include <edtinc.h>
-
-
+#include <unistd.h>
 
 #include "../../libMagAOX/libMagAOX.hpp" //Note this is included on command line to trigger pch
 #include "../../magaox_git_version.h"
 
-typedef MagAOX::app::MagAOXApp<true> MagAOXAppT; //This needs to be before pdvUtils.hpp for logging to work.
+typedef MagAOX::app::MagAOXApp<true> MagAOXAppT; // This needs to be before pdvUtils.hpp for logging to work.
 
 #include "fli/ocam2_sdk.h"
 #include "ocamUtils.hpp"
@@ -26,25 +25,29 @@ namespace app
 {
 
 /** \defgroup ocam2KCtrl OCAM2K EMCCD Camera
-  * \brief Control of the OCAM2K EMCCD Camera.
-  *
-  * <a href="../handbook/operating/software/apps/ocam2KCtrl.html">Application Documentation</a>
-  *
-  * \ingroup apps
-  *
-  */
+ * \brief Control of the OCAM2K EMCCD Camera.
+ *
+ * <a href="../handbook/operating/software/apps/ocam2KCtrl.html">Application Documentation</a>
+ *
+ * \ingroup apps
+ *
+ */
 
 /** \defgroup ocam2KCtrl_files OCAM2K EMCCD Camera Files
-  * \ingroup ocam2KCtrl
-  */
+ * \ingroup ocam2KCtrl
+ */
 
 /** MagAO-X application to control the OCAM 2K EMCCD
-  *
-  * \ingroup ocam2KCtrl
-  *
-  */
-class ocam2KCtrl : public MagAOXApp<>, public dev::stdCamera<ocam2KCtrl>, public dev::edtCamera<ocam2KCtrl>, public dev::frameGrabber<ocam2KCtrl>,
-                                           public dev::dssShutter<ocam2KCtrl>, public dev::telemeter<ocam2KCtrl>
+ *
+ * \ingroup ocam2KCtrl
+ *
+ */
+class ocam2KCtrl : public MagAOXApp<>,
+                   public dev::stdCamera<ocam2KCtrl>,
+                   public dev::edtCamera<ocam2KCtrl>,
+                   public dev::frameGrabber<ocam2KCtrl>,
+                   public dev::dssShutter<ocam2KCtrl>,
+                   public dev::telemeter<ocam2KCtrl>
 {
     friend class dev::stdCamera<ocam2KCtrl>;
     friend class dev::edtCamera<ocam2KCtrl>;
@@ -54,893 +57,1064 @@ class ocam2KCtrl : public MagAOXApp<>, public dev::stdCamera<ocam2KCtrl>, public
 
     typedef MagAOXApp<> MagAOXAppT;
 
-public:
+  public:
     /** \name app::dev Configurations
-      *@{
-      */
-    static constexpr bool c_stdCamera_tempControl = true; ///< app::dev config to tell stdCamera to expose temperature controls
+     *@{
+     */
+    static constexpr bool c_stdCamera_tempControl =
+        true; ///< app::dev config to tell stdCamera to expose temperature controls
 
-    static constexpr bool c_stdCamera_temp = true; ///< app::dev config to tell stdCamera to expose temperature (ignored since tempControl==true)
+    static constexpr bool c_stdCamera_temp =
+        true; ///< app::dev config to tell stdCamera to expose temperature (ignored since tempControl==true)
 
-    static constexpr bool c_stdCamera_readoutSpeed = false; ///< app::dev config to tell stdCamera not to expose readout speed controls
+    static constexpr bool c_stdCamera_readoutSpeed =
+        false; ///< app::dev config to tell stdCamera not to expose readout speed controls
 
-    static constexpr bool c_stdCamera_vShiftSpeed = false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
-    static constexpr bool c_stdCamera_fanSpeed = false; ///< app::dev config to tell stdCamera not to expose fan-speed control
+    static constexpr bool c_stdCamera_vShiftSpeed =
+        false; ///< app:dev config to tell stdCamera not to expose vertical shift speed control
+    static constexpr bool c_stdCamera_fanSpeed =
+        false; ///< app::dev config to tell stdCamera not to expose fan-speed control
 
     static constexpr bool c_stdCamera_emGain = true; ///< app::dev config to tell stdCamera to expose EM gain controls
 
-    static constexpr bool c_stdCamera_exptimeCtrl = false; ///< app::dev config to tell stdCamera not to expose exposure time controls
+    static constexpr bool c_stdCamera_exptimeCtrl =
+        false; ///< app::dev config to tell stdCamera not to expose exposure time controls
 
     static constexpr bool c_stdCamera_fpsCtrl = true; ///< app::dev config to tell stdCamera to expose FPS controls
 
-    static constexpr bool c_stdCamera_fps = true; ///< app::dev config to tell stdCamera not to expose FPS status (ignored since fpsCtrl==true)
+    static constexpr bool c_stdCamera_fps =
+        true; ///< app::dev config to tell stdCamera not to expose FPS status (ignored since fpsCtrl==true)
 
-    static constexpr bool c_stdCamera_synchro = true; ///< app::dev config to tell stdCamera to expose synchro mode controls
+    static constexpr bool c_stdCamera_synchro =
+        true; ///< app::dev config to tell stdCamera to expose synchro mode controls
 
-    static constexpr bool c_stdCamera_usesModes = true; ///< app:dev config to tell stdCamera not to expose mode controls
+    static constexpr bool c_stdCamera_usesModes =
+        true; ///< app:dev config to tell stdCamera not to expose mode controls
 
     static constexpr bool c_stdCamera_usesROI = false; ///< app:dev config to tell stdCamera to expose ROI controls
 
-    static constexpr bool c_stdCamera_cropMode = false; ///< app:dev config to tell stdCamera to expose Crop Mode controls
+    static constexpr bool c_stdCamera_cropMode =
+        false; ///< app:dev config to tell stdCamera to expose Crop Mode controls
 
-    static constexpr bool c_stdCamera_hasShutter = true; ///< app:dev config to tell stdCamera to expose shutter controls
+    static constexpr bool c_stdCamera_hasShutter =
+        true; ///< app:dev config to tell stdCamera to expose shutter controls
 
-    static constexpr bool c_stdCamera_usesStateString = true; ///< app::dev confg to tell stdCamera to expose the state string property
+    static constexpr bool c_stdCamera_usesStateString =
+        true; ///< app::dev confg to tell stdCamera to expose the state string property
 
-    static constexpr bool c_edtCamera_relativeConfigPath = true; ///< app::dev config to tell edtCamera to use relative path to camera config file
+    static constexpr bool c_edtCamera_relativeConfigPath =
+        true; ///< app::dev config to tell edtCamera to use relative path to camera config file
 
-    static constexpr bool c_frameGrabber_flippable = false; ///< app:dev config to tell framegrabber these images can not be flipped
+    static constexpr bool c_frameGrabber_flippable =
+        false; ///< app:dev config to tell framegrabber these images can not be flipped
 
     ///@}
-protected:
-
+  protected:
     /** \name configurable parameters
-      *@{
-      */
+     *@{
+     */
 
-    //Camera:
+    std::string m_ocamDescrambleFile; ///< Path to the OCAM 2K pixel descrambling file, relative to the MagAO-X config
+                                      ///< directory.
 
-    std::string m_ocamDescrambleFile; ///< Path the OCAM 2K pixel descrambling file, relative to MagAO-X config directory.
-
-
+    std::string m_syncShmimName; ///< Name of the sync-only ImageStreamIO output. Defaults to `framegrabber.shmimName +
+                                 ///< "_sync"`.
 
     ///@}
 
-    ocam2_id m_ocam2_id {0}; ///< OCAM SDK id.
+    static constexpr uint32_t c_syncStreamWidth{ 1 };  ///< Width of the sync-only ImageStreamIO stream.
+    static constexpr uint32_t c_syncStreamHeight{ 1 }; ///< Height of the sync-only ImageStreamIO stream.
+    static constexpr uint32_t c_syncStreamDepth{ 1 };  ///< Depth of the sync-only ImageStreamIO stream.
+    static constexpr uint8_t  c_syncStreamDataType{ _DATATYPE_UINT8 }; ///< Data type of the sync-only stream.
 
-    long m_currImageNumber {-1}; ///< The current image number, retrieved from the image itself.
+    ocam2_id m_ocam2_id{ 0 }; ///< OCAM SDK id.
 
-    long m_lastImageNumber {-1};  ///< The last image number, saved from the last loop through.
+    long m_currImageNumber{ -1 }; ///< The current image number, retrieved from the raw image itself.
 
-    bool m_protectionReset {false}; ///< Flag indicating that protection has been reset at least once.
+    long m_lastImageNumber{ -1 }; ///< The last image number saved from the previous acquisition loop.
 
-    unsigned m_protectionResetConfirmed {0}; ///< Counter indicating the number of times that the protection reset has been requested within 10 seconds, for confirmation.
+    bool m_protectionReset{ false }; ///< Flag indicating that protection has been reset at least once.
 
-    double m_protectionResetReqTime {0}; ///< The time at which protection reset was requested.  You have 10 seconds to confirm.
+    unsigned m_protectionResetConfirmed{ 0 }; ///< Counter indicating the number of times that the protection reset has
+                                              ///< been requested within 10 seconds, for confirmation.
 
-    bool m_poweredOn {false};
+    double m_protectionResetReqTime{
+        0 }; ///< The time at which protection reset was requested.  You have 10 seconds to confirm.
+
+    bool m_poweredOn{
+        false }; ///< Tracks that power-on defaults still need to restore the configured temperature setpoint.
 
     ocamTemps m_temps; ///< Structure holding the last temperature measurement.
 
-    unsigned m_digitalBinX {1};
+    unsigned m_digitalBinX{ 1 }; ///< Digital x-binning factor applied after descrambling.
 
-    unsigned m_digitalBinY {1};
+    unsigned m_digitalBinY{ 1 }; ///< Digital y-binning factor applied after descrambling.
 
-    bool m_digitalBin {false};
+    bool m_digitalBin{ false }; ///< Indicates whether post-descramble digital binning is active for the current mode.
 
-    mx::improc::eigenImage<int16_t> m_digitalBinWork;
+    mx::improc::eigenImage<int16_t>
+        m_digitalBinWork; ///< Scratch image holding the full descrambled frame before digital binning.
 
-    std::string m_syncDevice {"fxngensync"};
-    std::string m_syncFreqProp {"C1freq"};
+    std::string m_syncDevice{
+        "fxngensync" }; ///< INDI device providing the external sync frequency when synchro mode is enabled.
+    std::string m_syncFreqProp{ "C1freq" }; ///< INDI property name reporting the external sync frequency.
 
-    float m_syncFreq {0};
+    float m_syncFreq{ 0 }; ///< Current externally supplied sync frequency in Hz.
 
-    std::recursive_mutex m_cameraMutex; ///< Protects EDT PDV access and OCAM SDK lifetime across reconfigure, grab, and control paths.
+    IMAGE *m_syncImageStream{ nullptr }; ///< Secondary 1x1 uint8 ImageStreamIO stream used only for frame metadata
+                                         ///< and semaphores. Its lifetime is sequenced by the framegrabber thread and
+                                         ///< app shutdown so per-frame publication can remain lock-free.
 
-public:
+    std::recursive_mutex
+        m_cameraMutex; ///< Protects EDT PDV access and OCAM SDK lifetime across reconfigure, grab, and control paths.
 
-   ///Default c'tor
-   ocam2KCtrl();
+  public:
+    /// Default c'tor
+    ocam2KCtrl();
 
-   ///Destructor
-   ~ocam2KCtrl() noexcept;
+    /// Destructor
+    ~ocam2KCtrl() noexcept;
 
-   /// Setup the configuration system (called by MagAOXApp::setup())
-   virtual void setupConfig();
+    /// Setup the configuration system (called by MagAOXApp::setup())
+    virtual void setupConfig();
 
-   /// load the configuration system results (called by MagAOXApp::setup())
-   virtual void loadConfig();
+    /// load the configuration system results (called by MagAOXApp::setup())
+    virtual void loadConfig();
 
-   /// Startup functions
-   /** Sets up the INDI vars, and the f.g. thread.
+    /// Startup functions
+    /** Sets up the INDI vars, and the f.g. thread.
      *
      */
-   virtual int appStartup();
+    virtual int appStartup();
 
-   /// Implementation of the FSM for the OCAM 2K.
-   virtual int appLogic();
+    /// Implementation of the FSM for the OCAM 2K.
+    virtual int appLogic();
 
-   /// Implementation of the on-power-off FSM logic
-   virtual int onPowerOff();
+    /// Implementation of the on-power-off FSM logic
+    virtual int onPowerOff();
 
-   /// Implementation of the while-powered-off FSM
-   virtual int whilePowerOff();
+    /// Implementation of the while-powered-off FSM
+    virtual int whilePowerOff();
 
-   /// Do any needed shutdown tasks.
-   virtual int appShutdown();
+    /// Do any needed shutdown tasks.
+    virtual int appShutdown();
 
-   /// Get the current device temperatures
-   /**
+    /// Get the current device temperatures
+    /**
      * \returns 0 on success
      * \returns -1 on error
      */
-   int getTemps();
+    int getTemps();
 
-   /// Get the current frame rate.
-   /**
+    /// Get the current frame rate.
+    /**
      * \returns 0 on success
      * \returns -1 on error
      */
-   int getFPS();
+    int getFPS();
 
-   /** \name stdCamera Interface
-     *
-     * @{
-     */
-
-   /// Set defaults for a power on state.
-   /**
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int powerOnDefaults();
-
-   /// Turn temperature control on or off.
-   /** Sets temperature control on or off based on the current value of m_tempControlStatus
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int setTempControl();
-
-   /// Set the CCD temperature setpoint [stdCamera interface].
-   /** Sets the temperature to m_ccdTempSetpt.
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int setTempSetPt();
-
-   /// Set the frame rate. [stdCamera interface]
-   /** Sets the frame rate to m_fpsSet.
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int setFPS();
-
-   /// Set the synchro state. [stdCamera interface]
-   /** Sets the synchro state to m_synchroSet.
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int setSynchro();
-
-   /// Required by stdCamera, but this does not do anything for this camera [stdCamera interface]
-   /**
-     * \returns 0 always
-     */
-   int setExpTime();
-
-   /// Required by stdCamera, but this does not do anything for this camera [stdCamera interface]
-   /**
-     * \returns 0 always
-     */
-   int setNextROI();
-
-   /// Sets the shutter state, via call to dssShutter::setShutterState(int) [stdCamera interface]
-   /**
-     * \returns 0 always
-     */
-   int setShutter(int sh);
-
-   std::string stateString();
-
-   bool stateStringValid();
-
-   ///@}
-
-   /// Reset the EM Protection
-   /**
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int resetEMProtection();
-
-   /// Get the current EM Gain.
-   /**
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int getEMGain();
-
-   /// Set the EM gain.
-   /** Sets it to the value of stdCamera::m_emGainSet
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int setEMGain();
-
-   /// Implementation of the framegrabber configureAcquisition interface
-   /** Sends the mode command over serial, sets the FPS, and initializes the OCAM SDK.
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int configureAcquisition();
-
-   /// Implementation of the frameGrabber fps interface
-   /** Just returns the value of m_fps
-     */
-   float fps();
-
-   /// Implementation of the framegrabber startAcquisition interface
-   /** Initializes m_lastImageNumber, and calls edtCamera::pdvStartAcquisition
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int startAcquisition();
-
-   /// Implementation of the framegrabber acquireAndCheckValid interface
-   /** Calls edtCamera::pdvAcquire, then analyzes the OCAM generated framenumber for skips and corruption.
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int acquireAndCheckValid();
-
-   /// Implementation of the framegrabber loadImageIntoStream interface
-   /** Conducts the OCAM descramble.
-     *
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int loadImageIntoStream( void * dest  /**< [in] */);
-
-   /// Implementation of the framegrabber reconfig interface
-   /** Locks the INDI mutex and calls edtCamera::pdvReconfig.
-     * \returns 0 on success
-     * \returns -1 on error
-     */
-   int reconfig();
-
-
-   //INDI:
-protected:
-   //declare our properties
-   pcf::IndiProperty m_indiP_temps;
-   pcf::IndiProperty m_indiP_emProt;
-   pcf::IndiProperty m_indiP_emProtReset;
-
-   pcf::IndiProperty m_indiP_syncFreq;
-
-public:
-   INDI_NEWCALLBACK_DECL(ocam2KCtrl, m_indiP_emProtReset);
-
-   INDI_SETCALLBACK_DECL(ocam2KCtrl, m_indiP_syncFreq);
-
-   /** \name Telemeter Interface
+    /** \name stdCamera Interface
      *
      * @{
      */
-   int checkRecordTimes();
 
-   int recordTelem( const ocam_temps * );
+    /// Set defaults for a power on state.
+    /**
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int powerOnDefaults();
 
-   int recordTelem( const telem_stdcam * );
+    /// Turn temperature control on or off.
+    /** Sets temperature control on or off based on the current value of m_tempControlStatus
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int setTempControl();
 
-   int recordTelem( const telem_fgtimings * );
+    /// Set the CCD temperature setpoint [stdCamera interface].
+    /** Sets the temperature to m_ccdTempSetpt.
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int setTempSetPt();
 
-   int recordTemps(bool force = false);
+    /// Set the frame rate. [stdCamera interface]
+    /** Sets the frame rate to m_fpsSet.
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int setFPS();
 
-   ///@}
+    /// Set the synchro state. [stdCamera interface]
+    /** Sets the synchro state to m_synchroSet.
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int setSynchro();
+
+    /// Required by stdCamera, but this does not do anything for this camera [stdCamera interface]
+    /**
+     * \returns 0 always
+     */
+    int setExpTime();
+
+    /// Required by stdCamera, but this does not do anything for this camera [stdCamera interface]
+    /**
+     * \returns 0 always
+     */
+    int setNextROI();
+
+    /// Sets the shutter state, via call to dssShutter::setShutterState(int) [stdCamera interface]
+    /**
+     * \returns 0 always
+     */
+    int setShutter( int sh /**< [in] requested shutter state */ );
+
+    /// Return the current stdCamera state string.
+    std::string stateString();
+
+    /// Report whether the current stdCamera state string is valid for persistence and telemetry.
+    bool stateStringValid();
+
+    ///@}
+
+    /// Reset the EM Protection
+    /**
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int resetEMProtection();
+
+    /// Get the current EM Gain.
+    /**
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int getEMGain();
+
+    /// Set the EM gain.
+    /** Sets it to the value of stdCamera::m_emGainSet
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int setEMGain();
+
+    /// Implementation of the framegrabber configureAcquisition interface
+    /** Sends the mode command over serial, sets the FPS, and initializes the OCAM SDK.
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int configureAcquisition();
+
+    /// Implementation of the frameGrabber fps interface
+    /** Just returns the value of m_fps
+     */
+    float fps();
+
+    /// Implementation of the framegrabber startAcquisition interface
+    /** Initializes m_lastImageNumber, and calls edtCamera::pdvStartAcquisition
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int startAcquisition();
+
+    /// Implementation of the framegrabber acquireAndCheckValid interface
+    /** Calls edtCamera::pdvAcquire, then analyzes the OCAM generated framenumber for skips and corruption.
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int acquireAndCheckValid();
+
+    /// Implementation of the framegrabber loadImageIntoStream interface
+    /** Conducts the OCAM descramble.
+     *
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int loadImageIntoStream( void *dest /**< [in] destination image buffer */ );
+
+    /// Implementation of the framegrabber reconfig interface
+    /** Locks the INDI mutex and calls edtCamera::pdvReconfig.
+     * \returns 0 on success
+     * \returns -1 on error
+     */
+    int reconfig();
+
+    /// Publish the sync-only stream immediately after the main framegrabber publication.
+    /** This hot path relies on framegrabber sequencing: configureAcquisition() and this hook both run on the
+     * framegrabber thread, while appShutdown() destroys the sync stream only after frameGrabber::appShutdown()
+     * joins that thread.
+     */
+    int frameGrabberPostPublish( IMAGE *imageStream /**< [in] main framegrabber stream that was just posted */ );
+
+  protected:
+    /// Ensure the sync-only ImageStreamIO stream exists with the expected 1x1 uint8 layout.
+    int ensureSyncStream();
+
+    /// Destroy the sync-only ImageStreamIO stream owned by this app.
+    int destroySyncStream();
+
+    // INDI:
+  protected:
+    // declare our properties
+    pcf::IndiProperty m_indiP_temps;       ///< INDI property publishing the latest camera temperatures.
+    pcf::IndiProperty m_indiP_emProt;      ///< INDI property publishing the EM protection state.
+    pcf::IndiProperty m_indiP_emProtReset; ///< INDI property handling operator requests to reset EM protection.
+
+    pcf::IndiProperty m_indiP_syncFreq; ///< INDI subscription to the external sync-frequency source.
+
+  public:
+    INDI_NEWCALLBACK_DECL( ocam2KCtrl, m_indiP_emProtReset );
+
+    INDI_SETCALLBACK_DECL( ocam2KCtrl, m_indiP_syncFreq );
+
+    /** \name Telemeter Interface
+     *
+     * @{
+     */
+    int checkRecordTimes();
+
+    int recordTelem( const ocam_temps * );
+
+    int recordTelem( const telem_stdcam * );
+
+    int recordTelem( const telem_fgtimings * );
+
+    int
+    recordTemps( bool force = false /**< [in] whether to force a telemetry record even if values have not changed */ );
+
+    ///@}
 };
 
-inline
-ocam2KCtrl::ocam2KCtrl() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
+inline ocam2KCtrl::ocam2KCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
-   //--- MagAOXApp Power Mgt. ---
-   m_powerMgtEnabled = true;
-   m_powerOnWait = 10;
+    //--- MagAOXApp Power Mgt. ---
+    m_powerMgtEnabled = true;
+    m_powerOnWait     = 10;
 
-   //--- stdCamera ---
-   m_startupTemp = 20;
+    //--- stdCamera ---
+    m_startupTemp = 20;
 
-   m_maxEMGain = 600;
+    m_maxEMGain = 600;
 
-   return;
+    return;
 }
 
-inline
-ocam2KCtrl::~ocam2KCtrl() noexcept
+inline ocam2KCtrl::~ocam2KCtrl() noexcept
 {
-   return;
+    return;
 }
 
-inline
-void ocam2KCtrl::setupConfig()
+inline void ocam2KCtrl::setupConfig()
 {
-   dev::stdCamera<ocam2KCtrl>::setupConfig(config);
+    dev::stdCamera<ocam2KCtrl>::setupConfig( config );
 
-   dev::edtCamera<ocam2KCtrl>::setupConfig(config);
+    dev::edtCamera<ocam2KCtrl>::setupConfig( config );
 
-   config.add("camera.ocamDescrambleFile", "", "camera.ocamDescrambleFile", argType::Required, "camera", "ocamDescrambleFile", false, "string", "The path of the OCAM descramble file, relative to MagAOX/config.");
+    config.add( "camera.ocamDescrambleFile",
+                "",
+                "camera.ocamDescrambleFile",
+                argType::Required,
+                "camera",
+                "ocamDescrambleFile",
+                false,
+                "string",
+                "The path of the OCAM descramble file, relative to MagAOX/config." );
 
-   dev::frameGrabber<ocam2KCtrl>::setupConfig(config);
+    dev::frameGrabber<ocam2KCtrl>::setupConfig( config );
 
-   dev::dssShutter<ocam2KCtrl>::setupConfig(config);
+    config.add( "framegrabber.syncShmimName",
+                "",
+                "framegrabber.syncShmimName",
+                argType::Required,
+                "framegrabber",
+                "syncShmimName",
+                false,
+                "string",
+                "The name of the 1x1 uint8 ImageStreamIO sync stream used only for frame metadata and semaphores. "
+                "Defaults to framegrabber.shmimName + \"_sync\"." );
 
-   dev::telemeter<ocam2KCtrl>::setupConfig(config);
+    dev::dssShutter<ocam2KCtrl>::setupConfig( config );
+
+    dev::telemeter<ocam2KCtrl>::setupConfig( config );
 }
 
-
-inline
-void ocam2KCtrl::loadConfig()
+inline void ocam2KCtrl::loadConfig()
 {
-   dev::stdCamera<ocam2KCtrl>::loadConfig(config);
-   dev::edtCamera<ocam2KCtrl>::loadConfig(config);
+    dev::stdCamera<ocam2KCtrl>::loadConfig( config );
+    dev::edtCamera<ocam2KCtrl>::loadConfig( config );
 
-   config(m_ocamDescrambleFile, "camera.ocamDescrambleFile");
+    config( m_ocamDescrambleFile, "camera.ocamDescrambleFile" );
 
-   if(m_maxEMGain < 1)
-   {
-      m_maxEMGain = 1;
-      log<text_log>("maxEMGain set to 1");
-   }
+    if( m_maxEMGain < 1 )
+    {
+        m_maxEMGain = 1;
+        log<text_log>( "maxEMGain set to 1" );
+    }
 
-   if(m_maxEMGain > 600)
-   {
-      m_maxEMGain = 600;
-      log<text_log>("maxEMGain set to 600");
-   }
+    if( m_maxEMGain > 600 )
+    {
+        m_maxEMGain = 600;
+        log<text_log>( "maxEMGain set to 600" );
+    }
 
-   dev::frameGrabber<ocam2KCtrl>::loadConfig(config);
-   dev::dssShutter<ocam2KCtrl>::loadConfig(config);
-   dev::telemeter<ocam2KCtrl>::loadConfig(config);
+    dev::frameGrabber<ocam2KCtrl>::loadConfig( config );
+    config( m_syncShmimName, "framegrabber.syncShmimName" );
+    if( m_syncShmimName == "" )
+    {
+        m_syncShmimName = m_shmimName + "_sync";
+    }
+    dev::dssShutter<ocam2KCtrl>::loadConfig( config );
+    dev::telemeter<ocam2KCtrl>::loadConfig( config );
 }
 
-inline
-int ocam2KCtrl::appStartup()
+inline int ocam2KCtrl::ensureSyncStream()
 {
-   REG_INDI_NEWPROP_NOCB(m_indiP_temps, "temps", pcf::IndiProperty::Number);
-   m_indiP_temps.add (pcf::IndiElement("cpu"));
-   m_indiP_temps["cpu"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("power"));
-   m_indiP_temps["power"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("bias"));
-   m_indiP_temps["bias"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("water"));
-   m_indiP_temps["water"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("left"));
-   m_indiP_temps["left"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("right"));
-   m_indiP_temps["right"].set(0);
-   m_indiP_temps.add (pcf::IndiElement("cooling"));
-   m_indiP_temps["cooling"].set(0);
+    if( m_syncImageStream != nullptr )
+    {
+        uint32_t syncWidth  = m_syncImageStream->md[0].size[0];
+        uint32_t syncHeight = 1;
+        uint32_t syncDepth  = 1;
 
-   REG_INDI_NEWPROP_NOCB(m_indiP_emProt, "emProtection", pcf::IndiProperty::Text);
-   m_indiP_emProt.add(pcf::IndiElement("status"));
-   m_indiP_emProt["status"].set("UNKNOWN");
-   m_indiP_emProt.setState(INDI_IDLE);
+        if( m_syncImageStream->md[0].naxis > 1 )
+        {
+            syncHeight = m_syncImageStream->md[0].size[1];
+        }
 
-   createStandardIndiRequestSw( m_indiP_emProtReset, "emProtectionReset", "Reset", "EM Protection");
-   registerIndiPropertyNew( m_indiP_emProtReset, INDI_NEWCALLBACK(m_indiP_emProtReset));
+        if( m_syncImageStream->md[0].naxis > 2 )
+        {
+            syncDepth = m_syncImageStream->md[0].size[2];
+        }
 
-   REG_INDI_SETPROP(m_indiP_syncFreq, m_syncDevice, m_syncFreqProp);
+        if( m_syncImageStream->md[0].datatype == c_syncStreamDataType && syncWidth == c_syncStreamWidth &&
+            syncHeight == c_syncStreamHeight && syncDepth == c_syncStreamDepth )
+        {
+            return 0;
+        }
 
-   if(dev::stdCamera<ocam2KCtrl>::appStartup() < 0)
-   {
-      return log<software_critical,-1>({""});
-   }
+        ImageStreamIO_destroyIm( m_syncImageStream );
+        free( m_syncImageStream );
+        m_syncImageStream = nullptr;
+    }
 
-   if(dev::edtCamera<ocam2KCtrl>::appStartup() < 0)
-   {
-      return log<software_critical,-1>({""});
-   }
+    char syncFileName[1024];
+    ImageStreamIO_filename( syncFileName, sizeof( syncFileName ), m_syncShmimName.c_str() );
 
-   if(dev::frameGrabber<ocam2KCtrl>::appStartup() < 0)
-   {
-      return log<software_critical,-1>({""});
-   }
+    int syncFd = ::open( syncFileName, O_RDWR );
+    if( syncFd != -1 )
+    {
+        ::close( syncFd );
 
-   if(dev::dssShutter<ocam2KCtrl>::appStartup() < 0)
-   {
-      return log<software_critical,-1>({""});
-   }
+        IMAGE staleSyncStream;
+        if( ImageStreamIO_openIm( &staleSyncStream, m_syncShmimName.c_str() ) != IMAGESTREAMIO_SUCCESS )
+        {
+            return log<software_error, -1>(
+                { __FILE__, __LINE__, "error opening existing sync ImageStreamIO stream" } );
+        }
 
-   m_temps.setInvalid();
-   if(dev::telemeter<ocam2KCtrl>::appStartup() < 0)
-   {
-      return log<software_error,-1>({""});
-   }
+        if( ImageStreamIO_destroyIm( &staleSyncStream ) != IMAGESTREAMIO_SUCCESS )
+        {
+            return log<software_error, -1>(
+                { __FILE__, __LINE__, "error destroying existing sync ImageStreamIO stream" } );
+        }
+    }
 
-   return 0;
+    m_syncImageStream = reinterpret_cast<IMAGE *>( malloc( sizeof( IMAGE ) ) );
+    if( m_syncImageStream == nullptr )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error allocating sync ImageStreamIO stream" } );
+    }
 
+    uint32_t imsize[3] = { c_syncStreamWidth, c_syncStreamHeight, c_syncStreamDepth };
+
+    if( ImageStreamIO_createIm_gpu( m_syncImageStream,
+                                    m_syncShmimName.c_str(),
+                                    3,
+                                    imsize,
+                                    c_syncStreamDataType,
+                                    -1,
+                                    1,
+                                    IMAGE_NB_SEMAPHORE,
+                                    0,
+                                    CIRCULAR_BUFFER | ZAXIS_TEMPORAL,
+                                    0 ) != IMAGESTREAMIO_SUCCESS )
+    {
+        free( m_syncImageStream );
+        m_syncImageStream = nullptr;
+        return log<software_error, -1>( { __FILE__, __LINE__, "error creating sync ImageStreamIO stream" } );
+    }
+
+    m_syncImageStream->array.UI8[0]      = 0;
+    m_syncImageStream->md[0].cnt0        = 0;
+    m_syncImageStream->md[0].cnt1        = 0;
+    m_syncImageStream->md[0].write       = 0;
+    m_syncImageStream->writetimearray[0] = m_syncImageStream->md[0].writetime;
+    m_syncImageStream->atimearray[0]     = m_syncImageStream->md[0].atime;
+    m_syncImageStream->cntarray[0]       = 0;
+
+    return 0;
 }
 
+inline int ocam2KCtrl::destroySyncStream()
+{
+    if( m_syncImageStream == nullptr )
+    {
+        return 0;
+    }
 
+    int rv = 0;
 
-inline
-int ocam2KCtrl::appLogic()
+    if( ImageStreamIO_destroyIm( m_syncImageStream ) != IMAGESTREAMIO_SUCCESS )
+    {
+        rv = log<software_error, -1>( { __FILE__, __LINE__, "error destroying sync ImageStreamIO stream" } );
+    }
+
+    free( m_syncImageStream );
+    m_syncImageStream = nullptr;
+
+    return rv;
+}
+
+inline int ocam2KCtrl::appStartup()
+{
+    REG_INDI_NEWPROP_NOCB( m_indiP_temps, "temps", pcf::IndiProperty::Number );
+    m_indiP_temps.add( pcf::IndiElement( "cpu" ) );
+    m_indiP_temps["cpu"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "power" ) );
+    m_indiP_temps["power"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "bias" ) );
+    m_indiP_temps["bias"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "water" ) );
+    m_indiP_temps["water"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "left" ) );
+    m_indiP_temps["left"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "right" ) );
+    m_indiP_temps["right"].set( 0 );
+    m_indiP_temps.add( pcf::IndiElement( "cooling" ) );
+    m_indiP_temps["cooling"].set( 0 );
+
+    REG_INDI_NEWPROP_NOCB( m_indiP_emProt, "emProtection", pcf::IndiProperty::Text );
+    m_indiP_emProt.add( pcf::IndiElement( "status" ) );
+    m_indiP_emProt["status"].set( "UNKNOWN" );
+    m_indiP_emProt.setState( INDI_IDLE );
+
+    createStandardIndiRequestSw( m_indiP_emProtReset, "emProtectionReset", "Reset", "EM Protection" );
+    registerIndiPropertyNew( m_indiP_emProtReset, INDI_NEWCALLBACK( m_indiP_emProtReset ) );
+
+    REG_INDI_SETPROP( m_indiP_syncFreq, m_syncDevice, m_syncFreqProp );
+
+    if( dev::stdCamera<ocam2KCtrl>::appStartup() < 0 )
+    {
+        return log<software_critical, -1>( { "" } );
+    }
+
+    if( dev::edtCamera<ocam2KCtrl>::appStartup() < 0 )
+    {
+        return log<software_critical, -1>( { "" } );
+    }
+
+    if( dev::frameGrabber<ocam2KCtrl>::appStartup() < 0 )
+    {
+        return log<software_critical, -1>( { "" } );
+    }
+
+    if( dev::dssShutter<ocam2KCtrl>::appStartup() < 0 )
+    {
+        return log<software_critical, -1>( { "" } );
+    }
+
+    m_temps.setInvalid();
+    if( dev::telemeter<ocam2KCtrl>::appStartup() < 0 )
+    {
+        return log<software_error, -1>( { "" } );
+    }
+
+    return 0;
+}
+
+inline int ocam2KCtrl::appLogic()
 {
 
-   //and run stdCamera's appLogic
-   if(dev::stdCamera<ocam2KCtrl>::appLogic() < 0)
-   {
-      return log<software_error, -1>({""});
-   }
+    // and run stdCamera's appLogic
+    if( dev::stdCamera<ocam2KCtrl>::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { "" } );
+    }
 
-   //and run edtCamera's appLogic
-   if(dev::edtCamera<ocam2KCtrl>::appLogic() < 0)
-   {
-      return log<software_error, -1>({""});
-   }
+    // and run edtCamera's appLogic
+    if( dev::edtCamera<ocam2KCtrl>::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { "" } );
+    }
 
-   //first run frameGrabber's appLogic to see if the f.g. thread has exited.
-   if(dev::frameGrabber<ocam2KCtrl>::appLogic() < 0)
-   {
-      return log<software_error, -1>({""});
-   }
+    // first run frameGrabber's appLogic to see if the f.g. thread has exited.
+    if( dev::frameGrabber<ocam2KCtrl>::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { "" } );
+    }
 
-   //and run dssShutter's appLogic
-   if(dev::dssShutter<ocam2KCtrl>::appLogic() < 0)
-   {
-      return log<software_error, -1>({""});
-   }
+    // and run dssShutter's appLogic
+    if( dev::dssShutter<ocam2KCtrl>::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { "" } );
+    }
 
-   if( state() == stateCodes::POWERON) return 0;
+    if( state() == stateCodes::POWERON )
+        return 0;
 
-   if( state() == stateCodes::NOTCONNECTED || state() == stateCodes::ERROR)
-   {
-      m_temps.setInvalid();
+    if( state() == stateCodes::NOTCONNECTED || state() == stateCodes::ERROR )
+    {
+        m_temps.setInvalid();
 
-      std::string response;
+        std::string response;
 
-      //Might have gotten here because of a power off.
-      if(MagAOXAppT::m_powerState == 0) return 0;
+        // Might have gotten here because of a power off.
+        if( MagAOXAppT::m_powerState == 0 )
+            return 0;
 
-      int ret = 0;
-      { //mutex scope
-         std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-         ret = pdvSerialWriteRead( response, "fps"); //m_pdv, "fps", m_readTimeout);
-      }
-      if( ret == 0)
-      {
-         state(stateCodes::CONNECTED);
-      }
-      else
-      {
-         sleep(1);
-         return 0;
-      }
-   }
+        int ret = 0;
+        { // mutex scope
+            std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+            ret = pdvSerialWriteRead( response, "fps" ); // m_pdv, "fps", m_readTimeout);
+        }
+        if( ret == 0 )
+        {
+            state( stateCodes::CONNECTED );
+        }
+        else
+        {
+            sleep( 1 );
+            return 0;
+        }
+    }
 
-   if( state() == stateCodes::CONNECTED )
-   {
-      //Get a lock
-      std::unique_lock<std::mutex> lock(m_indiMutex);
+    if( state() == stateCodes::CONNECTED )
+    {
+        // Get a lock
+        std::unique_lock<std::mutex> lock( m_indiMutex );
 
-      if( getFPS() == 0 )
-      {
-         if(m_fpsSet == 0) state(stateCodes::READY);
-         else state(stateCodes::OPERATING);
+        if( getFPS() == 0 )
+        {
+            if( m_fpsSet == 0 )
+                state( stateCodes::READY );
+            else
+                state( stateCodes::OPERATING );
 
-         if(m_poweredOn && m_ccdTempSetpt > -999)
-         {
-            m_poweredOn = false;
-            if(setTempSetPt() < 0)
+            if( m_poweredOn && m_ccdTempSetpt > -999 )
             {
-               if(powerState() != 1 || powerStateTarget() != 1) return 0;
-               return log<software_error,0>({""});
+                m_poweredOn = false;
+                if( setTempSetPt() < 0 )
+                {
+                    if( powerState() != 1 || powerStateTarget() != 1 )
+                    {
+                        return 0;
+                    }
+                    return log<software_error, 0>( { "" } );
+                }
             }
-         }
 
-         //We always have to set synchro on connecting, b/c otherwise we don't know the state.
-         m_synchroSet = false;
-         if( setSynchro() != 0 )
-         {
-            log<software_error>({"error from setSynchro on CONNECT"});
-         }
-      }
-      else
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return 0;
-         state(stateCodes::ERROR);
-         return log<software_error,0>({""});
-      }
-   }
+            // We always have to set synchro on connecting, b/c otherwise we don't know the state.
+            m_synchroSet = false;
+            if( setSynchro() != 0 )
+            {
+                log<software_error>( { "error from setSynchro on CONNECT" } );
+            }
+        }
+        else
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return 0;
+            state( stateCodes::ERROR );
+            return log<software_error, 0>( { "" } );
+        }
+    }
 
-   if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
-   {
-      //Get a lock if we can
-      std::unique_lock<std::mutex> lock(m_indiMutex, std::try_to_lock);
+    if( state() == stateCodes::READY || state() == stateCodes::OPERATING )
+    {
+        // Get a lock if we can
+        std::unique_lock<std::mutex> lock( m_indiMutex, std::try_to_lock );
 
-      //but don't wait for it, just go back around.
-      if(!lock.owns_lock()) return 0;
+        // but don't wait for it, just go back around.
+        if( !lock.owns_lock() )
+            return 0;
 
-      if(getTemps() < 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return 0;
-         m_temps.setInvalid();
-         state(stateCodes::ERROR);
-         return 0;
-      }
+        if( getTemps() < 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return 0;
+            m_temps.setInvalid();
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(getFPS() < 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return 0;
+        if( getFPS() < 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return 0;
 
-         state(stateCodes::ERROR);
-         return 0;
-      }
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(m_protectionResetConfirmed > 0 )
-      {
-         if( mx::sys::get_curr_time() - m_protectionResetReqTime > 10.0)
-         {
-            m_protectionResetConfirmed = 0;
-            updateIfChanged(m_indiP_emProt, "status", std::string("UNCONFIRMED"));
-            log<text_log>("protection reset request not confirmed", logPrio::LOG_NOTICE);
-         }
-      }
+        if( m_protectionResetConfirmed > 0 )
+        {
+            if( mx::sys::get_curr_time() - m_protectionResetReqTime > 10.0 )
+            {
+                m_protectionResetConfirmed = 0;
+                updateIfChanged( m_indiP_emProt, "status", std::string( "UNCONFIRMED" ) );
+                log<text_log>( "protection reset request not confirmed", logPrio::LOG_NOTICE );
+            }
+        }
 
-      if(getEMGain () < 0)
-      {
-         if(MagAOXAppT::m_powerState == 0) return 0;
+        if( getEMGain() < 0 )
+        {
+            if( MagAOXAppT::m_powerState == 0 )
+                return 0;
 
-         state(stateCodes::ERROR);
-         return 0;
-      }
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(frameGrabber<ocam2KCtrl>::updateINDI() < 0)
-      {
-         log<software_error>({""});
-         state(stateCodes::ERROR);
-         return 0;
-      }
+        if( frameGrabber<ocam2KCtrl>::updateINDI() < 0 )
+        {
+            log<software_error>( { "" } );
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(stdCamera<ocam2KCtrl>::updateINDI() < 0)
-      {
-         log<software_error>({""});
-         state(stateCodes::ERROR);
-         return 0;
-      }
+        if( stdCamera<ocam2KCtrl>::updateINDI() < 0 )
+        {
+            log<software_error>( { "" } );
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(edtCamera<ocam2KCtrl>::updateINDI() < 0)
-      {
-         log<software_error>({""});
-         state(stateCodes::ERROR);
-         return 0;
-      }
+        if( edtCamera<ocam2KCtrl>::updateINDI() < 0 )
+        {
+            log<software_error>( { "" } );
+            state( stateCodes::ERROR );
+            return 0;
+        }
 
-      if(telemeter<ocam2KCtrl>::appLogic() < 0)
-      {
-         log<software_error>({""});
-         return 0;
-      }
+        if( telemeter<ocam2KCtrl>::appLogic() < 0 )
+        {
+            log<software_error>( { "" } );
+            return 0;
+        }
+    }
 
-   }
+    ///\todo Fall through check?
 
-   ///\todo Fall through check?
-
-   return 0;
-
+    return 0;
 }
 
-inline
-int ocam2KCtrl::onPowerOff()
+inline int ocam2KCtrl::onPowerOff()
 {
-   m_powerOnCounter = 0;
+    m_powerOnCounter = 0;
 
-   std::lock_guard<std::mutex> lock(m_indiMutex);
+    std::lock_guard<std::mutex> lock( m_indiMutex );
 
-   updateIfChanged(m_indiP_emProt, "status", std::string("UNKNOWN"), INDI_IDLE);
+    updateIfChanged( m_indiP_emProt, "status", std::string( "UNKNOWN" ), INDI_IDLE );
 
-   m_temps.setInvalid();
+    m_temps.setInvalid();
 
-   updateIfChanged(m_indiP_temps, "cpu", m_temps.CPU);
-   updateIfChanged(m_indiP_temps, "power", m_temps.POWER);
-   updateIfChanged(m_indiP_temps, "bias", m_temps.BIAS);
-   updateIfChanged(m_indiP_temps, "water", m_temps.WATER);
-   updateIfChanged(m_indiP_temps, "left", m_temps.LEFT);
-   updateIfChanged(m_indiP_temps, "right", m_temps.RIGHT);
-   updateIfChanged(m_indiP_temps, "cooling", m_temps.COOLING_POWER);
+    updateIfChanged( m_indiP_temps, "cpu", m_temps.CPU );
+    updateIfChanged( m_indiP_temps, "power", m_temps.POWER );
+    updateIfChanged( m_indiP_temps, "bias", m_temps.BIAS );
+    updateIfChanged( m_indiP_temps, "water", m_temps.WATER );
+    updateIfChanged( m_indiP_temps, "left", m_temps.LEFT );
+    updateIfChanged( m_indiP_temps, "right", m_temps.RIGHT );
+    updateIfChanged( m_indiP_temps, "cooling", m_temps.COOLING_POWER );
 
-   if(stdCamera<ocam2KCtrl>::onPowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( stdCamera<ocam2KCtrl>::onPowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   if(edtCamera<ocam2KCtrl>::onPowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( edtCamera<ocam2KCtrl>::onPowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   if(frameGrabber<ocam2KCtrl>::onPowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( frameGrabber<ocam2KCtrl>::onPowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   if(dssShutter<ocam2KCtrl>::onPowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( dssShutter<ocam2KCtrl>::onPowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   //Setting m_poweredOn
-   m_poweredOn = true;
+    // Setting m_poweredOn
+    m_poweredOn = true;
 
-
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::whilePowerOff()
+inline int ocam2KCtrl::whilePowerOff()
 {
-   std::lock_guard<std::mutex> lock(m_indiMutex);
+    std::lock_guard<std::mutex> lock( m_indiMutex );
 
-   if(stdCamera<ocam2KCtrl>::whilePowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( stdCamera<ocam2KCtrl>::whilePowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   if(edtCamera<ocam2KCtrl>::whilePowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( edtCamera<ocam2KCtrl>::whilePowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   if(dssShutter<ocam2KCtrl>::whilePowerOff() < 0)
-   {
-      log<software_error>({""});
-   }
+    if( dssShutter<ocam2KCtrl>::whilePowerOff() < 0 )
+    {
+        log<software_error>( { "" } );
+    }
 
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::appShutdown()
+inline int ocam2KCtrl::appShutdown()
 {
-   ///\todo error check these base class fxns.
+    ///\todo error check these base class fxns.
 
-   dev::stdCamera<ocam2KCtrl>::appShutdown();
+    dev::stdCamera<ocam2KCtrl>::appShutdown();
 
-   dev::edtCamera<ocam2KCtrl>::appShutdown();
+    dev::edtCamera<ocam2KCtrl>::appShutdown();
 
-   dev::frameGrabber<ocam2KCtrl>::appShutdown();
+    dev::frameGrabber<ocam2KCtrl>::appShutdown();
 
-   dev::dssShutter<ocam2KCtrl>::appShutdown();
+    destroySyncStream();
 
-   dev::telemeter<ocam2KCtrl>::appShutdown();
+    dev::dssShutter<ocam2KCtrl>::appShutdown();
 
-   return 0;
+    dev::telemeter<ocam2KCtrl>::appShutdown();
+
+    return 0;
 }
 
-
-inline
-int ocam2KCtrl::getTemps()
+inline int ocam2KCtrl::getTemps()
 {
-   std::string response;
+    std::string response;
 
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, "temp") != 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, "temp" ) != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
 
-   {
-      ocamTemps temps;
+    {
+        ocamTemps temps;
 
-      if(parseTemps( temps, response ) < 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
+        if( parseTemps( temps, response ) < 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
 
-         m_temps.setInvalid();
-         m_ccdTemp = m_temps.CCD;
-         m_ccdTempSetpt = m_temps.SET;
-         m_tempControlStatus = false;
-         m_tempControlStatusStr = "UNKNOWN";
+            m_temps.setInvalid();
+            m_ccdTemp              = m_temps.CCD;
+            m_ccdTempSetpt         = m_temps.SET;
+            m_tempControlStatus    = false;
+            m_tempControlStatusStr = "UNKNOWN";
 
-         recordTemps();
-         recordCamera();
+            recordTemps();
+            recordCamera();
 
-         std::cerr << "Temp. parse error. Response:\n" << response << std::endl;
+            std::cerr << "Temp. parse error. Response:\n" << response << std::endl;
 
-         //We don't trust the temps, but don't reconfig just for this.
-         return log<software_error, 0>({"Temp. parse error"});
-      }
+            // We don't trust the temps, but don't reconfig just for this.
+            return log<software_error, 0>( { "Temp. parse error" } );
+        }
 
-      m_temps = temps;
+        m_temps = temps;
 
-      //stdCamera temp control:
-      m_ccdTemp = m_temps.CCD;
-      m_ccdTempSetpt = m_temps.SET;
+        // stdCamera temp control:
+        m_ccdTemp      = m_temps.CCD;
+        m_ccdTempSetpt = m_temps.SET;
 
-      //Detect that temperature control is off
-      if(m_temps.COOLING_POWER < 5)
-      {
-         if( m_temps.CCD - m_temps.SET > 2.99 )
-         {
-            m_tempControlStatus = false;
-         }
-      }
-      else m_tempControlStatus = true;
+        // Detect that temperature control is off
+        if( m_temps.COOLING_POWER < 5 )
+        {
+            if( m_temps.CCD - m_temps.SET > 2.99 )
+            {
+                m_tempControlStatus = false;
+            }
+        }
+        else
+            m_tempControlStatus = true;
 
-      if(m_tempControlStatus == true)
-      {
-         if(fabs(m_temps.CCD - m_temps.SET) < 1.0)
-         {
-            m_tempControlStatusStr = "ON TARGET";
-            m_tempControlOnTarget = true;
-         }
-         else
-         {
-            m_tempControlStatusStr = "OFF TARGET";
-            m_tempControlOnTarget = false;
-         }
-      }
-      else
-      {
-         m_tempControlStatusStr = "TEMP OFF";
-         m_tempControlOnTarget = false;
-      }
+        if( m_tempControlStatus == true )
+        {
+            if( fabs( m_temps.CCD - m_temps.SET ) < 1.0 )
+            {
+                m_tempControlStatusStr = "ON TARGET";
+                m_tempControlOnTarget  = true;
+            }
+            else
+            {
+                m_tempControlStatusStr = "OFF TARGET";
+                m_tempControlOnTarget  = false;
+            }
+        }
+        else
+        {
+            m_tempControlStatusStr = "TEMP OFF";
+            m_tempControlOnTarget  = false;
+        }
 
+        // Telemeter:
+        recordTemps();
+        recordCamera();
 
-      //Telemeter:
-      recordTemps();
-      recordCamera();
-
-      updateIfChanged(m_indiP_temps, "cpu", m_temps.CPU);
-      updateIfChanged(m_indiP_temps, "power", m_temps.POWER);
-      updateIfChanged(m_indiP_temps, "bias", m_temps.BIAS);
-      updateIfChanged(m_indiP_temps, "water", m_temps.WATER);
-      updateIfChanged(m_indiP_temps, "left", m_temps.LEFT);
-      updateIfChanged(m_indiP_temps, "right", m_temps.RIGHT);
-      updateIfChanged(m_indiP_temps, "cooling", m_temps.COOLING_POWER);
-      return 0;
-
-   }
+        updateIfChanged( m_indiP_temps, "cpu", m_temps.CPU );
+        updateIfChanged( m_indiP_temps, "power", m_temps.POWER );
+        updateIfChanged( m_indiP_temps, "bias", m_temps.BIAS );
+        updateIfChanged( m_indiP_temps, "water", m_temps.WATER );
+        updateIfChanged( m_indiP_temps, "left", m_temps.LEFT );
+        updateIfChanged( m_indiP_temps, "right", m_temps.RIGHT );
+        updateIfChanged( m_indiP_temps, "cooling", m_temps.COOLING_POWER );
+        return 0;
+    }
 }
 
-inline
-int ocam2KCtrl::powerOnDefaults()
+inline int ocam2KCtrl::powerOnDefaults()
 {
-   //Camera boots up with this true in most cases.
-   m_tempControlStatusSet = false;
-   m_tempControlStatus =false;
+    // Camera boots up with this true in most cases.
+    m_tempControlStatusSet = false;
+    m_tempControlStatus    = false;
 
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::setTempControl()
+inline int ocam2KCtrl::setTempControl()
 {
-   std::string response;
+    std::string response;
 
-   std::string command;
+    std::string command;
 
-   std::string comStr = "temp ";
-   if(m_tempControlStatusSet)
-   {
-      command = "on";
-      m_tempControlStatusSet = true;
-      m_tempControlStatus = true;
-   }
-   else
-   {
-      if( m_ccdTemp > 19) //19 is 20 with a 1 C slop
-      {
-         command = "off";
-         m_tempControlStatusSet = false;
-         m_tempControlStatus = false;
-      }
-      else
-      {
-         return log<text_log,-1>("Can not turn temp control off when not at 20 C or higher", logPrio::LOG_ERROR);
-      }
-   }
+    std::string comStr = "temp ";
+    if( m_tempControlStatusSet )
+    {
+        command                = "on";
+        m_tempControlStatusSet = true;
+        m_tempControlStatus    = true;
+    }
+    else
+    {
+        if( m_ccdTemp > 19 ) // 19 is 20 with a 1 C slop
+        {
+            command                = "off";
+            m_tempControlStatusSet = false;
+            m_tempControlStatus    = false;
+        }
+        else
+        {
+            return log<text_log, -1>( "Can not turn temp control off when not at 20 C or higher", logPrio::LOG_ERROR );
+        }
+    }
 
-   comStr += command;
+    comStr += command;
 
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, comStr) != 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, comStr ) != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
 
-   {
-      std::cerr << "response: " << response << "\n";
-      ///\todo check response
-      log<text_log,0>({"Set temperature control to " + command});
-   }
+    {
+        std::cerr << "response: " << response << "\n";
+        ///\todo check response
+        log<text_log, 0>( { "Set temperature control to " + command } );
+    }
 
-   if( m_tempControlStatusSet && m_ccdTempSetpt > -999)
-   {
-      return setTempSetPt();
-   }
+    if( m_tempControlStatusSet && m_ccdTempSetpt > -999 )
+    {
+        return setTempSetPt();
+    }
 
-   recordCamera();
+    recordCamera();
 
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::setTempSetPt()
+inline int ocam2KCtrl::setTempSetPt()
 {
-   std::string response;
+    std::string response;
 
-   std::string tempStr = std::to_string( m_ccdTempSetpt );
+    std::string tempStr = std::to_string( m_ccdTempSetpt );
 
-   ///\todo make more configurable
-   if(m_ccdTempSetpt >= 30 || m_ccdTempSetpt < -50)
-   {
-      return log<text_log,-1>({"attempt to set temperature outside valid range: " + tempStr}, logPrio::LOG_ERROR);
-   }
+    ///\todo make more configurable
+    if( m_ccdTempSetpt >= 30 || m_ccdTempSetpt < -50 )
+    {
+        return log<text_log, -1>( { "attempt to set temperature outside valid range: " + tempStr },
+                                  logPrio::LOG_ERROR );
+    }
 
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, "temp " + tempStr) != 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, "temp " + tempStr ) != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
 
-   {
-      std::cerr << "response: " << response << "\n";
+    {
+        std::cerr << "response: " << response << "\n";
 
-      recordCamera();
+        recordCamera();
 
-      ///\todo check response
-      std::cerr << "temp " <<  tempStr << " response: " << response << "\n";
+        ///\todo check response
+        std::cerr << "temp " << tempStr << " response: " << response << "\n";
 
-      return log<text_log,0>({"set temperature: " + tempStr});
-   }
+        return log<text_log, 0>( { "set temperature: " + tempStr } );
+    }
 }
 
-inline
-int ocam2KCtrl::getFPS()
+inline int ocam2KCtrl::getFPS()
 {
-    if(!m_synchro)
+    if( !m_synchro )
     {
         std::string response;
 
-        { //mutex scope
-            std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-            if( pdvSerialWriteRead( response, "fps") != 0) return log<software_error,-1>({""}); // m_pdv, "fps", m_readTimeout) == 0)
+        { // mutex scope
+            std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+            if( pdvSerialWriteRead( response, "fps" ) != 0 )
+                return log<software_error, -1>( { "" } ); // m_pdv, "fps", m_readTimeout) == 0)
         }
 
         {
             float fps;
-            if(parseFPS( fps, response ) < 0)
+            if( parseFPS( fps, response ) < 0 )
             {
-                if(powerState() != 1 || powerStateTarget() != 1) return -1;
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                    return -1;
 
                 std::cerr << "fps parse error. Response:\n" << response << "\n";
 
-                return log<software_error, 0>({"fps parse error"});
+                return log<software_error, 0>( { "fps parse error" } );
             }
             m_fps = fps;
 
             recordCamera();
 
             return 0;
-
         }
     }
     else
@@ -952,297 +1126,292 @@ int ocam2KCtrl::getFPS()
     }
 }
 
-inline
-int ocam2KCtrl::setFPS()
+inline int ocam2KCtrl::setFPS()
 {
-    std::string fpsStr= std::to_string(m_fpsSet);
+    std::string fpsStr = std::to_string( m_fpsSet );
 
-    if(!m_synchro)
+    if( !m_synchro )
     {
         std::string response;
 
-        { //mutex scope
-            std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-            if( pdvSerialWriteRead( response, "fps " + fpsStr ) != 0)
+        { // mutex scope
+            std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+            if( pdvSerialWriteRead( response, "fps " + fpsStr ) != 0 )
             {
-                if(powerState() != 1 || powerStateTarget() != 1) return -1;
-                return log<software_error,-1>({""});
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                    return -1;
+                return log<software_error, -1>( { "" } );
             }
         }
 
         {
             ///\todo check response
             std::cerr << "fps " << fpsStr << " response: " << response << "\n";
-            log<text_log>({"set fps: " + fpsStr});
+            log<text_log>( { "set fps: " + fpsStr } );
 
-            //We always want to reset the latency circular buffers
+            // We always want to reset the latency circular buffers
             ///\todo verify that this works!!
             m_nextMode = m_modeName;
             m_reconfig = true;
-
         }
     }
     else
     {
         std::cerr << "setting: " << fpsStr << "\n";
 
-        pcf::IndiProperty ipFreq(pcf::IndiProperty::Number);
+        pcf::IndiProperty ipFreq( pcf::IndiProperty::Number );
 
-        ipFreq.setDevice(m_syncDevice);
-        ipFreq.setName(m_syncFreqProp);
-        ipFreq.add(pcf::IndiElement("target"));
+        ipFreq.setDevice( m_syncDevice );
+        ipFreq.setName( m_syncFreqProp );
+        ipFreq.add( pcf::IndiElement( "target" ) );
 
         ipFreq["target"] = fpsStr;
 
-        sendNewProperty(ipFreq);
+        sendNewProperty( ipFreq );
     }
-
-
 
     return 0;
 }
 
-inline
-int ocam2KCtrl::setSynchro()
+inline int ocam2KCtrl::setSynchro()
 {
     std::string response;
 
-    { //mutex scope
-        std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
 
-        //First set the actual FPS to 0 to get to max
-        std::string fpsStr= std::to_string(0);
-        if( pdvSerialWriteRead( response, "fps " + fpsStr ) == 0)
+        // First set the actual FPS to 0 to get to max
+        std::string fpsStr = std::to_string( 0 );
+        if( pdvSerialWriteRead( response, "fps " + fpsStr ) == 0 )
         {
             ///\todo check response
             std::cerr << "fps " << fpsStr << " response: " << response << "\n";
-            log<text_log>({"set fps: " + fpsStr});
+            log<text_log>( { "set fps: " + fpsStr } );
         }
         else
         {
-            if(powerState() != 1 || powerStateTarget() != 1) return -1;
-            return log<software_error,-1>({""});
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
         }
 
-        //Now actually turn synchro on
+        // Now actually turn synchro on
         std::string sStr;
-        if(m_synchroSet) sStr = "on";
-        else sStr = "off";
-        if( pdvSerialWriteRead( response, "synchro " + sStr ) == 0)
+        if( m_synchroSet )
+            sStr = "on";
+        else
+            sStr = "off";
+        if( pdvSerialWriteRead( response, "synchro " + sStr ) == 0 )
         {
             ///\todo check response
             std::cerr << "synchro " << sStr << " resonse: " << response << "\n";
-            log<text_log>({"set synchro: " + sStr});
+            log<text_log>( { "set synchro: " + sStr } );
 
             m_synchro = m_synchroSet;
 
-            if(m_synchro == false)
+            if( m_synchro == false )
             {
-                updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE);
+                updateSwitchIfChanged( m_indiP_synchro, "toggle", pcf::IndiElement::Off, INDI_IDLE );
             }
             else
             {
-                updateSwitchIfChanged(m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_OK);
+                updateSwitchIfChanged( m_indiP_synchro, "toggle", pcf::IndiElement::On, INDI_OK );
             }
         }
         else
         {
-            if(powerState() != 1 || powerStateTarget() != 1) return -1;
-            return log<software_error,-1>({""});
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
         }
     }
 
-    //Finally we set the FPS of the synchro device
+    // Finally we set the FPS of the synchro device
     return setFPS();
 }
 
-inline
-int ocam2KCtrl::setExpTime()
+inline int ocam2KCtrl::setExpTime()
 {
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::setNextROI()
+inline int ocam2KCtrl::setNextROI()
 {
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::setShutter(int sh)
+inline int ocam2KCtrl::setShutter( int sh )
 {
-   return dssShutter<ocam2KCtrl>::setShutterState(sh);
+    return dssShutter<ocam2KCtrl>::setShutterState( sh );
 }
 
-inline
-std::string ocam2KCtrl::stateString()
+inline std::string ocam2KCtrl::stateString()
 {
-   std::string ss;
+    std::string ss;
 
-   ss += m_modeName + "_";
-   ss += std::to_string(m_fps) + "_";
-   ss += std::to_string(m_emGain) + "_";
-   ss += std::to_string(m_ccdTempSetpt);
+    ss += m_modeName + "_";
+    ss += std::to_string( m_fps ) + "_";
+    ss += std::to_string( m_emGain ) + "_";
+    ss += std::to_string( m_ccdTempSetpt );
 
-   return ss;
+    return ss;
 }
 
-inline
-bool ocam2KCtrl::stateStringValid()
+inline bool ocam2KCtrl::stateStringValid()
 {
-   if(state() == stateCodes::OPERATING && m_tempControlOnTarget)
-   {
-      return true;
-   }
-   else return false;
-}
-
-inline
-int ocam2KCtrl::resetEMProtection()
-{
-   std::string response;
-
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, "protection reset") != 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
-
-   {
-      std::cerr << "\n******************************************\n";
-      std::cerr << "protection reset:\n";
-      std::cerr << response << "\n";
-      std::cerr << "\n******************************************\n";
-      ///\todo check response.
-
-      updateIfChanged(m_indiP_emProt, "status", std::string("RESET"), INDI_OK);
-
-      log<text_log>("overillumination protection has been reset", logPrio::LOG_NOTICE);
-
-      m_protectionResetConfirmed = 0;
-
-      m_protectionReset = true;
-
-      return 0;
-
-   }
-}
-
-inline
-int ocam2KCtrl::getEMGain()
-{
-   std::string response;
-
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, "gain") != 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
-
-   {
-      unsigned emGain;
-      if(parseEMGain( emGain, response ) < 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-
-         if(response.find("HV") != std::string::npos)
-         {
-            m_emGain = 1;
-            updateIfChanged(m_indiP_emProt, "status", std::string("TRIPPED"), INDI_ALERT);
-            return log<software_warning, -1>({"EM Gain tripped!"});
-
-         }
-
-         std::cerr << "EM Gain parse error, response:\n" << response << "\n";
-
-         return log<software_error, -1>({"EM Gain parse error"});
-      }
-
-      m_emGain = emGain;
-
-      return 0;
-
-   }
-}
-
-inline
-int ocam2KCtrl::setEMGain( )
-{
-   std::string response;
-
-   if(m_protectionReset == false)
-   {
-      log<text_log>("Attempt to set EM gain before protection reset", logPrio::LOG_NOTICE);
-
-      if(m_emGainSet > 1) //we allow setting to 1 for safety
-      {
-         return 0;
-      }
-   }
-
-   unsigned emg  = m_emGainSet; //a float
-
-   if(emg < 1 || emg > m_maxEMGain)
-   {
-      log<text_log>("Attempt to set EM gain to " + std::to_string(emg) + " outside limits refused", logPrio::LOG_WARNING);
-      return 0;
-   }
-
-   std::string emgStr= std::to_string(emg);
-   { //mutex scope
-      std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-      if( pdvSerialWriteRead( response, "gain " + emgStr ) != 0) //m_pdv, "gain " + emgStr, m_readTimeout) == 0)
-      {
-         if(powerState() != 1 || powerStateTarget() != 1) return -1;
-         return log<software_error,-1>({""});
-      }
-   }
-
-   {
-      ///\todo check response
-      std::cerr << "gain " << emgStr << " response: " << emgStr << "\n";
-
-      log<text_log>({"set EM Gain: " + emgStr});
-
-      return 0;
-   }
-}
-
-inline
-int ocam2KCtrl::configureAcquisition()
-{
-    //lock mutex
-    std::unique_lock<std::mutex> lock(m_indiMutex);
-    std::lock_guard<std::recursive_mutex> cameraGuard(m_cameraMutex);
-
-    //Send command to camera to place it in the correct mode
-    std::string response;
-    if( pdvSerialWriteRead( response, m_cameraModes[m_modeName].m_serialCommand) != 0) //m_pdv, m_cameraModes[m_modeName].m_serialCommand, m_readTimeout) != 0)
+    if( state() == stateCodes::OPERATING && m_tempControlOnTarget )
     {
-        if(powerState() != 1 || powerStateTarget() != 1) return -1;
+        return true;
+    }
+    else
+        return false;
+}
 
-        log<software_error>({"Error sending command to set mode"});
-        sleep(1);
+inline int ocam2KCtrl::resetEMProtection()
+{
+    std::string response;
+
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, "protection reset" ) != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
+
+    {
+        std::cerr << "\n******************************************\n";
+        std::cerr << "protection reset:\n";
+        std::cerr << response << "\n";
+        std::cerr << "\n******************************************\n";
+        ///\todo check response.
+
+        updateIfChanged( m_indiP_emProt, "status", std::string( "RESET" ), INDI_OK );
+
+        log<text_log>( "overillumination protection has been reset", logPrio::LOG_NOTICE );
+
+        m_protectionResetConfirmed = 0;
+
+        m_protectionReset = true;
+
+        return 0;
+    }
+}
+
+inline int ocam2KCtrl::getEMGain()
+{
+    std::string response;
+
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, "gain" ) != 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
+
+    {
+        unsigned emGain;
+        if( parseEMGain( emGain, response ) < 0 )
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+
+            if( response.find( "HV" ) != std::string::npos )
+            {
+                m_emGain = 1;
+                updateIfChanged( m_indiP_emProt, "status", std::string( "TRIPPED" ), INDI_ALERT );
+                return log<software_warning, -1>( { "EM Gain tripped!" } );
+            }
+
+            std::cerr << "EM Gain parse error, response:\n" << response << "\n";
+
+            return log<software_error, -1>( { "EM Gain parse error" } );
+        }
+
+        m_emGain = emGain;
+
+        return 0;
+    }
+}
+
+inline int ocam2KCtrl::setEMGain()
+{
+    std::string response;
+
+    if( m_protectionReset == false )
+    {
+        log<text_log>( "Attempt to set EM gain before protection reset", logPrio::LOG_NOTICE );
+
+        if( m_emGainSet > 1 ) // we allow setting to 1 for safety
+        {
+            return 0;
+        }
+    }
+
+    unsigned emg = m_emGainSet; // a float
+
+    if( emg < 1 || emg > m_maxEMGain )
+    {
+        log<text_log>( "Attempt to set EM gain to " + std::to_string( emg ) + " outside limits refused",
+                       logPrio::LOG_WARNING );
+        return 0;
+    }
+
+    std::string emgStr = std::to_string( emg );
+    { // mutex scope
+        std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+        if( pdvSerialWriteRead( response, "gain " + emgStr ) != 0 ) // m_pdv, "gain " + emgStr, m_readTimeout) == 0)
+        {
+            if( powerState() != 1 || powerStateTarget() != 1 )
+                return -1;
+            return log<software_error, -1>( { "" } );
+        }
+    }
+
+    {
+        ///\todo check response
+        std::cerr << "gain " << emgStr << " response: " << emgStr << "\n";
+
+        log<text_log>( { "set EM Gain: " + emgStr } );
+
+        return 0;
+    }
+}
+
+inline int ocam2KCtrl::configureAcquisition()
+{
+    // lock mutex
+    std::unique_lock<std::mutex>          lock( m_indiMutex );
+    std::lock_guard<std::recursive_mutex> cameraGuard( m_cameraMutex );
+
+    // Send command to camera to place it in the correct mode
+    std::string response;
+    if( pdvSerialWriteRead( response, m_cameraModes[m_modeName].m_serialCommand ) != 0 )
+    {
+        if( powerState() != 1 || powerStateTarget() != 1 )
+            return -1;
+
+        log<software_error>( { "Error sending command to set mode" } );
+        sleep( 1 );
         return -1;
     }
 
-    m_currentROI.x = 119.5;
-    m_currentROI.y = 119.5;
-    m_currentROI.w = 240;
-    m_currentROI.h = 240;
+    m_currentROI.x     = 119.5;
+    m_currentROI.y     = 119.5;
+    m_currentROI.w     = 240;
+    m_currentROI.h     = 240;
     m_currentROI.bin_x = m_cameraModes[m_modeName].m_binningX;
     m_currentROI.bin_y = m_cameraModes[m_modeName].m_binningY;
 
     m_digitalBinX = m_cameraModes[m_modeName].m_digitalBinX;
     m_digitalBinY = m_cameraModes[m_modeName].m_digitalBinY;
 
-    if(m_digitalBinX > 1)
+    if( m_digitalBinX > 1 )
     {
         m_digitalBin = true;
         std::cerr << "digital binning!\n";
@@ -1254,59 +1423,62 @@ int ocam2KCtrl::configureAcquisition()
 
     recordCamera();
 
-     ///\todo check response of pdvSerialWriteRead
-    log<text_log>("camera configured with: " +m_cameraModes[m_modeName].m_serialCommand);
+    ///\todo check response of pdvSerialWriteRead
+    log<text_log>( "camera configured with: " + m_cameraModes[m_modeName].m_serialCommand );
 
-    if(m_fpsSet > 0) setFPS();
-
-    log<text_log>("Send command to set mode: " + m_cameraModes[m_modeName].m_serialCommand);
-    log<text_log>("Response was: " + response);
-
-    if(setSynchro() < 0)
+    if( m_fpsSet > 0 )
     {
-        log<software_error>({"Error setting synchro during configureAcquisition"});
+        setFPS();
+    }
+
+    log<text_log>( "Send command to set mode: " + m_cameraModes[m_modeName].m_serialCommand );
+    log<text_log>( "Response was: " + response );
+
+    if( setSynchro() < 0 )
+    {
+        log<software_error>( { "Error setting synchro during configureAcquisition" } );
     }
 
     /* Initialize the OCAM2 SDK
-        */
+     */
 
-    if(m_ocam2_id > 0)
+    if( m_ocam2_id > 0 )
     {
-        ocam2_exit(m_ocam2_id);
+        ocam2_exit( m_ocam2_id );
         m_ocam2_id = 0;
     }
-    ocam2_rc rc;
+    ocam2_rc   rc;
     ocam2_mode mode;
 
     int OCAM_SZw;
     int OCAM_SZh;
-    if(m_raw_height == 121)
+    if( m_raw_height == 121 )
     {
-        mode = OCAM2_NORMAL;
+        mode     = OCAM2_NORMAL;
         OCAM_SZw = 240;
         OCAM_SZh = 240;
     }
-    else if (m_raw_height == 62)
+    else if( m_raw_height == 62 )
     {
-        mode = OCAM2_BINNING;
+        mode     = OCAM2_BINNING;
         OCAM_SZw = 120;
         OCAM_SZh = 120;
     }
-    else if (m_raw_height == 41)
+    else if( m_raw_height == 41 )
     {
-        mode = OCAM2_BINNING1x3;
+        mode     = OCAM2_BINNING1x3;
         OCAM_SZw = 240;
         OCAM_SZh = 80;
     }
-    else if (m_raw_height == 31)
+    else if( m_raw_height == 31 )
     {
-        mode = OCAM2_BINNING1x4;
+        mode     = OCAM2_BINNING1x4;
         OCAM_SZw = 240;
         OCAM_SZh = 60;
     }
     else
     {
-        log<text_log>("Unrecognized OCAM2 mode.", logPrio::LOG_ERROR);
+        log<text_log>( "Unrecognized OCAM2 mode.", logPrio::LOG_ERROR );
         return -1;
     }
 
@@ -1315,229 +1487,266 @@ int ocam2KCtrl::configureAcquisition()
     std::cerr << "ocamDescrambleFile: " << ocamDescrambleFile << std::endl;
 
     ocam2_id nextOcam2Id = 0;
-    rc=ocam2_init(mode, ocamDescrambleFile.c_str(), &nextOcam2Id);
 
-    if (rc != OCAM2_OK)
+    rc = ocam2_init( mode, ocamDescrambleFile.c_str(), &nextOcam2Id );
+
+    if( rc != OCAM2_OK )
     {
-        if(powerState() != 1 || powerStateTarget() != 1) return -1;
-        log<text_log>("ocam2_init error. Failed to initialize OCAM SDK with descramble file: " + ocamDescrambleFile, logPrio::LOG_ERROR);
+        if( powerState() != 1 || powerStateTarget() != 1 )
+            return -1;
+        log<text_log>( "ocam2_init error. Failed to initialize OCAM SDK with descramble file: " + ocamDescrambleFile,
+                       logPrio::LOG_ERROR );
         return -1;
     }
 
     m_ocam2_id = nextOcam2Id;
 
+    log<text_log>( "OCAM2K initialized. id: " + std::to_string( m_ocam2_id ) );
 
-    log<text_log>("OCAM2K initialized. id: " + std::to_string(m_ocam2_id));
+    log<text_log>( std::string( "OCAM2K mode is:" ) + ocam2_modeStr( ocam2_getMode( m_ocam2_id ) ) );
 
-    log<text_log>(std::string("OCAM2K mode is:") + ocam2_modeStr(ocam2_getMode(m_ocam2_id)));
-
-
-
-
-    if(m_digitalBin)
+    if( m_digitalBin )
     {
         std::cerr << "and digital binning!\n";
-        m_digitalBinWork.resize(OCAM_SZw, OCAM_SZh);
+        m_digitalBinWork.resize( OCAM_SZw, OCAM_SZh );
 
-        m_width = OCAM_SZw / m_digitalBinX;
+        m_width  = OCAM_SZw / m_digitalBinX;
         m_height = OCAM_SZh / m_digitalBinY;
     }
     else
     {
-        m_width = OCAM_SZw;
+        m_width  = OCAM_SZw;
         m_height = OCAM_SZh;
     }
 
     m_dataType = _DATATYPE_UINT16;
 
-    state(stateCodes::OPERATING);
+    if( ensureSyncStream() < 0 )
+    {
+        return log<software_error, -1>( { "Error preparing sync ImageStreamIO stream" } );
+    }
+
+    state( stateCodes::OPERATING );
 
     return 0;
 }
 
-inline
-float ocam2KCtrl::fps()
+inline float ocam2KCtrl::fps()
 {
-   return m_fps;
+    return m_fps;
 }
 
-inline
-int ocam2KCtrl::startAcquisition()
+inline int ocam2KCtrl::startAcquisition()
 {
-   m_lastImageNumber = -1;
-   return edtCamera<ocam2KCtrl>::pdvStartAcquisition();
-
+    m_lastImageNumber = -1;
+    return edtCamera<ocam2KCtrl>::pdvStartAcquisition();
 }
 
-inline
-int ocam2KCtrl::acquireAndCheckValid()
+inline int ocam2KCtrl::acquireAndCheckValid()
 {
-   edtCamera<ocam2KCtrl>::pdvAcquire( m_currImageTimestamp );
+    edtCamera<ocam2KCtrl>::pdvAcquire( m_currImageTimestamp );
 
-   /* Removed all pdv timeout and overrun checking, since we can rely on frame number from the camera
-      to detect missed and corrupted frames.
+    /* Removed all pdv timeout and overrun checking, since we can rely on frame number from the camera
+       to detect missed and corrupted frames.
 
-      See ef0dd24 for last version with full checks in it.
-   */
+       See ef0dd24 for last version with full checks in it.
+    */
 
-   //Get the image number to see if this is valid.
-   //This is how it is in the ocam2_sdk:
-   unsigned currImageNumber = (reinterpret_cast<int *>(m_image_p))[OCAM2_IMAGE_NB_OFFSET/4]; /* int offset */
-   m_currImageNumber = currImageNumber;
+    // Get the image number to see if this is valid.
+    // This is how it is in the ocam2_sdk:
+    unsigned currImageNumber = ( reinterpret_cast<int *>( m_image_p ) )[OCAM2_IMAGE_NB_OFFSET / 4]; /* int offset */
+    m_currImageNumber        = currImageNumber;
 
-   //For the first loop after a restart
-   if( m_lastImageNumber == -1 )
-   {
-      m_lastImageNumber = m_currImageNumber - 1;
-   }
+    // For the first loop after a restart
+    if( m_lastImageNumber == -1 )
+    {
+        m_lastImageNumber = m_currImageNumber - 1;
+    }
 
-   if(m_currImageNumber - m_lastImageNumber != 1)
-   {
-      //Detect exact condition of a wraparound on the unsigned int.
-      // Yes, this can only happen once every 13.72 days at 3622 fps
-      // But just in case . . .
-      if(m_lastImageNumber != std::numeric_limits<unsigned int>::max() && m_currImageNumber != 0)
-      {
-         //The far more likely case is a problem...
+    if( m_currImageNumber - m_lastImageNumber != 1 )
+    {
+        // Detect exact condition of a wraparound on the unsigned int.
+        //  Yes, this can only happen once every 13.72 days at 3622 fps
+        //  But just in case . . .
+        if( m_lastImageNumber != std::numeric_limits<unsigned int>::max() && m_currImageNumber != 0 )
+        {
+            // The far more likely case is a problem...
 
-         //If a reasonably small number of frames skipped, then we trust the image number
-         if(m_currImageNumber - m_lastImageNumber > 1 && m_currImageNumber - m_lastImageNumber < 100)
-         {
-            //This we handle as a non-timeout -- report how many frames were skipped
-            long framesSkipped = m_currImageNumber - m_lastImageNumber - 1;
+            // If a reasonably small number of frames skipped, then we trust the image number
+            if( m_currImageNumber - m_lastImageNumber > 1 && m_currImageNumber - m_lastImageNumber < 100 )
+            {
+                // This we handle as a non-timeout -- report how many frames were skipped
+                long framesSkipped = m_currImageNumber - m_lastImageNumber - 1;
 
-            log<text_log>("frames skipped: " + std::to_string(framesSkipped), logPrio::LOG_ERROR);
+                log<text_log>( "frames skipped: " + std::to_string( framesSkipped ), logPrio::LOG_ERROR );
 
-            m_lastImageNumber = -1;
-            m_nextMode = m_modeName;
-            m_reconfig = 1;
-            return 1;
+                m_lastImageNumber = -1;
+                m_nextMode        = m_modeName;
+                m_reconfig        = 1;
+                return 1;
+            }
+            else // but if it's any bigger or < 0, it's probably garbage
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                    return -1;
 
-         }
-         else //but if it's any bigger or < 0, it's probably garbage
-         {
-            if(powerState() != 1 || powerStateTarget() != 1) return -1;
+                ///\todo need frame corrupt log type
+                log<text_log>( "frame number possibly corrupt: " + std::to_string( m_currImageNumber ) + " - " +
+                                   std::to_string( m_lastImageNumber ),
+                               logPrio::LOG_ERROR );
 
-            ///\todo need frame corrupt log type
-            log<text_log>("frame number possibly corrupt: " + std::to_string(m_currImageNumber) + " - " + std::to_string(m_lastImageNumber), logPrio::LOG_ERROR);
+                m_nextMode = m_modeName;
+                m_reconfig = 1;
 
-            m_nextMode = m_modeName;
-            m_reconfig = 1;
-
-            //Reset the counters.
-            m_lastImageNumber = -1;
-            return 1;
-
-         }
-      }
-   }
-   m_lastImageNumber = m_currImageNumber;
-   return 0;
+                // Reset the counters.
+                m_lastImageNumber = -1;
+                return 1;
+            }
+        }
+    }
+    m_lastImageNumber = m_currImageNumber;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::loadImageIntoStream(void * dest)
+inline int ocam2KCtrl::loadImageIntoStream( void *dest )
 {
     unsigned currImageNumber = 0;
 
-    if(!m_digitalBin)
+    if( !m_digitalBin )
     {
-        ocam2_descramble(m_ocam2_id, &currImageNumber, reinterpret_cast<int16_t *>(dest), reinterpret_cast<int16_t *>(m_image_p));
-        //memcpy(dest, m_image_p, 120*120*2); //This is about 10 usec faster -- but we have to descramble.
+        ocam2_descramble( m_ocam2_id,
+                          &currImageNumber,
+                          reinterpret_cast<int16_t *>( dest ),
+                          reinterpret_cast<int16_t *>( m_image_p ) );
+        // memcpy(dest, m_image_p, 120*120*2); //This is about 10 usec faster -- but we have to descramble.
     }
     else
     {
-        ocam2_descramble(m_ocam2_id, &currImageNumber, m_digitalBinWork.data(), reinterpret_cast<int16_t *>(m_image_p));
+        ocam2_descramble(
+            m_ocam2_id, &currImageNumber, m_digitalBinWork.data(), reinterpret_cast<int16_t *>( m_image_p ) );
 
-        mx::improc::eigenMap<int16_t> destMap( reinterpret_cast<int16_t*>(dest), m_width, m_height);
+        mx::improc::eigenMap<int16_t> destMap( reinterpret_cast<int16_t *>( dest ), m_width, m_height );
 
-        if(m_digitalBinX > 1)
+        if( m_digitalBinX > 1 )
         {
-            for(int cc = 0; cc < destMap.cols(); ++cc)
+            for( int cc = 0; cc < destMap.cols(); ++cc )
             {
-                for(int rr = 0; rr < destMap.rows(); ++rr)
+                for( int rr = 0; rr < destMap.rows(); ++rr )
                 {
-                    destMap(rr,cc)  = m_digitalBinWork(rr*m_digitalBinX + 0, cc);
+                    destMap( rr, cc ) = m_digitalBinWork( rr * m_digitalBinX + 0, cc );
 
-                    for(unsigned b = 1; b < m_digitalBinX; ++b)
+                    for( unsigned b = 1; b < m_digitalBinX; ++b )
                     {
-                        destMap(rr,cc)  = m_digitalBinWork(rr*m_digitalBinX + b,cc);
+                        destMap( rr, cc ) = m_digitalBinWork( rr * m_digitalBinX + b, cc );
                     }
                 }
             }
         }
     }
 
-   return 0;
+    return 0;
 }
 
-inline
-int ocam2KCtrl::reconfig()
+inline int ocam2KCtrl::reconfig()
 {
-   std::lock_guard<std::recursive_mutex> guard(m_cameraMutex);
-   int rv = edtCamera<ocam2KCtrl>::pdvReconfig();
-   if(rv < 0) return rv;
-   state(stateCodes::READY);
-   return 0;
+    std::lock_guard<std::recursive_mutex> guard( m_cameraMutex );
+
+    int rv = edtCamera<ocam2KCtrl>::pdvReconfig();
+
+    if( rv < 0 )
+    {
+        return rv;
+    }
+
+    state( stateCodes::READY );
+    return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(ocam2KCtrl, m_indiP_emProtReset)(const pcf::IndiProperty &ipRecv)
+inline int ocam2KCtrl::frameGrabberPostPublish( IMAGE *imageStream )
 {
-   if(MagAOXAppT::m_powerState == 0) return 0;
+    if( imageStream == nullptr )
+    {
+        return 0;
+    }
 
-   if (ipRecv.getName() != m_indiP_emProtReset.getName())
-   {
-      log<software_error>({"wrong INDI property received."});
-      return -1;
-   }
+    if( m_syncImageStream == nullptr )
+    {
+        return log<software_error, -1>( { "Sync ImageStreamIO stream unavailable during publication" } );
+    }
 
-   if(!ipRecv.find("request"))
-   {
-      return 0;
-   }
+    m_syncImageStream->md[0].write       = 1;
+    m_syncImageStream->array.UI8[0]      = 0;
+    m_syncImageStream->md[0].writetime   = imageStream->md[0].writetime;
+    m_syncImageStream->md[0].atime       = imageStream->md[0].atime;
+    m_syncImageStream->md[0].cnt0        = imageStream->md[0].cnt0;
+    m_syncImageStream->md[0].cnt1        = 0;
+    m_syncImageStream->writetimearray[0] = imageStream->md[0].writetime;
+    m_syncImageStream->atimearray[0]     = imageStream->md[0].atime;
+    m_syncImageStream->cntarray[0]       = imageStream->md[0].cnt0;
+    m_syncImageStream->md[0].write       = 0;
 
-   if( ipRecv["request"].getSwitchState() == pcf::IndiElement::Off )
-   {
-      return 0;
-   }
+    ImageStreamIO_sempost( m_syncImageStream, -1 );
 
-   std::unique_lock<std::mutex> lock(m_indiMutex);
-
-   if(m_protectionResetConfirmed == 0)
-   {
-      updateIfChanged(m_indiP_emProt, "status", std::string("CONFIRM"), INDI_BUSY);
-
-      m_protectionResetConfirmed = 1;
-
-      m_protectionResetReqTime = mx::sys::get_curr_time();
-
-      log<text_log>("protection reset requested", logPrio::LOG_NOTICE);
-
-      return 0;
-   }
-
-
-   //If here, this is a confirmation.
-   return resetEMProtection();
+    return 0;
 }
 
-INDI_SETCALLBACK_DEFN(ocam2KCtrl, m_indiP_syncFreq)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( ocam2KCtrl, m_indiP_emProtReset )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_syncFreq)
+    if( MagAOXAppT::m_powerState == 0 )
+        return 0;
 
-    if(!ipRecv.find("current"))
+    if( ipRecv.getName() != m_indiP_emProtReset.getName() )
+    {
+        log<software_error>( { "wrong INDI property received." } );
+        return -1;
+    }
+
+    if( !ipRecv.find( "request" ) )
+    {
+        return 0;
+    }
+
+    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::Off )
+    {
+        return 0;
+    }
+
+    std::unique_lock<std::mutex> lock( m_indiMutex );
+
+    if( m_protectionResetConfirmed == 0 )
+    {
+        updateIfChanged( m_indiP_emProt, "status", std::string( "CONFIRM" ), INDI_BUSY );
+
+        m_protectionResetConfirmed = 1;
+
+        m_protectionResetReqTime = mx::sys::get_curr_time();
+
+        log<text_log>( "protection reset requested", logPrio::LOG_NOTICE );
+
+        return 0;
+    }
+
+    // If here, this is a confirmation.
+    return resetEMProtection();
+}
+
+INDI_SETCALLBACK_DEFN( ocam2KCtrl, m_indiP_syncFreq )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_syncFreq )
+
+    if( !ipRecv.find( "current" ) )
     {
         return -1;
     }
 
     m_syncFreq = ipRecv["current"].get<double>();
 
-    if(m_synchro && m_syncFreq != m_fps)
+    if( m_synchro && m_syncFreq != m_fps )
     {
-        recordCamera(true);
+        recordCamera( true );
         m_fps = m_syncFreq;
 
-        //We always want to reset the latency circular buffers
+        // We always want to reset the latency circular buffers
         m_nextMode = m_modeName;
         m_reconfig = true;
     }
@@ -1545,45 +1754,47 @@ INDI_SETCALLBACK_DEFN(ocam2KCtrl, m_indiP_syncFreq)(const pcf::IndiProperty &ipR
     return 0;
 }
 
-inline
-int ocam2KCtrl::checkRecordTimes()
+inline int ocam2KCtrl::checkRecordTimes()
 {
-   return telemeter<ocam2KCtrl>::checkRecordTimes(ocam_temps(), telem_stdcam(), telem_fgtimings());
+    return telemeter<ocam2KCtrl>::checkRecordTimes( ocam_temps(), telem_stdcam(), telem_fgtimings() );
 }
 
-inline
-int ocam2KCtrl::recordTelem( const ocam_temps * )
+inline int ocam2KCtrl::recordTelem( const ocam_temps * )
 {
-   return recordTemps(true);
+    return recordTemps( true );
 }
 
-inline
-int ocam2KCtrl::recordTelem( const telem_stdcam * )
+inline int ocam2KCtrl::recordTelem( const telem_stdcam * )
 {
-   return recordCamera(true);
+    return recordCamera( true );
 }
 
-inline
-int ocam2KCtrl::recordTelem( const telem_fgtimings * )
+inline int ocam2KCtrl::recordTelem( const telem_fgtimings * )
 {
-   return recordFGTimings(true);
+    return recordFGTimings( true );
 }
 
-inline
-int ocam2KCtrl::recordTemps( bool force )
+inline int ocam2KCtrl::recordTemps( bool force )
 {
-   static ocamTemps lastTemps;
+    static ocamTemps lastTemps;
 
-   if(!(lastTemps == m_temps) || force)
-   {
-      telem<ocam_temps>({m_temps.CCD, m_temps.CPU, m_temps.POWER, m_temps.BIAS, m_temps.WATER, m_temps.LEFT, m_temps.RIGHT, m_temps.COOLING_POWER});
-      lastTemps = m_temps;
-   }
+    if( !( lastTemps == m_temps ) || force )
+    {
+        telem<ocam_temps>( { m_temps.CCD,
+                             m_temps.CPU,
+                             m_temps.POWER,
+                             m_temps.BIAS,
+                             m_temps.WATER,
+                             m_temps.LEFT,
+                             m_temps.RIGHT,
+                             m_temps.COOLING_POWER } );
+        lastTemps = m_temps;
+    }
 
-   return 0;
+    return 0;
 }
 
-}//namespace app
-} //namespace MagAOX
+} // namespace app
+} // namespace MagAOX
 
 #endif

--- a/apps/ocam2KCtrl/tests/edtinc.h
+++ b/apps/ocam2KCtrl/tests/edtinc.h
@@ -1,0 +1,120 @@
+/** \file edtinc.h
+ * \brief Minimal EDT SDK declarations for `ocam2KCtrl` unit tests.
+ * \author OpenAI Codex
+ */
+
+#ifndef ocam2KCtrl_tests_edtinc_h
+#define ocam2KCtrl_tests_edtinc_h
+
+typedef unsigned int  uint;
+typedef unsigned char u_char;
+
+/// Stub EDT device handle type used by unit tests.
+struct EdtDev
+{
+    int unused;
+};
+
+/// Stub EDT camera handle type used by unit tests.
+struct PdvDev
+{
+    int unused;
+};
+
+/// Stub EDT dependent-configuration type used by unit tests.
+struct Dependent
+{
+    int unused;
+};
+
+/// Stub EDT configuration info structure used by unit tests.
+struct Edtinfo
+{
+    int unused;
+};
+
+/// Default EDT interface name used by the production code.
+#define EDT_INTERFACE "pdv"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /// Allocate a stub EDT dependent configuration object.
+    Dependent *pdv_alloc_dependent();
+
+    /// Read a stub EDT configuration file.
+    int pdv_readcfg( const char *configFile, Dependent *dd_p, Edtinfo *edtinfo );
+
+    /// Open a stub EDT device channel.
+    EdtDev *edt_open_channel( const char *deviceName, int unit, int channel );
+
+    /// Report the last stub EDT error message.
+    void edt_perror( char *errstr );
+
+    /// Initialize a stub EDT camera instance.
+    int pdv_initcam( EdtDev     *edt_p,
+                     Dependent  *dd_p,
+                     int         unit,
+                     Edtinfo    *edtinfo,
+                     const char *configFile,
+                     char       *bitdir,
+                     int         pdv_debug );
+
+    /// Close a stub EDT device channel.
+    void edt_close( EdtDev *edt_p );
+
+    /// Open a stub PDV device handle.
+    PdvDev *pdv_open_channel( const char *deviceName, int unit, int channel );
+
+    /// Close a stub PDV device handle.
+    void pdv_close( PdvDev *pdv_p );
+
+    /// Flush the stub PDV FIFO.
+    void pdv_flush_fifo( PdvDev *pdv_p );
+
+    /// Enable stub PDV serial reads.
+    void pdv_serial_read_enable( PdvDev *pdv_p );
+
+    /// Return the stub PDV frame width.
+    int pdv_get_width( PdvDev *pdv_p );
+
+    /// Return the stub PDV frame height.
+    int pdv_get_height( PdvDev *pdv_p );
+
+    /// Return the stub PDV frame bit depth.
+    int pdv_get_depth( PdvDev *pdv_p );
+
+    /// Return the stub PDV camera type string.
+    char *pdv_get_cameratype( PdvDev *pdv_p );
+
+    /// Configure the stub PDV ring-buffer depth.
+    void pdv_multibuf( PdvDev *pdv_p, int numBuffs );
+
+    /// Start stub PDV acquisition for multiple images.
+    void pdv_start_images( PdvDev *pdv_p, int numBuffs );
+
+    /// Wait for the last stub PDV image and fill the DMA timestamp.
+    u_char *pdv_wait_last_image_timed( PdvDev *pdv_p, uint dmaTimeStamp[2] );
+
+    /// Start acquisition of the next stub PDV image.
+    void pdv_start_image( PdvDev *pdv_p );
+
+    /// Read bytes from the stub PDV serial channel.
+    int pdv_serial_read( PdvDev *pdv_p, char *buf, int size );
+
+    /// Send a command over the stub PDV serial channel.
+    int pdv_serial_command( PdvDev *pdv_p, const char *command );
+
+    /// Wait for serial data on the stub PDV channel.
+    int pdv_serial_wait( PdvDev *pdv_p, int timeout, int count );
+
+    /// Return the configured stub PDV serial terminator.
+    int pdv_get_waitchar( PdvDev *pdv_p, u_char *waitc );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // ocam2KCtrl_tests_edtinc_h

--- a/apps/ocam2KCtrl/tests/ocam2KCtrl_lifecycle_test.cpp
+++ b/apps/ocam2KCtrl/tests/ocam2KCtrl_lifecycle_test.cpp
@@ -1,0 +1,103 @@
+/** \file ocam2KCtrl_lifecycle_test.cpp
+ * \brief Isolated Catch2 lifecycle tests for the ocam2KCtrl app.
+ * \author OpenAI Codex
+ *
+ * \ingroup ocam2KCtrl_files
+ */
+
+#define OCAM2KCTRL_TEST_SUPPORT_ONLY
+#include "ocam2KCtrl_test.cpp"
+#undef OCAM2KCTRL_TEST_SUPPORT_ONLY
+
+namespace libXWCTest
+{
+
+/// Namespace for `ocam2KCtrl` lifecycle unit tests.
+/** \ingroup ocam2KCtrl_unit_test
+ */
+namespace ocam2KCtrlTest
+{
+
+/// Verify lifecycle entrypoints cover startup failure handling and the POWERON fast-return path.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl lifecycle entrypoints handle startup failures and POWERON logic", "[ocam2KCtrl]" )
+{
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appStartup() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appLogic() );
+    #endif
+    // clang-format on
+
+    SECTION( "appStartup reports failure when the startup mode cannot be configured" )
+    {
+        ocam2KCtrl_test app;
+
+        app.m_startupMode = "";
+
+        REQUIRE( app.appStartup() < 0 );
+    }
+
+    SECTION( "appStartup reports failure when EDT startup cannot load the configured mode" )
+    {
+        ocam2KCtrl_test app;
+
+        configureStartupMode( app );
+        g_edtStubState.readcfgReturn = -1;
+
+        REQUIRE( app.appStartup() < 0 );
+    }
+
+    SECTION( "appStartup succeeds once a startup mode and telemetry path are configured" )
+    {
+        ocam2KCtrl_test app;
+        startupScope    startup( app );
+
+        configureStartupMode( app );
+
+        const int startupRv = app.appStartup();
+        startup.markStarted( startupRv == 0 );
+
+        REQUIRE( startupRv == 0 );
+        REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
+    }
+
+    SECTION( "appLogic returns immediately while the app is still in POWERON and the wait has not elapsed" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 1;
+        app.m_powerTargetState                        = 1;
+        app.state( stateCodes::POWERON );
+        app.m_powerOnCounter                         = 0;
+        static_cast<MagAOXAppT &>( app ).m_loopPause = 0;
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::POWERON );
+    }
+
+    SECTION( "appLogic returns an error if the framegrabber thread has already exited" )
+    {
+        auto *app = new ocam2KCtrl_test;
+
+        static_cast<MagAOXAppT &>( *app ).m_powerState = 1;
+        app->m_powerTargetState                        = 1;
+        app->state( stateCodes::POWERON );
+        startFgThread( *app, 1 );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+
+        REQUIRE( app->appLogic() == -1 );
+
+        // `frameGrabber::appLogic()` uses `pthread_tryjoin_np`, which consumes the native thread
+        // without clearing the owning `std::thread`. Leak this tiny test instance so its destructor
+        // does not terminate the process while exercising the error-return branch.
+    }
+}
+
+} // namespace ocam2KCtrlTest
+} // namespace libXWCTest

--- a/apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp
+++ b/apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp
@@ -14,9 +14,10 @@
 #include "../../../tests/testXWC.hpp"
 
 #include <chrono>
-#include <deque>
 #include <array>
+#include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <semaphore.h>
 #include <stdexcept>
 #include <string>
@@ -53,6 +54,7 @@ struct edtStubState
         waitTimeSec       = 0;
         waitTimeNsec      = 0;
         waitImage.fill( 0 );
+        readcfgReturn = 0;
         serialResponses.clear();
         serialCommands.clear();
         activeSerialResponse.clear();
@@ -68,6 +70,7 @@ struct edtStubState
     uint                       waitTimeSec{ 0 };        ///< Seconds returned by `pdv_wait_last_image_timed`.
     uint                       waitTimeNsec{ 0 };       ///< Nanoseconds returned by `pdv_wait_last_image_timed`.
     std::array<u_char, 32>     waitImage{};             ///< Raw EDT frame buffer returned to the app.
+    int                        readcfgReturn{ 0 };      ///< Return code forced from `pdv_readcfg`.
     std::deque<serialResponse> serialResponses;         ///< Scripted serial responses queued for future commands.
     std::vector<std::string>   serialCommands;          ///< Serial commands issued by the app under test.
     std::string                activeSerialResponse;    ///< Active serial response returned by the current command.
@@ -125,14 +128,15 @@ void resetStubState()
 }
 
 /// Store a frame number into the raw EDT image buffer at the OCAM metadata offset.
-void setStubFrameNumber( unsigned int frameNumber )
+[[maybe_unused]] void setStubFrameNumber( unsigned int frameNumber )
 {
     reinterpret_cast<int *>( g_edtStubState.waitImage.data() )[OCAM2_IMAGE_NB_OFFSET / 4] =
         static_cast<int>( frameNumber );
 }
 
 /// Queue one scripted serial response for the next `pdvSerialWriteRead` invocation.
-void queueSerialResponse( const std::string &response, int commandResult = 0, int initialWaitResult = 1 )
+[[maybe_unused]] void
+queueSerialResponse( const std::string &response, int commandResult = 0, int initialWaitResult = 1 )
 {
     g_edtStubState.serialResponses.push_back( { response, commandResult, initialWaitResult } );
 }
@@ -152,7 +156,7 @@ extern "C"
         static_cast<void>( configFile );
         static_cast<void>( dd_p );
         static_cast<void>( edtinfo );
-        return 0;
+        return g_edtStubState.readcfgReturn;
     }
 
     EdtDev *edt_open_channel( const char *deviceName, int unit, int channel )
@@ -444,7 +448,7 @@ std::string uniqueShmimName( const std::string &suffix )
 }
 
 /// Build a unique temporary config-file path for one test.
-std::string uniqueConfigPath( const std::string &suffix )
+[[maybe_unused]] std::string uniqueConfigPath( const std::string &suffix )
 {
     return "/tmp/ocam2KCtrl_test_" + suffix + "_" + std::to_string( ::getpid() ) + ".conf";
 }
@@ -528,10 +532,40 @@ class ocam2KCtrl_test : public MagAOX::app::ocam2KCtrl
 };
 
 /// Put the app into the nominal powered-on state used by the serial helpers.
-void setPoweredOn( ocam2KCtrl_test &app )
+[[maybe_unused]] void setPoweredOn( ocam2KCtrl_test &app )
 {
     static_cast<MagAOXAppT &>( app ).m_powerState = 1;
     app.m_powerTargetState                        = 1;
+}
+
+/// Seed one minimal but internally consistent camera-mode setup for startup and acquisition tests.
+[[maybe_unused]] void configureStartupMode( ocam2KCtrl_test   &app,
+                                            const std::string &modeName       = "science",
+                                            const std::string &serialCommand  = "mode science",
+                                            const std::string &configFileName = "stub.cfg" )
+{
+    dev::cameraConfig config;
+
+    app.m_startupMode                                                  = modeName;
+    app.m_modeName                                                     = modeName;
+    app.m_configDir                                                    = "/tmp";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_powerDevice    = "pwr";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_powerChannel   = "cam";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_dioDevice      = "dio";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_sensorChannel  = "sensor";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_triggerChannel = "trigger";
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_shutterWait    = 0;
+    static_cast<dev::dssShutter<ocam2KCtrl> &>( app ).m_shutterTimeout = 0.1;
+    app.m_tel.logPath( "/tmp" );
+    app.m_tel.logName( app.m_configName );
+    app.m_tel.logExt( "bintel" );
+    config.m_serialCommand      = serialCommand;
+    config.m_configFile         = configFileName;
+    config.m_binningX           = 1;
+    config.m_binningY           = 1;
+    config.m_digitalBinX        = 1;
+    config.m_digitalBinY        = 1;
+    app.m_cameraModes[modeName] = config;
 }
 
 /// Start a short-lived framegrabber thread so `frameGrabber::appLogic()` sees a running worker.
@@ -568,13 +602,44 @@ struct fgThreadScope
     }
 };
 
+/// Ensure startup-driven telemetry resources are shut down when a test exits early.
+struct startupScope
+{
+    ocam2KCtrl_test &m_app;     ///< App whose startup resources are managed by this scope.
+    bool             m_started; ///< Tracks whether `appStartup()` completed successfully in the test.
+
+    /// Construct a startup guard for one test app instance.
+    explicit startupScope( ocam2KCtrl_test &app ) : m_app( app ), m_started( false )
+    {
+    }
+
+    /// Record whether startup completed so shutdown only runs when needed.
+    void markStarted( bool started )
+    {
+        m_started = started;
+    }
+
+    /// Shut down telemetry logging and app resources on scope exit after a successful startup.
+    ~startupScope()
+    {
+        if( m_started )
+        {
+            m_app.m_shutdown = 1;
+            m_app.m_tel.logShutdown( true );
+            static_cast<void>( m_app.appShutdown() );
+        }
+    }
+};
+
 /// Report whether a telemetry timestamp has been written at least once.
-bool hasRecordedTime( const timespec &ts )
+[[maybe_unused]] bool hasRecordedTime( const timespec &ts )
 {
     return ts.tv_sec != 0 || ts.tv_nsec != 0;
 }
 
 } // namespace
+
+#ifndef OCAM2KCTRL_TEST_SUPPORT_ONLY
 
 /// Verify the sync stream is created as a 1x1 uint8 ImageStreamIO buffer.
 /**
@@ -628,39 +693,52 @@ TEST_CASE( "ocam2KCtrl sync stream publication mirrors metadata and posts semaph
     #endif
     // clang-format on
 
-    REQUIRE( app.ensureSyncStream() == 0 );
+    SECTION( "null source streams are ignored" )
+    {
+        REQUIRE( app.frameGrabberPostPublish( nullptr ) == 0 );
+    }
 
-    sourceStream.image()->md[0].writetime.tv_sec  = 1234;
-    sourceStream.image()->md[0].writetime.tv_nsec = 5678;
-    sourceStream.image()->md[0].atime.tv_sec      = 1234;
-    sourceStream.image()->md[0].atime.tv_nsec     = 4321;
-    sourceStream.image()->md[0].cnt0              = 77;
-    sourceStream.image()->md[0].cnt1              = 0;
-    sourceStream.image()->writetimearray[0]       = sourceStream.image()->md[0].writetime;
-    sourceStream.image()->atimearray[0]           = sourceStream.image()->md[0].atime;
-    sourceStream.image()->cntarray[0]             = sourceStream.image()->md[0].cnt0;
+    SECTION( "publication fails cleanly if the sync stream has not been prepared" )
+    {
+        REQUIRE( app.frameGrabberPostPublish( sourceStream.image() ) == -1 );
+    }
 
-    semIndex = ImageStreamIO_getsemwaitindex( app.m_syncImageStream, 0 );
-    REQUIRE( semIndex >= 0 );
-    ImageStreamIO_semflush( app.m_syncImageStream, semIndex );
-    REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
-    REQUIRE( semValue == 0 );
+    SECTION( "publication mirrors metadata and posts one semaphore on the sync stream" )
+    {
+        REQUIRE( app.ensureSyncStream() == 0 );
 
-    app.m_syncImageStream->array.UI8[0] = 99;
+        sourceStream.image()->md[0].writetime.tv_sec  = 1234;
+        sourceStream.image()->md[0].writetime.tv_nsec = 5678;
+        sourceStream.image()->md[0].atime.tv_sec      = 1234;
+        sourceStream.image()->md[0].atime.tv_nsec     = 4321;
+        sourceStream.image()->md[0].cnt0              = 77;
+        sourceStream.image()->md[0].cnt1              = 0;
+        sourceStream.image()->writetimearray[0]       = sourceStream.image()->md[0].writetime;
+        sourceStream.image()->atimearray[0]           = sourceStream.image()->md[0].atime;
+        sourceStream.image()->cntarray[0]             = sourceStream.image()->md[0].cnt0;
 
-    REQUIRE( app.frameGrabberPostPublish( sourceStream.image() ) == 0 );
-    REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
-    REQUIRE( semValue == 1 );
-    REQUIRE( app.m_syncImageStream->array.UI8[0] == 0 );
-    REQUIRE( app.m_syncImageStream->md[0].writetime.tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
-    REQUIRE( app.m_syncImageStream->md[0].writetime.tv_nsec == sourceStream.image()->md[0].writetime.tv_nsec );
-    REQUIRE( app.m_syncImageStream->md[0].atime.tv_sec == sourceStream.image()->md[0].atime.tv_sec );
-    REQUIRE( app.m_syncImageStream->md[0].atime.tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
-    REQUIRE( app.m_syncImageStream->md[0].cnt0 == sourceStream.image()->md[0].cnt0 );
-    REQUIRE( app.m_syncImageStream->md[0].cnt1 == 0 );
-    REQUIRE( app.m_syncImageStream->writetimearray[0].tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
-    REQUIRE( app.m_syncImageStream->atimearray[0].tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
-    REQUIRE( app.m_syncImageStream->cntarray[0] == sourceStream.image()->md[0].cnt0 );
+        semIndex = ImageStreamIO_getsemwaitindex( app.m_syncImageStream, 0 );
+        REQUIRE( semIndex >= 0 );
+        ImageStreamIO_semflush( app.m_syncImageStream, semIndex );
+        REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
+        REQUIRE( semValue == 0 );
+
+        app.m_syncImageStream->array.UI8[0] = 99;
+
+        REQUIRE( app.frameGrabberPostPublish( sourceStream.image() ) == 0 );
+        REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
+        REQUIRE( semValue == 1 );
+        REQUIRE( app.m_syncImageStream->array.UI8[0] == 0 );
+        REQUIRE( app.m_syncImageStream->md[0].writetime.tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
+        REQUIRE( app.m_syncImageStream->md[0].writetime.tv_nsec == sourceStream.image()->md[0].writetime.tv_nsec );
+        REQUIRE( app.m_syncImageStream->md[0].atime.tv_sec == sourceStream.image()->md[0].atime.tv_sec );
+        REQUIRE( app.m_syncImageStream->md[0].atime.tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
+        REQUIRE( app.m_syncImageStream->md[0].cnt0 == sourceStream.image()->md[0].cnt0 );
+        REQUIRE( app.m_syncImageStream->md[0].cnt1 == 0 );
+        REQUIRE( app.m_syncImageStream->writetimearray[0].tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
+        REQUIRE( app.m_syncImageStream->atimearray[0].tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
+        REQUIRE( app.m_syncImageStream->cntarray[0] == sourceStream.image()->md[0].cnt0 );
+    }
 }
 
 /// Verify sync-stream preparation reuses valid streams and recovers from stale or mismatched ones.
@@ -734,6 +812,21 @@ TEST_CASE( "ocam2KCtrl ensureSyncStream reuses and replaces existing stream stat
         REQUIRE( app.m_syncImageStream->md[0].size[0] == 1 );
         REQUIRE( app.m_syncImageStream->md[0].size[1] == 1 );
         REQUIRE( app.m_syncImageStream->md[0].size[2] == 1 );
+    }
+
+    SECTION( "an invalid pre-existing sync-stream file returns an error" )
+    {
+        char syncFileName[1024];
+        ImageStreamIO_filename( syncFileName, sizeof( syncFileName ), app.m_syncShmimName.c_str() );
+
+        std::FILE *syncFile = std::fopen( syncFileName, "w" );
+        REQUIRE( syncFile != nullptr );
+        REQUIRE( std::fputs( "not an ImageStreamIO stream\n", syncFile ) >= 0 );
+        REQUIRE( std::fclose( syncFile ) == 0 );
+
+        REQUIRE( app.ensureSyncStream() == -1 );
+        REQUIRE( app.m_syncImageStream == nullptr );
+        REQUIRE( ::unlink( syncFileName ) == 0 );
     }
 }
 
@@ -929,6 +1022,52 @@ TEST_CASE( "ocam2KCtrl getTemps handles valid and malformed serial responses", "
         REQUIRE( app.m_tempControlStatusStr == "UNKNOWN" );
         REQUIRE( app.m_tempControlOnTarget == false );
     }
+
+    SECTION( "low cooling power with a warm detector reports temperature control off" )
+    {
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[165]\nCooling Power [2]mW.\n\n" );
+
+        REQUIRE( app.getTemps() == 0 );
+        REQUIRE( app.m_temps.CCD == Approx( 20.4f ) );
+        REQUIRE( app.m_temps.SET == Approx( 16.5f ) );
+        REQUIRE( app.m_tempControlStatus == false );
+        REQUIRE( app.m_tempControlStatusStr == "TEMP OFF" );
+        REQUIRE( app.m_tempControlOnTarget == false );
+    }
+
+    SECTION( "serial failures while powered off return -1 immediately" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.getTemps() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp" );
+    }
+
+    SECTION( "serial failures while powered on return a software error" )
+    {
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.getTemps() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp" );
+    }
+
+    SECTION( "malformed temperature responses while powered off return -1" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+
+        queueSerialResponse( "Temperatures : CCD[20.4]\n" );
+
+        REQUIRE( app.getTemps() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp" );
+    }
 }
 
 /// Verify FPS queries handle valid and malformed serial responses, plus synchro mode.
@@ -970,6 +1109,35 @@ TEST_CASE( "ocam2KCtrl getFPS handles valid and malformed serial responses", "[o
         queueSerialResponse( "fps 150.5\n" );
 
         REQUIRE( app.getFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps" );
+        REQUIRE( app.m_fps == Approx( 75.0f ) );
+    }
+
+    SECTION( "malformed fps responses while powered off return -1" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_synchro                                 = false;
+        app.m_fps                                     = 75.0f;
+
+        queueSerialResponse( "fps 150.5\n" );
+
+        REQUIRE( app.getFPS() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps" );
+        REQUIRE( app.m_fps == Approx( 75.0f ) );
+    }
+
+    SECTION( "serial failures while powered on return a software error" )
+    {
+        setPoweredOn( app );
+        app.m_synchro = false;
+        app.m_fps     = 75.0f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.getFPS() == -1 );
         REQUIRE( g_edtStubState.serialCommands.size() == 1 );
         REQUIRE( g_edtStubState.serialCommands[0] == "fps" );
         REQUIRE( app.m_fps == Approx( 75.0f ) );
@@ -1049,6 +1217,34 @@ TEST_CASE( "ocam2KCtrl temperature control helpers handle valid and invalid requ
         REQUIRE( app.m_tempControlStatus == true );
     }
 
+    SECTION( "setTempControl returns -1 on serial failure once power is already off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_tempControlStatusSet                    = true;
+        app.m_tempControlStatus                       = false;
+        app.m_ccdTempSetpt                            = 15.5f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setTempControl() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp on" );
+    }
+
+    SECTION( "setTempControl returns a software error on serial failure while still powered" )
+    {
+        app.m_tempControlStatusSet = true;
+        app.m_tempControlStatus    = false;
+        app.m_ccdTempSetpt         = 15.5f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setTempControl() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp on" );
+    }
+
     SECTION( "setTempSetPt rejects out-of-range high setpoints without serial traffic" )
     {
         app.m_ccdTempSetpt = 30.0f;
@@ -1072,6 +1268,30 @@ TEST_CASE( "ocam2KCtrl temperature control helpers handle valid and invalid requ
         queueSerialResponse( "setpoint updated\n" );
 
         REQUIRE( app.setTempSetPt() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp 12.250000" );
+    }
+
+    SECTION( "setTempSetPt returns -1 on serial failure once power is already off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_ccdTempSetpt                            = 12.25f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setTempSetPt() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp 12.250000" );
+    }
+
+    SECTION( "setTempSetPt returns a software error on serial failure while still powered" )
+    {
+        app.m_ccdTempSetpt = 12.25f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setTempSetPt() == -1 );
         REQUIRE( g_edtStubState.serialCommands.size() == 1 );
         REQUIRE( g_edtStubState.serialCommands[0] == "temp 12.250000" );
     }
@@ -1285,21 +1505,49 @@ TEST_CASE( "ocam2KCtrl loadImageIntoStream uses the OCAM descramble output", "[o
     #endif
     // clang-format on
 
-    app.m_ocam2_id   = 7;
-    app.m_digitalBin = false;
-    app.m_image_p    = reinterpret_cast<u_char *>( rawImage.data() );
+    SECTION( "the non-digital path writes the descrambled frame directly to the destination" )
+    {
+        app.m_ocam2_id   = 7;
+        app.m_digitalBin = false;
+        app.m_image_p    = reinterpret_cast<u_char *>( rawImage.data() );
 
-    g_ocam2StubState.imageNumber = 44;
-    g_ocam2StubState.outputImage = { 10, 20, 30, 40 };
+        g_ocam2StubState.imageNumber = 44;
+        g_ocam2StubState.outputImage = { 10, 20, 30, 40 };
 
-    REQUIRE( app.loadImageIntoStream( destImage.data() ) == 0 );
-    REQUIRE( g_ocam2StubState.lastId == 7 );
-    REQUIRE( g_ocam2StubState.lastRaw == rawImage.data() );
-    REQUIRE( g_ocam2StubState.lastOutput == destImage.data() );
-    REQUIRE( destImage[0] == 10 );
-    REQUIRE( destImage[1] == 20 );
-    REQUIRE( destImage[2] == 30 );
-    REQUIRE( destImage[3] == 40 );
+        REQUIRE( app.loadImageIntoStream( destImage.data() ) == 0 );
+        REQUIRE( g_ocam2StubState.lastId == 7 );
+        REQUIRE( g_ocam2StubState.lastRaw == rawImage.data() );
+        REQUIRE( g_ocam2StubState.lastOutput == destImage.data() );
+        REQUIRE( destImage[0] == 10 );
+        REQUIRE( destImage[1] == 20 );
+        REQUIRE( destImage[2] == 30 );
+        REQUIRE( destImage[3] == 40 );
+    }
+
+    SECTION( "the digital-binning path descrambles into the work image before filling the output frame" )
+    {
+        app.m_ocam2_id    = 8;
+        app.m_digitalBin  = true;
+        app.m_digitalBinX = 2;
+        app.m_digitalBinY = 1;
+        app.m_width       = 2;
+        app.m_height      = 2;
+        app.m_image_p     = reinterpret_cast<u_char *>( rawImage.data() );
+        app.m_digitalBinWork.resize( 4, 2 );
+
+        destImage.fill( 0 );
+        g_ocam2StubState.imageNumber = 55;
+        g_ocam2StubState.outputImage = { 7, 7, 7, 7, 7, 7, 7, 7 };
+
+        REQUIRE( app.loadImageIntoStream( destImage.data() ) == 0 );
+        REQUIRE( g_ocam2StubState.lastId == 8 );
+        REQUIRE( g_ocam2StubState.lastRaw == rawImage.data() );
+        REQUIRE( g_ocam2StubState.lastOutput == app.m_digitalBinWork.data() );
+        REQUIRE( destImage[0] == 7 );
+        REQUIRE( destImage[1] == 7 );
+        REQUIRE( destImage[2] == 7 );
+        REQUIRE( destImage[3] == 7 );
+    }
 }
 
 /// Verify the serial gain helpers accept valid responses and handle malformed or tripped ones.
@@ -1346,6 +1594,20 @@ TEST_CASE( "ocam2KCtrl serial gain helpers handle valid and invalid responses", 
         REQUIRE( app.m_emGain == 77 );
     }
 
+    SECTION( "malformed EM gain responses while powered off return -1 immediately" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_emGain                                  = 77;
+
+        queueSerialResponse( "Gain set to \n\n" );
+
+        REQUIRE( app.getEMGain() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain" );
+        REQUIRE( app.m_emGain == 77 );
+    }
+
     SECTION( "HV trip response forces the cached EM gain back to the safe minimum" )
     {
         app.m_emGain = 77;
@@ -1370,6 +1632,31 @@ TEST_CASE( "ocam2KCtrl serial gain helpers handle valid and invalid responses", 
         REQUIRE( g_edtStubState.serialCommands[0] == "protection reset" );
         REQUIRE( app.m_protectionReset == true );
         REQUIRE( app.m_protectionResetConfirmed == 0 );
+    }
+
+    SECTION( "resetEMProtection returns a software error while still powered" )
+    {
+        app.m_indiP_emProt = pcf::IndiProperty( pcf::IndiProperty::Text );
+        app.m_indiP_emProt.add( pcf::IndiElement( "status" ) );
+        app.m_indiP_emProt["status"].set( "CONFIRM" );
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.resetEMProtection() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "protection reset" );
+    }
+
+    SECTION( "resetEMProtection returns -1 once power is already off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.resetEMProtection() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "protection reset" );
     }
 
     SECTION( "setEMGain refuses unsafe requests before protection reset" )
@@ -1400,6 +1687,34 @@ TEST_CASE( "ocam2KCtrl serial gain helpers handle valid and invalid responses", 
         queueSerialResponse( "Gain set to 25 \n\n" );
 
         REQUIRE( app.setEMGain() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain 25" );
+    }
+
+    SECTION( "setEMGain returns -1 on serial failure once power is already off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_protectionReset                         = true;
+        app.m_maxEMGain                               = 600;
+        app.m_emGainSet                               = 25;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setEMGain() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain 25" );
+    }
+
+    SECTION( "setEMGain returns a software error on serial failure while still powered" )
+    {
+        app.m_protectionReset = true;
+        app.m_maxEMGain       = 600;
+        app.m_emGainSet       = 25;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setEMGain() == -1 );
         REQUIRE( g_edtStubState.serialCommands.size() == 1 );
         REQUIRE( g_edtStubState.serialCommands[0] == "gain 25" );
     }
@@ -1441,10 +1756,47 @@ TEST_CASE( "ocam2KCtrl serial setter commands send the expected sequence", "[oca
         REQUIRE( app.m_reconfig == true );
     }
 
+    SECTION( "setFPS returns a software error on serial failure while still powered" )
+    {
+        app.m_synchro = false;
+        app.m_fpsSet  = 250.5f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setFPS() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 250.500000" );
+    }
+
+    SECTION( "setFPS uses the sync-device property path when synchro is enabled" )
+    {
+        app.m_synchro = true;
+        app.m_fpsSet  = 88.5f;
+
+        REQUIRE( app.setFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "setFPS returns -1 on serial failure once power is already off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_synchro                                 = false;
+        app.m_fpsSet                                  = 250.5f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setFPS() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 250.500000" );
+    }
+
     SECTION( "setSynchro off uses the OCAM serial path for both synchro and FPS" )
     {
-        app.m_synchroSet = false;
-        app.m_fpsSet     = 175.0f;
+        app.m_synchroSet    = false;
+        app.m_fpsSet        = 175.0f;
+        app.m_indiP_synchro = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        app.m_indiP_synchro.add( pcf::IndiElement( "toggle", pcf::IndiElement::On ) );
 
         queueSerialResponse( "fps max\n" );
         queueSerialResponse( "synchro off\n" );
@@ -1456,6 +1808,79 @@ TEST_CASE( "ocam2KCtrl serial setter commands send the expected sequence", "[oca
         REQUIRE( g_edtStubState.serialCommands[1] == "synchro off" );
         REQUIRE( g_edtStubState.serialCommands[2] == "fps 175.000000" );
         REQUIRE( app.m_synchro == false );
+    }
+
+    SECTION( "setSynchro on updates the local synchro state and leaves FPS to the sync device" )
+    {
+        app.m_synchroSet    = true;
+        app.m_fpsSet        = 175.0f;
+        app.m_indiP_synchro = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        app.m_indiP_synchro.add( pcf::IndiElement( "toggle", pcf::IndiElement::Off ) );
+
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro on\n" );
+
+        REQUIRE( app.setSynchro() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 2 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "synchro on" );
+        REQUIRE( app.m_synchro == true );
+    }
+
+    SECTION( "setSynchro returns a software error when the initial fps-max command fails on powered hardware" )
+    {
+        app.m_synchroSet = false;
+        app.m_fpsSet     = 175.0f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setSynchro() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+    }
+
+    SECTION( "setSynchro returns a software error when the synchro command fails on powered hardware" )
+    {
+        app.m_synchroSet = true;
+        app.m_fpsSet     = 175.0f;
+
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setSynchro() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 2 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "synchro on" );
+    }
+
+    SECTION( "setSynchro returns -1 when the initial fps-max command fails while powered off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_synchroSet                              = false;
+        app.m_fpsSet                                  = 175.0f;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setSynchro() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+    }
+
+    SECTION( "setSynchro returns -1 when the synchro command fails while powered off" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_synchroSet                              = true;
+        app.m_fpsSet                                  = 175.0f;
+
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.setSynchro() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 2 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "synchro on" );
     }
 }
 
@@ -1527,6 +1952,169 @@ TEST_CASE( "ocam2KCtrl configureAcquisition handles valid and invalid OCAM modes
         REQUIRE( app.state() == stateCodes::OPERATING );
     }
 
+    SECTION( "configureAcquisition keeps the full OCAM frame size when digital binning is disabled" )
+    {
+        app.m_raw_height                           = 121;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_NORMAL );
+        REQUIRE( app.m_digitalBin == false );
+        REQUIRE( app.m_width == 240 );
+        REQUIRE( app.m_height == 240 );
+    }
+
+    SECTION( "configureAcquisition selects OCAM binning mode for 62-row raw frames" )
+    {
+        app.m_raw_height                           = 62;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_BINNING );
+        REQUIRE( app.m_width == 120 );
+        REQUIRE( app.m_height == 120 );
+    }
+
+    SECTION( "configureAcquisition selects OCAM 1x3 binning mode for 41-row raw frames" )
+    {
+        app.m_raw_height                           = 41;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_BINNING1x3 );
+        REQUIRE( app.m_width == 240 );
+        REQUIRE( app.m_height == 80 );
+    }
+
+    SECTION( "configureAcquisition selects OCAM 1x4 binning mode for 31-row raw frames" )
+    {
+        app.m_raw_height                           = 31;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_BINNING1x4 );
+        REQUIRE( app.m_width == 240 );
+        REQUIRE( app.m_height == 60 );
+    }
+
+    SECTION( "configureAcquisition reports a set-mode serial failure on powered hardware" )
+    {
+        app.m_raw_height = 121;
+        app.m_fpsSet     = 0.0f;
+        app.m_synchroSet = false;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.configureAcquisition() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "mode science" );
+    }
+
+    SECTION( "configureAcquisition returns -1 quietly once power is already off during the set-mode command" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_raw_height                              = 121;
+        app.m_fpsSet                                  = 0.0f;
+        app.m_synchroSet                              = false;
+
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.configureAcquisition() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "mode science" );
+    }
+
+    SECTION( "configureAcquisition logs but continues when setSynchro fails" )
+    {
+        app.m_raw_height                           = 121;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "", -1 );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 3 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "mode science" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[2] == "synchro off" );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_NORMAL );
+    }
+
+    SECTION( "configureAcquisition returns -1 if OCAM initialization fails after power is lost" )
+    {
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_raw_height                              = 121;
+        app.m_fpsSet                                  = 0.0f;
+        app.m_synchroSet                              = false;
+        app.m_cameraModes["science"].m_digitalBinX    = 1;
+        app.m_cameraModes["science"].m_digitalBinY    = 1;
+        g_ocam2StubState.initReturn                   = OCAM2_ERROR;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == -1 );
+        REQUIRE( app.m_syncImageStream == nullptr );
+    }
+
+    SECTION( "configureAcquisition returns -1 if OCAM initialization fails on powered hardware" )
+    {
+        app.m_raw_height                           = 121;
+        app.m_fpsSet                               = 0.0f;
+        app.m_synchroSet                           = false;
+        app.m_cameraModes["science"].m_digitalBinX = 1;
+        app.m_cameraModes["science"].m_digitalBinY = 1;
+        g_ocam2StubState.initReturn                = OCAM2_ERROR;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == -1 );
+        REQUIRE( app.m_syncImageStream == nullptr );
+    }
+
     SECTION( "configureAcquisition rejects unsupported raw frame heights" )
     {
         app.m_raw_height = 100;
@@ -1593,6 +2181,56 @@ TEST_CASE( "ocam2KCtrl INDI callbacks update local state", "[ocam2KCtrl]" )
         REQUIRE( app.m_protectionResetConfirmed == 0 );
     }
 
+    SECTION( "EM protection reset callback ignores requests while power is off" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Switch );
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_indiP_emProtReset.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProtReset.setName( "emProtReset" );
+        ipRecv.setDevice( "ocam2KCtrl" );
+        ipRecv.setName( "emProtReset" );
+        ipRecv.add( pcf::IndiElement( "request", pcf::IndiElement::On ) );
+
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( ipRecv ) == 0 );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "EM protection reset callback rejects the wrong property name" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Switch );
+
+        app.m_indiP_emProtReset.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProtReset.setName( "emProtReset" );
+        ipRecv.setDevice( "ocam2KCtrl" );
+        ipRecv.setName( "wrongName" );
+        ipRecv.add( pcf::IndiElement( "request", pcf::IndiElement::On ) );
+
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( ipRecv ) == -1 );
+    }
+
+    SECTION( "EM protection reset callback ignores requests without the request element or with it off" )
+    {
+        pcf::IndiProperty missingReq( pcf::IndiProperty::Switch );
+        pcf::IndiProperty offReq( pcf::IndiProperty::Switch );
+
+        app.m_indiP_emProtReset.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProtReset.setName( "emProtReset" );
+
+        missingReq.setDevice( "ocam2KCtrl" );
+        missingReq.setName( "emProtReset" );
+        offReq.setDevice( "ocam2KCtrl" );
+        offReq.setName( "emProtReset" );
+        offReq.add( pcf::IndiElement( "request", pcf::IndiElement::Off ) );
+
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( missingReq ) == 0 );
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( offReq ) == 0 );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
     SECTION( "sync frequency callback queues a reconfiguration when synchro mode changes the effective FPS" )
     {
         pcf::IndiProperty ipRecv( pcf::IndiProperty::Number );
@@ -1616,6 +2254,18 @@ TEST_CASE( "ocam2KCtrl INDI callbacks update local state", "[ocam2KCtrl]" )
         REQUIRE( app.m_fps == Approx( 123.4f ) );
         REQUIRE( app.m_nextMode == "science" );
         REQUIRE( app.m_reconfig == true );
+    }
+
+    SECTION( "sync frequency callback rejects updates that do not include the current element" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Number );
+
+        app.m_indiP_syncFreq.setDevice( "syncDevice" );
+        app.m_indiP_syncFreq.setName( "C1freq" );
+        ipRecv.setDevice( "syncDevice" );
+        ipRecv.setName( "C1freq" );
+
+        REQUIRE( app.setCallBack_m_indiP_syncFreq( ipRecv ) == -1 );
     }
 }
 
@@ -1760,41 +2410,6 @@ TEST_CASE( "ocam2KCtrl telemetry wrappers record snapshots and stale intervals",
     }
 }
 
-/// Verify lifecycle entrypoints cover startup failure handling and the POWERON fast-return path.
-/**
- * \ingroup ocam2KCtrl_unit_test
- */
-TEST_CASE( "ocam2KCtrl lifecycle entrypoints handle startup failures and POWERON logic", "[ocam2KCtrl]" )
-{
-    resetStubState();
-
-    // clang-format off
-    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
-    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appStartup() );
-    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appLogic() );
-    #endif
-    // clang-format on
-
-    SECTION( "appStartup reports failure when the startup mode cannot be configured" )
-    {
-        ocam2KCtrl_test app;
-
-        app.m_startupMode = "";
-
-        REQUIRE( app.appStartup() < 0 );
-    }
-
-    SECTION( "appLogic returns immediately while the app is still in POWERON" )
-    {
-        ocam2KCtrl_test app;
-
-        app.state( stateCodes::POWERON );
-        fgThreadScope fgThread( app );
-
-        REQUIRE( app.appLogic() == 0 );
-    }
-}
-
 /// Verify appLogic covers connection transitions, error handling, and READY-state housekeeping.
 /**
  * \ingroup ocam2KCtrl_unit_test
@@ -1824,6 +2439,20 @@ TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[oca
         REQUIRE( app.appLogic() == 0 );
         REQUIRE( app.state() == stateCodes::NOTCONNECTED );
         REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "POWEROFF falls through to the final return without camera traffic" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::POWEROFF );
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::POWEROFF );
         REQUIRE( g_edtStubState.serialCommands.empty() );
     }
 
@@ -1871,6 +2500,51 @@ TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[oca
                      "fps", "fps", "temp 18.500000", "fps 0", "synchro off", "fps 0.000000", "temp", "fps", "gain" } );
     }
 
+    SECTION( "NOTCONNECTED returns after a failed connectivity probe while power remains on" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::NOTCONNECTED );
+
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::NOTCONNECTED );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps" } );
+    }
+
+    SECTION( "CONNECTED with a requested FPS transitions through OPERATING before housekeeping" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+
+        app.state( stateCodes::CONNECTED );
+        app.m_fpsSet                   = 10.0f;
+        app.m_poweredOn                = false;
+        app.m_protectionResetConfirmed = 0;
+
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps 10.000000 restored\n" );
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "Gain set to 42 \n\n" );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::FAILURE );
+        REQUIRE( app.m_shutdown == 1 );
+        REQUIRE( g_edtStubState.serialCommands ==
+                 std::vector<std::string>{ "fps", "fps 0", "synchro off", "fps 10.000000", "temp", "fps", "gain" } );
+    }
+
     SECTION( "CONNECTED enters ERROR when getFPS fails on powered hardware" )
     {
         ocam2KCtrl_test app;
@@ -1885,6 +2559,92 @@ TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[oca
         REQUIRE( app.appLogic() == 0 );
         REQUIRE( app.state() == stateCodes::ERROR );
         REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps" } );
+    }
+
+    SECTION( "CONNECTED returns quietly if getFPS fails after power is lost" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::CONNECTED );
+
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::CONNECTED );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps" } );
+    }
+
+    SECTION( "CONNECTED returns quietly when setTempSetPt fails after power is lost" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::CONNECTED );
+        app.m_fpsSet       = 0.0f;
+        app.m_poweredOn    = true;
+        app.m_ccdTempSetpt = 18.5f;
+
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::READY );
+        REQUIRE( app.m_poweredOn == false );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps", "temp 18.500000" } );
+    }
+
+    SECTION( "CONNECTED returns a software error when setTempSetPt fails on powered hardware" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::CONNECTED );
+        app.m_fpsSet       = 0.0f;
+        app.m_poweredOn    = true;
+        app.m_ccdTempSetpt = 18.5f;
+
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::READY );
+        REQUIRE( app.m_poweredOn == false );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps", "temp 18.500000" } );
+    }
+
+    SECTION( "CONNECTED logs but continues when setSynchro fails during the initial connect" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::CONNECTED );
+        app.m_fpsSet    = 0.0f;
+        app.m_poweredOn = false;
+
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "", -1 );
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "Gain set to 42 \n\n" );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::FAILURE );
+        REQUIRE( app.m_shutdown == 1 );
+        REQUIRE( g_edtStubState.serialCommands ==
+                 std::vector<std::string>{ "fps", "fps 0", "synchro off", "temp", "fps", "gain" } );
     }
 
     SECTION( "READY expires stale protection resets and completes housekeeping before telemetry shutdown" )
@@ -1916,6 +2676,20 @@ TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[oca
         REQUIRE( app.m_emGain == 42 );
     }
 
+    SECTION( "READY returns immediately if the INDI mutex is already locked elsewhere" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::READY );
+
+        std::unique_lock<std::mutex> hold( app.m_indiMutex );
+        fgThreadScope                fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
     SECTION( "READY moves to ERROR when temperature polling fails on powered hardware" )
     {
         ocam2KCtrl_test app;
@@ -1931,6 +2705,99 @@ TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[oca
         REQUIRE( app.state() == stateCodes::ERROR );
         REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
         REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp" } );
+    }
+
+    SECTION( "READY returns quietly when temperature polling fails after power is lost" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::READY );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp" } );
+    }
+
+    SECTION( "READY moves to ERROR when FPS polling fails after temperatures succeed" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::ERROR );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp", "fps" } );
+    }
+
+    SECTION( "READY returns quietly when FPS polling fails after power is lost" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::READY );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp", "fps" } );
+    }
+
+    SECTION( "READY returns quietly when EM gain polling fails after power is lost" )
+    {
+        ocam2KCtrl_test app;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::READY );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp", "fps", "gain" } );
+    }
+
+    SECTION( "READY moves to ERROR when EM gain polling fails on powered hardware" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::ERROR );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp", "fps", "gain" } );
     }
 }
 
@@ -1964,7 +2831,10 @@ TEST_CASE( "ocam2KCtrl reconfig reloads the next mode through edtCamera", "[ocam
     REQUIRE( app.m_raw_height == 121 );
     REQUIRE( app.m_raw_depth == 16 );
     REQUIRE( app.m_cameraType == "stub_pdv" );
+    REQUIRE( app.fps() == Approx( app.m_fps ) );
 }
+
+#endif // OCAM2KCTRL_TEST_SUPPORT_ONLY
 
 } // namespace ocam2KCtrlTest
 } // namespace libXWCTest

--- a/apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp
+++ b/apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp
@@ -1,0 +1,1970 @@
+/** \file ocam2KCtrl_test.cpp
+ * \brief Catch2 tests for the ocam2KCtrl app.
+ * \author OpenAI Codex
+ *
+ * \ingroup ocam2KCtrl_files
+ */
+
+/** \defgroup ocam2KCtrl_unit_test ocam2KCtrl Unit Tests
+ * \brief Unit tests for the ocam2KCtrl application.
+ *
+ * \ingroup application_unit_test
+ */
+
+#include "../../../tests/testXWC.hpp"
+
+#include <chrono>
+#include <deque>
+#include <array>
+#include <cstdlib>
+#include <semaphore.h>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#define protected public
+#include "../ocam2KCtrl.hpp"
+#undef protected
+
+using namespace MagAOX::app;
+
+namespace
+{
+
+/// Scripted serial response returned by the EDT serial-command stubs.
+struct serialResponse
+{
+    std::string response;               ///< Response returned by the next serial read.
+    int         commandResult{ 0 };     ///< Return code from `pdv_serial_command`.
+    int         initialWaitResult{ 1 }; ///< Return code from the first `pdv_serial_wait`.
+};
+
+/// Shared EDT stub state used to verify acquisition-related calls from `ocam2KCtrl`.
+struct edtStubState
+{
+    /// Reset the stub to a known default state before each test section.
+    void reset()
+    {
+        startImagesCalls  = 0;
+        lastStartNumBuffs = -1;
+        startImageCalls   = 0;
+        waitTimeSec       = 0;
+        waitTimeNsec      = 0;
+        waitImage.fill( 0 );
+        serialResponses.clear();
+        serialCommands.clear();
+        activeSerialResponse.clear();
+        activeSerialReadPending = false;
+        activeSerialTransaction = false;
+        activeSerialWaitResult  = 0;
+        activeSerialWaitServed  = false;
+    }
+
+    int                        startImagesCalls{ 0 };   ///< Number of `pdv_start_images` calls observed.
+    int                        lastStartNumBuffs{ -1 }; ///< Most recent requested EDT buffer count.
+    int                        startImageCalls{ 0 };    ///< Number of `pdv_start_image` calls observed.
+    uint                       waitTimeSec{ 0 };        ///< Seconds returned by `pdv_wait_last_image_timed`.
+    uint                       waitTimeNsec{ 0 };       ///< Nanoseconds returned by `pdv_wait_last_image_timed`.
+    std::array<u_char, 32>     waitImage{};             ///< Raw EDT frame buffer returned to the app.
+    std::deque<serialResponse> serialResponses;         ///< Scripted serial responses queued for future commands.
+    std::vector<std::string>   serialCommands;          ///< Serial commands issued by the app under test.
+    std::string                activeSerialResponse;    ///< Active serial response returned by the current command.
+    bool activeSerialReadPending{ false }; ///< Indicates that the next `pdv_serial_read` should return data.
+    bool activeSerialTransaction{ false }; ///< Indicates that a serial command is mid-transaction.
+    int  activeSerialWaitResult{ 0 };      ///< Return code for the first wait after a command.
+    bool activeSerialWaitServed{ false };  ///< Tracks whether the first serial wait has been consumed.
+};
+
+/// Shared OCAM SDK stub state used to drive descramble output in tests.
+struct ocam2StubState
+{
+    /// Reset the stub to its default state before each test section.
+    void reset()
+    {
+        lastId     = 0;
+        lastRaw    = nullptr;
+        lastOutput = nullptr;
+        outputImage.clear();
+        imageNumber  = 0;
+        lastInitMode = OCAM2_NORMAL;
+        lastDescrambleFile.clear();
+        nextInitId   = 1;
+        initReturn   = OCAM2_OK;
+        exitCalls    = 0;
+        lastExitId   = 0;
+        reportedMode = OCAM2_NORMAL;
+    }
+
+    ocam2_id             lastId{ 0 };           ///< Most recent OCAM handle passed into `ocam2_descramble`.
+    const short         *lastRaw{ nullptr };    ///< Most recent raw source frame passed to `ocam2_descramble`.
+    short               *lastOutput{ nullptr }; ///< Most recent output frame passed to `ocam2_descramble`.
+    std::vector<int16_t> outputImage;      ///< Pixel values the descramble stub should copy into the output buffer.
+    unsigned int         imageNumber{ 0 }; ///< Frame number returned by the descramble stub.
+    ocam2_mode           lastInitMode{ OCAM2_NORMAL }; ///< Most recent OCAM SDK mode requested by `ocam2_init`.
+    std::string          lastDescrambleFile;           ///< Most recent descramble file passed to `ocam2_init`.
+    ocam2_id             nextInitId{ 1 };              ///< OCAM id returned by the next successful `ocam2_init`.
+    ocam2_rc             initReturn{ OCAM2_OK };       ///< Return code from `ocam2_init`.
+    int                  exitCalls{ 0 };               ///< Number of `ocam2_exit` invocations.
+    ocam2_id             lastExitId{ 0 };              ///< Most recent OCAM id passed to `ocam2_exit`.
+    ocam2_mode           reportedMode{ OCAM2_NORMAL }; ///< Mode returned by `ocam2_getMode`.
+};
+
+/// Global EDT stub state for the `extern "C"` wrappers below.
+edtStubState g_edtStubState;
+
+/// Global OCAM SDK stub state for the `extern "C"` wrappers below.
+ocam2StubState g_ocam2StubState;
+
+/// Reset all external-library stub state before a test.
+void resetStubState()
+{
+    g_edtStubState.reset();
+    g_ocam2StubState.reset();
+}
+
+/// Store a frame number into the raw EDT image buffer at the OCAM metadata offset.
+void setStubFrameNumber( unsigned int frameNumber )
+{
+    reinterpret_cast<int *>( g_edtStubState.waitImage.data() )[OCAM2_IMAGE_NB_OFFSET / 4] =
+        static_cast<int>( frameNumber );
+}
+
+/// Queue one scripted serial response for the next `pdvSerialWriteRead` invocation.
+void queueSerialResponse( const std::string &response, int commandResult = 0, int initialWaitResult = 1 )
+{
+    g_edtStubState.serialResponses.push_back( { response, commandResult, initialWaitResult } );
+}
+
+} // namespace
+
+extern "C"
+{
+
+    Dependent *pdv_alloc_dependent()
+    {
+        return reinterpret_cast<Dependent *>( malloc( sizeof( Dependent ) ) );
+    }
+
+    int pdv_readcfg( const char *configFile, Dependent *dd_p, Edtinfo *edtinfo )
+    {
+        static_cast<void>( configFile );
+        static_cast<void>( dd_p );
+        static_cast<void>( edtinfo );
+        return 0;
+    }
+
+    EdtDev *edt_open_channel( const char *deviceName, int unit, int channel )
+    {
+        static EdtDev device;
+        static_cast<void>( deviceName );
+        static_cast<void>( unit );
+        static_cast<void>( channel );
+        return &device;
+    }
+
+    void edt_perror( char *errstr )
+    {
+        if( errstr != nullptr )
+        {
+            errstr[0] = '\0';
+        }
+    }
+
+    int pdv_initcam( EdtDev     *edt_p,
+                     Dependent  *dd_p,
+                     int         unit,
+                     Edtinfo    *edtinfo,
+                     const char *configFile,
+                     char       *bitdir,
+                     int         pdv_debug )
+    {
+        static_cast<void>( edt_p );
+        static_cast<void>( dd_p );
+        static_cast<void>( unit );
+        static_cast<void>( edtinfo );
+        static_cast<void>( configFile );
+        static_cast<void>( bitdir );
+        static_cast<void>( pdv_debug );
+        return 0;
+    }
+
+    void edt_close( EdtDev *edt_p )
+    {
+        static_cast<void>( edt_p );
+    }
+
+    PdvDev *pdv_open_channel( const char *deviceName, int unit, int channel )
+    {
+        static PdvDev device;
+        static_cast<void>( deviceName );
+        static_cast<void>( unit );
+        static_cast<void>( channel );
+        return &device;
+    }
+
+    void pdv_close( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+    }
+
+    void pdv_flush_fifo( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+    }
+
+    void pdv_serial_read_enable( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+    }
+
+    int pdv_get_width( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+        return 240;
+    }
+
+    int pdv_get_height( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+        return 121;
+    }
+
+    int pdv_get_depth( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+        return 16;
+    }
+
+    char *pdv_get_cameratype( PdvDev *pdv_p )
+    {
+        static char cameraType[] = "stub_pdv";
+        static_cast<void>( pdv_p );
+        return cameraType;
+    }
+
+    void pdv_multibuf( PdvDev *pdv_p, int numBuffs )
+    {
+        static_cast<void>( pdv_p );
+        static_cast<void>( numBuffs );
+    }
+
+    void pdv_start_images( PdvDev *pdv_p, int numBuffs )
+    {
+        static_cast<void>( pdv_p );
+        ++g_edtStubState.startImagesCalls;
+        g_edtStubState.lastStartNumBuffs = numBuffs;
+    }
+
+    u_char *pdv_wait_last_image_timed( PdvDev *pdv_p, uint dmaTimeStamp[2] )
+    {
+        static_cast<void>( pdv_p );
+        dmaTimeStamp[0] = g_edtStubState.waitTimeSec;
+        dmaTimeStamp[1] = g_edtStubState.waitTimeNsec;
+        return g_edtStubState.waitImage.data();
+    }
+
+    void pdv_start_image( PdvDev *pdv_p )
+    {
+        static_cast<void>( pdv_p );
+        ++g_edtStubState.startImageCalls;
+    }
+
+    int pdv_serial_read( PdvDev *pdv_p, char *buf, int size )
+    {
+        static_cast<void>( pdv_p );
+        if( buf != nullptr && size > 0 )
+        {
+            buf[0] = '\0';
+        }
+
+        if( !g_edtStubState.activeSerialReadPending || buf == nullptr || size <= 0 )
+        {
+            return 0;
+        }
+
+        size_t copyCount = g_edtStubState.activeSerialResponse.size();
+        if( copyCount > static_cast<size_t>( size - 1 ) )
+        {
+            copyCount = static_cast<size_t>( size - 1 );
+        }
+
+        std::copy_n( g_edtStubState.activeSerialResponse.data(), copyCount, buf );
+        buf[copyCount] = '\0';
+
+        g_edtStubState.activeSerialReadPending = false;
+
+        return static_cast<int>( copyCount );
+    }
+
+    int pdv_serial_command( PdvDev *pdv_p, const char *command )
+    {
+        static_cast<void>( pdv_p );
+        g_edtStubState.serialCommands.emplace_back( command == nullptr ? "" : command );
+
+        g_edtStubState.activeSerialResponse.clear();
+        g_edtStubState.activeSerialReadPending = false;
+        g_edtStubState.activeSerialTransaction = false;
+        g_edtStubState.activeSerialWaitResult  = 0;
+        g_edtStubState.activeSerialWaitServed  = false;
+
+        if( g_edtStubState.serialResponses.empty() )
+        {
+            return 0;
+        }
+
+        serialResponse response = g_edtStubState.serialResponses.front();
+        g_edtStubState.serialResponses.pop_front();
+
+        if( response.commandResult < 0 )
+        {
+            return response.commandResult;
+        }
+
+        g_edtStubState.activeSerialResponse    = response.response;
+        g_edtStubState.activeSerialReadPending = true;
+        g_edtStubState.activeSerialTransaction = true;
+        g_edtStubState.activeSerialWaitResult  = response.initialWaitResult;
+
+        return response.commandResult;
+    }
+
+    int pdv_serial_wait( PdvDev *pdv_p, int timeout, int count )
+    {
+        static_cast<void>( pdv_p );
+        static_cast<void>( timeout );
+        static_cast<void>( count );
+
+        if( !g_edtStubState.activeSerialTransaction )
+        {
+            return 0;
+        }
+
+        if( !g_edtStubState.activeSerialWaitServed )
+        {
+            g_edtStubState.activeSerialWaitServed = true;
+            return g_edtStubState.activeSerialWaitResult;
+        }
+
+        return 0;
+    }
+
+    int pdv_get_waitchar( PdvDev *pdv_p, u_char *waitc )
+    {
+        static_cast<void>( pdv_p );
+        if( waitc != nullptr )
+        {
+            *waitc = '\n';
+        }
+        return 1;
+    }
+
+    const char *ocam2_sdkVersion()
+    {
+        return "stub";
+    }
+
+    const char *ocam2_sdkBuild()
+    {
+        return "stub";
+    }
+
+    ocam2_rc ocam2_init( ocam2_mode mode, const char *descrbFile, ocam2_id *id )
+    {
+        g_ocam2StubState.lastInitMode       = mode;
+        g_ocam2StubState.lastDescrambleFile = descrbFile == nullptr ? "" : descrbFile;
+        if( id != nullptr )
+        {
+            *id = g_ocam2StubState.nextInitId;
+        }
+        g_ocam2StubState.reportedMode = mode;
+        return g_ocam2StubState.initReturn;
+    }
+
+    void ocam2_descramble( ocam2_id id, unsigned int *number, short *image, const short *imageRaw )
+    {
+        g_ocam2StubState.lastId     = id;
+        g_ocam2StubState.lastRaw    = imageRaw;
+        g_ocam2StubState.lastOutput = image;
+        if( number != nullptr )
+        {
+            *number = g_ocam2StubState.imageNumber;
+        }
+        if( image != nullptr )
+        {
+            for( size_t nn = 0; nn < g_ocam2StubState.outputImage.size(); ++nn )
+            {
+                image[nn] = g_ocam2StubState.outputImage[nn];
+            }
+        }
+    }
+
+    ocam2_rc ocam2_exit( ocam2_id id )
+    {
+        ++g_ocam2StubState.exitCalls;
+        g_ocam2StubState.lastExitId = id;
+        return OCAM2_OK;
+    }
+
+    ocam2_mode ocam2_getMode( ocam2_id id )
+    {
+        static_cast<void>( id );
+        return g_ocam2StubState.reportedMode;
+    }
+
+    const char *ocam2_modeStr( ocam2_mode mode )
+    {
+        static_cast<void>( mode );
+        return "stub";
+    }
+
+} // extern "C"
+
+namespace libXWCTest
+{
+
+/// Namespace for `ocam2KCtrl` unit tests.
+/** \ingroup ocam2KCtrl_unit_test
+ */
+namespace ocam2KCtrlTest
+{
+
+namespace
+{
+
+/// Build a unique shmim name for one temporary test stream.
+std::string uniqueShmimName( const std::string &suffix )
+{
+    static unsigned counter = 0;
+
+    ++counter;
+
+    return "ocam2KCtrl_test_" + suffix + "_" + std::to_string( ::getpid() ) + "_" + std::to_string( counter );
+}
+
+/// Build a unique temporary config-file path for one test.
+std::string uniqueConfigPath( const std::string &suffix )
+{
+    return "/tmp/ocam2KCtrl_test_" + suffix + "_" + std::to_string( ::getpid() ) + ".conf";
+}
+
+/// RAII wrapper for a temporary 1x1 uint8 ImageStreamIO stream used by tests.
+class tempStream
+{
+  public:
+    /// Create the temporary stream or throw if ImageStreamIO setup fails.
+    explicit tempStream( const std::string &name,
+                         uint32_t           width    = 1,
+                         uint32_t           height   = 1,
+                         uint32_t           depth    = 1,
+                         uint8_t            dataType = _DATATYPE_UINT8 )
+        : m_name( name )
+    {
+        uint32_t imsize[3] = { width, height, depth };
+
+        if( ImageStreamIO_createIm_gpu( &m_image,
+                                        m_name.c_str(),
+                                        3,
+                                        imsize,
+                                        dataType,
+                                        -1,
+                                        1,
+                                        IMAGE_NB_SEMAPHORE,
+                                        0,
+                                        CIRCULAR_BUFFER | ZAXIS_TEMPORAL,
+                                        0 ) != IMAGESTREAMIO_SUCCESS )
+        {
+            throw std::runtime_error( "failed to create temporary ImageStreamIO stream" );
+        }
+
+        m_image.md[0].cnt1 = 0;
+    }
+
+    /// Destroy the temporary stream.
+    ~tempStream()
+    {
+        if( m_owner )
+        {
+            ImageStreamIO_destroyIm( &m_image );
+        }
+    }
+
+    /// Return the underlying temporary stream.
+    IMAGE *image()
+    {
+        return &m_image;
+    }
+
+    /// Release destruction ownership after the stream is handed off elsewhere.
+    void dismiss()
+    {
+        m_owner = false;
+    }
+
+  private:
+    std::string m_name;          ///< Unique shmim name for the temporary stream.
+    IMAGE       m_image{};       ///< ImageStreamIO handle for the temporary stream.
+    bool        m_owner{ true }; ///< Whether this wrapper should destroy the underlying shmim on teardown.
+};
+
+/// Test harness exposing protected `ocam2KCtrl` helpers.
+class ocam2KCtrl_test : public MagAOX::app::ocam2KCtrl
+{
+  public:
+    /// Construct a testable controller instance with unique shmim names.
+    ocam2KCtrl_test()
+    {
+        m_configName    = "ocam2KCtrl_test";
+        m_shmimName     = uniqueShmimName( "main" );
+        m_syncShmimName = uniqueShmimName( "sync" );
+    }
+
+    /// Tear down any sync stream left behind by the test.
+    ~ocam2KCtrl_test() noexcept
+    {
+        destroySyncStream();
+    }
+};
+
+/// Put the app into the nominal powered-on state used by the serial helpers.
+void setPoweredOn( ocam2KCtrl_test &app )
+{
+    static_cast<MagAOXAppT &>( app ).m_powerState = 1;
+    app.m_powerTargetState                        = 1;
+}
+
+/// Start a short-lived framegrabber thread so `frameGrabber::appLogic()` sees a running worker.
+void startFgThread( ocam2KCtrl_test &app, int sleepMs = 200 )
+{
+    app.m_fgThread =
+        std::thread( [sleepMs]() { std::this_thread::sleep_for( std::chrono::milliseconds( sleepMs ) ); } );
+}
+
+/// Join the temporary framegrabber thread if a test started one.
+void joinFgThread( ocam2KCtrl_test &app )
+{
+    if( app.m_fgThread.joinable() )
+    {
+        app.m_fgThread.join();
+    }
+}
+
+/// Keep a temporary framegrabber thread joined even when a test fails mid-scope.
+struct fgThreadScope
+{
+    ocam2KCtrl_test &m_app; ///< App whose temporary framegrabber thread is managed by this scope.
+
+    /// Start a temporary framegrabber thread for the lifetime of this scope.
+    explicit fgThreadScope( ocam2KCtrl_test &app, int sleepMs = 200 ) : m_app( app )
+    {
+        startFgThread( m_app, sleepMs );
+    }
+
+    /// Join the temporary framegrabber thread on scope exit.
+    ~fgThreadScope()
+    {
+        joinFgThread( m_app );
+    }
+};
+
+/// Report whether a telemetry timestamp has been written at least once.
+bool hasRecordedTime( const timespec &ts )
+{
+    return ts.tv_sec != 0 || ts.tv_nsec != 0;
+}
+
+} // namespace
+
+/// Verify the sync stream is created as a 1x1 uint8 ImageStreamIO buffer.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl sync stream creation uses a 1x1 uint8 layout", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+    IMAGE           openedSyncStream;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::ensureSyncStream() );
+    #endif
+    // clang-format on
+
+    REQUIRE( app.ensureSyncStream() == 0 );
+    REQUIRE( app.m_syncImageStream != nullptr );
+    REQUIRE( app.m_syncImageStream->md[0].datatype == _DATATYPE_UINT8 );
+    REQUIRE( app.m_syncImageStream->md[0].size[0] == 1 );
+    REQUIRE( app.m_syncImageStream->md[0].size[1] == 1 );
+    REQUIRE( app.m_syncImageStream->md[0].size[2] == 1 );
+    REQUIRE( app.m_syncImageStream->md[0].cnt1 == 0 );
+
+    REQUIRE( ImageStreamIO_openIm( &openedSyncStream, app.m_syncShmimName.c_str() ) == IMAGESTREAMIO_SUCCESS );
+    REQUIRE( openedSyncStream.md[0].datatype == _DATATYPE_UINT8 );
+    REQUIRE( openedSyncStream.md[0].size[0] == 1 );
+    REQUIRE( openedSyncStream.md[0].size[1] == 1 );
+    REQUIRE( openedSyncStream.md[0].size[2] == 1 );
+    REQUIRE( ImageStreamIO_closeIm( &openedSyncStream ) == IMAGESTREAMIO_SUCCESS );
+}
+
+/// Verify the sync stream mirrors main-stream metadata and posts a semaphore.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl sync stream publication mirrors metadata and posts semaphores", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+    tempStream      sourceStream( uniqueShmimName( "source" ) );
+    int             semIndex = -1;
+    int             semValue = -1;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::frameGrabberPostPublish( nullptr ) );
+    #endif
+    // clang-format on
+
+    REQUIRE( app.ensureSyncStream() == 0 );
+
+    sourceStream.image()->md[0].writetime.tv_sec  = 1234;
+    sourceStream.image()->md[0].writetime.tv_nsec = 5678;
+    sourceStream.image()->md[0].atime.tv_sec      = 1234;
+    sourceStream.image()->md[0].atime.tv_nsec     = 4321;
+    sourceStream.image()->md[0].cnt0              = 77;
+    sourceStream.image()->md[0].cnt1              = 0;
+    sourceStream.image()->writetimearray[0]       = sourceStream.image()->md[0].writetime;
+    sourceStream.image()->atimearray[0]           = sourceStream.image()->md[0].atime;
+    sourceStream.image()->cntarray[0]             = sourceStream.image()->md[0].cnt0;
+
+    semIndex = ImageStreamIO_getsemwaitindex( app.m_syncImageStream, 0 );
+    REQUIRE( semIndex >= 0 );
+    ImageStreamIO_semflush( app.m_syncImageStream, semIndex );
+    REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
+    REQUIRE( semValue == 0 );
+
+    app.m_syncImageStream->array.UI8[0] = 99;
+
+    REQUIRE( app.frameGrabberPostPublish( sourceStream.image() ) == 0 );
+    REQUIRE( sem_getvalue( app.m_syncImageStream->semptr[semIndex], &semValue ) == 0 );
+    REQUIRE( semValue == 1 );
+    REQUIRE( app.m_syncImageStream->array.UI8[0] == 0 );
+    REQUIRE( app.m_syncImageStream->md[0].writetime.tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
+    REQUIRE( app.m_syncImageStream->md[0].writetime.tv_nsec == sourceStream.image()->md[0].writetime.tv_nsec );
+    REQUIRE( app.m_syncImageStream->md[0].atime.tv_sec == sourceStream.image()->md[0].atime.tv_sec );
+    REQUIRE( app.m_syncImageStream->md[0].atime.tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
+    REQUIRE( app.m_syncImageStream->md[0].cnt0 == sourceStream.image()->md[0].cnt0 );
+    REQUIRE( app.m_syncImageStream->md[0].cnt1 == 0 );
+    REQUIRE( app.m_syncImageStream->writetimearray[0].tv_sec == sourceStream.image()->md[0].writetime.tv_sec );
+    REQUIRE( app.m_syncImageStream->atimearray[0].tv_nsec == sourceStream.image()->md[0].atime.tv_nsec );
+    REQUIRE( app.m_syncImageStream->cntarray[0] == sourceStream.image()->md[0].cnt0 );
+}
+
+/// Verify sync-stream preparation reuses valid streams and recovers from stale or mismatched ones.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl ensureSyncStream reuses and replaces existing stream state", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::ensureSyncStream() );
+    #endif
+    // clang-format on
+
+    SECTION( "a valid existing sync stream is reused in place" )
+    {
+        REQUIRE( app.ensureSyncStream() == 0 );
+
+        IMAGE *existingStream = app.m_syncImageStream;
+
+        REQUIRE( app.ensureSyncStream() == 0 );
+        REQUIRE( app.m_syncImageStream == existingStream );
+    }
+
+    SECTION( "a mismatched in-memory sync stream is destroyed and recreated with the expected layout" )
+    {
+        app.m_syncImageStream = reinterpret_cast<IMAGE *>( malloc( sizeof( IMAGE ) ) );
+        REQUIRE( app.m_syncImageStream != nullptr );
+
+        {
+            uint32_t wrongSize[3] = { 1, 2, 1 };
+
+            REQUIRE( ImageStreamIO_createIm_gpu( app.m_syncImageStream,
+                                                 app.m_syncShmimName.c_str(),
+                                                 3,
+                                                 wrongSize,
+                                                 _DATATYPE_UINT8,
+                                                 -1,
+                                                 1,
+                                                 IMAGE_NB_SEMAPHORE,
+                                                 0,
+                                                 CIRCULAR_BUFFER | ZAXIS_TEMPORAL,
+                                                 0 ) == IMAGESTREAMIO_SUCCESS );
+        }
+
+        void *wrongPtr = app.m_syncImageStream;
+
+        REQUIRE( app.ensureSyncStream() == 0 );
+        REQUIRE( app.m_syncImageStream != nullptr );
+        REQUIRE( static_cast<void *>( app.m_syncImageStream ) == wrongPtr );
+        REQUIRE( app.m_syncImageStream->md[0].datatype == _DATATYPE_UINT8 );
+        REQUIRE( app.m_syncImageStream->md[0].size[0] == 1 );
+        REQUIRE( app.m_syncImageStream->md[0].size[1] == 1 );
+        REQUIRE( app.m_syncImageStream->md[0].size[2] == 1 );
+        REQUIRE( app.m_syncImageStream->md[0].size[1] != 2 );
+    }
+
+    SECTION( "a stale on-disk sync stream is reopened, destroyed, and replaced" )
+    {
+        tempStream staleStream( app.m_syncShmimName, 1, 1, 1, _DATATYPE_UINT8 );
+        staleStream.dismiss();
+
+        REQUIRE( app.m_syncImageStream == nullptr );
+        REQUIRE( app.ensureSyncStream() == 0 );
+        REQUIRE( app.m_syncImageStream != nullptr );
+        REQUIRE( app.m_syncImageStream->md[0].datatype == _DATATYPE_UINT8 );
+        REQUIRE( app.m_syncImageStream->md[0].size[0] == 1 );
+        REQUIRE( app.m_syncImageStream->md[0].size[1] == 1 );
+        REQUIRE( app.m_syncImageStream->md[0].size[2] == 1 );
+    }
+}
+
+/// Verify the stdCamera state string is assembled from the OCAM state members.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl stateString reports mode fps gain and setpoint", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::stateString() );
+    #endif
+    // clang-format on
+
+    app.m_modeName     = "science";
+    app.m_fps          = 150.0f;
+    app.m_emGain       = 42;
+    app.m_ccdTempSetpt = 19.5;
+
+    REQUIRE( app.stateString() == "science_150.000000_42.000000_19.500000" );
+}
+
+/// Verify the state string validity depends on operating state and temperature lock.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl stateStringValid requires OPERATING and on-target temperature control", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::stateStringValid() );
+    #endif
+    // clang-format on
+
+    app.state( stateCodes::OPERATING );
+    app.m_tempControlOnTarget = true;
+    REQUIRE( app.stateStringValid() );
+
+    app.m_tempControlOnTarget = false;
+    REQUIRE( !app.stateStringValid() );
+
+    app.state( stateCodes::READY );
+    app.m_tempControlOnTarget = true;
+    REQUIRE( !app.stateStringValid() );
+}
+
+/// Verify OCAM-specific configuration values load defaults, overrides, and gain clamps.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl configuration loading handles defaults and supported gain limits", "[ocam2KCtrl]" )
+{
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setupConfig() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::loadConfig() );
+    #endif
+    // clang-format on
+
+    SECTION( "loadConfig falls back to the main shmim name for the sync stream" )
+    {
+        ocam2KCtrl_test app;
+
+        app.setupConfig();
+
+        mx::app::writeConfigFile( uniqueConfigPath( "defaults" ), { "unused" }, { "value" }, { "0" } );
+        app.config.readConfig( uniqueConfigPath( "defaults" ) );
+
+        app.m_shmimName     = "ocam_main_default";
+        app.m_syncShmimName = "";
+
+        app.loadConfig();
+
+        REQUIRE( app.m_ocamDescrambleFile == "" );
+        REQUIRE( app.m_maxEMGain == Approx( 600.0f ) );
+        REQUIRE( app.m_syncShmimName == app.m_shmimName + "_sync" );
+    }
+
+    SECTION( "loadConfig applies configured overrides for the descramble and stream names" )
+    {
+        ocam2KCtrl_test app;
+
+        app.setupConfig();
+
+        mx::app::writeConfigFile( uniqueConfigPath( "overrides" ),
+                                  { "camera", "camera", "framegrabber", "framegrabber" },
+                                  { "ocamDescrambleFile", "maxEMGain", "shmimName", "syncShmimName" },
+                                  { "descramble_stub.txt", "321", "ocam_main_override", "ocam_sync_override" } );
+        app.config.readConfig( uniqueConfigPath( "overrides" ) );
+
+        app.loadConfig();
+
+        REQUIRE( app.m_ocamDescrambleFile == "descramble_stub.txt" );
+        REQUIRE( app.m_maxEMGain == Approx( 321.0f ) );
+        REQUIRE( app.m_shmimName == "ocam_main_override" );
+        REQUIRE( app.m_syncShmimName == "ocam_sync_override" );
+    }
+
+    SECTION( "loadConfig clamps maxEMGain below the supported minimum" )
+    {
+        ocam2KCtrl_test app;
+
+        app.setupConfig();
+
+        mx::app::writeConfigFile( uniqueConfigPath( "gain_low" ), { "camera" }, { "maxEMGain" }, { "0" } );
+        app.config.readConfig( uniqueConfigPath( "gain_low" ) );
+
+        app.loadConfig();
+
+        REQUIRE( app.m_maxEMGain == Approx( 1.0f ) );
+    }
+
+    SECTION( "loadConfig clamps maxEMGain above the supported maximum" )
+    {
+        ocam2KCtrl_test app;
+
+        app.setupConfig();
+
+        mx::app::writeConfigFile( uniqueConfigPath( "gain_high" ), { "camera" }, { "maxEMGain" }, { "700" } );
+        app.config.readConfig( uniqueConfigPath( "gain_high" ) );
+
+        app.loadConfig();
+
+        REQUIRE( app.m_maxEMGain == Approx( 600.0f ) );
+    }
+}
+
+/// Verify temperature queries handle valid and malformed serial responses.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl getTemps handles valid and malformed serial responses", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::getTemps() );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "valid temperature response updates cached temperatures and status" )
+    {
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+
+        REQUIRE( app.getTemps() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp" );
+        REQUIRE( app.m_temps.CCD == Approx( 20.4f ) );
+        REQUIRE( app.m_temps.CPU == Approx( 41.0f ) );
+        REQUIRE( app.m_ccdTemp == Approx( 20.4f ) );
+        REQUIRE( app.m_ccdTempSetpt == Approx( 20.5f ) );
+        REQUIRE( app.m_tempControlStatus == true );
+        REQUIRE( app.m_tempControlStatusStr == "ON TARGET" );
+        REQUIRE( app.m_tempControlOnTarget == true );
+    }
+
+    SECTION( "malformed temperature response marks cached temperatures invalid without forcing reconfig" )
+    {
+        queueSerialResponse( "Temperatures : CCD[20.4]\n" );
+
+        app.m_temps.CCD            = 5;
+        app.m_ccdTemp              = 5;
+        app.m_ccdTempSetpt         = 6;
+        app.m_tempControlStatus    = true;
+        app.m_tempControlOnTarget  = false;
+        app.m_tempControlStatusStr = "ON TARGET";
+
+        REQUIRE( app.getTemps() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp" );
+        REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
+        REQUIRE( app.m_temps.SET == Approx( -999.0f ) );
+        REQUIRE( app.m_ccdTemp == Approx( -999.0f ) );
+        REQUIRE( app.m_ccdTempSetpt == Approx( -999.0f ) );
+        REQUIRE( app.m_tempControlStatus == false );
+        REQUIRE( app.m_tempControlStatusStr == "UNKNOWN" );
+        REQUIRE( app.m_tempControlOnTarget == false );
+    }
+}
+
+/// Verify FPS queries handle valid and malformed serial responses, plus synchro mode.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl getFPS handles valid and malformed serial responses", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::getFPS() );
+    #endif
+    // clang-format on
+
+    SECTION( "valid fps response updates the cached frame rate" )
+    {
+        setPoweredOn( app );
+        app.m_synchro = false;
+        app.m_fps     = 0;
+
+        queueSerialResponse( "fps [150.5] Hz\n" );
+
+        REQUIRE( app.getFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps" );
+        REQUIRE( app.m_fps == Approx( 150.5f ) );
+    }
+
+    SECTION( "malformed fps response is non-fatal and leaves the cached value unchanged" )
+    {
+        setPoweredOn( app );
+        app.m_synchro = false;
+        app.m_fps     = 75.0f;
+
+        queueSerialResponse( "fps 150.5\n" );
+
+        REQUIRE( app.getFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps" );
+        REQUIRE( app.m_fps == Approx( 75.0f ) );
+    }
+
+    SECTION( "synchro mode bypasses serial queries and mirrors the sync frequency" )
+    {
+        app.m_synchro  = true;
+        app.m_syncFreq = 205.25f;
+        app.m_fps      = 0;
+
+        REQUIRE( app.getFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+        REQUIRE( app.m_fps == Approx( 205.25f ) );
+    }
+}
+
+/// Verify the temperature-control helpers handle safe, unsafe, and valid setpoint requests.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl temperature control helpers handle valid and invalid requests", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setTempControl() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setTempSetPt() );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "setTempControl refuses to turn cooling off below the safe temperature" )
+    {
+        app.m_tempControlStatusSet = false;
+        app.m_tempControlStatus    = true;
+        app.m_ccdTemp              = 18.5f;
+
+        REQUIRE( app.setTempControl() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+        REQUIRE( app.m_tempControlStatus == true );
+    }
+
+    SECTION( "setTempControl turns cooling off when the detector is warm enough" )
+    {
+        app.m_tempControlStatusSet = false;
+        app.m_tempControlStatus    = true;
+        app.m_ccdTemp              = 20.0f;
+
+        queueSerialResponse( "temperature control off\n" );
+
+        REQUIRE( app.setTempControl() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp off" );
+        REQUIRE( app.m_tempControlStatusSet == false );
+        REQUIRE( app.m_tempControlStatus == false );
+    }
+
+    SECTION( "setTempControl turns cooling on and reapplies the configured setpoint" )
+    {
+        app.m_tempControlStatusSet = true;
+        app.m_tempControlStatus    = false;
+        app.m_ccdTempSetpt         = 15.5f;
+
+        queueSerialResponse( "temperature control on\n" );
+        queueSerialResponse( "setpoint updated\n" );
+
+        REQUIRE( app.setTempControl() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 2 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp on" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "temp 15.500000" );
+        REQUIRE( app.m_tempControlStatusSet == true );
+        REQUIRE( app.m_tempControlStatus == true );
+    }
+
+    SECTION( "setTempSetPt rejects out-of-range high setpoints without serial traffic" )
+    {
+        app.m_ccdTempSetpt = 30.0f;
+
+        REQUIRE( app.setTempSetPt() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "setTempSetPt rejects out-of-range low setpoints without serial traffic" )
+    {
+        app.m_ccdTempSetpt = -50.1f;
+
+        REQUIRE( app.setTempSetPt() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "setTempSetPt sends valid setpoints to the camera" )
+    {
+        app.m_ccdTempSetpt = 12.25f;
+
+        queueSerialResponse( "setpoint updated\n" );
+
+        REQUIRE( app.setTempSetPt() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "temp 12.250000" );
+    }
+}
+
+/// Verify the shutter adapter rejects invalid requests before touching the DSS threads.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl setShutter rejects invalid shutter requests", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setShutter( 0 ) );
+    #endif
+    // clang-format on
+
+    REQUIRE( app.setShutter( 2 ) == -1 );
+}
+
+/// Verify simple helper methods update local app state without hardware dependencies.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl helper interfaces reset local state and power-off lifecycle flags", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::powerOnDefaults() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setExpTime() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setNextROI() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::fps() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::onPowerOff() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::whilePowerOff() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appShutdown() );
+    #endif
+    // clang-format on
+
+    app.m_tempControlStatusSet = true;
+    app.m_tempControlStatus    = true;
+    REQUIRE( app.powerOnDefaults() == 0 );
+    REQUIRE( app.m_tempControlStatusSet == false );
+    REQUIRE( app.m_tempControlStatus == false );
+
+    app.m_fps = 250.5f;
+    REQUIRE( app.fps() == Approx( 250.5f ) );
+
+    REQUIRE( app.setExpTime() == 0 );
+    REQUIRE( app.setNextROI() == 0 );
+
+    REQUIRE( app.ensureSyncStream() == 0 );
+    REQUIRE( app.m_syncImageStream != nullptr );
+
+    app.m_powerOnCounter = -1;
+    app.m_poweredOn      = false;
+    app.m_width          = 17;
+    app.m_height         = 19;
+    app.m_circBuffLength = 23;
+    app.m_reconfig       = false;
+
+    REQUIRE( app.onPowerOff() == 0 );
+    REQUIRE( app.m_powerOnCounter == 0 );
+    REQUIRE( app.m_poweredOn == true );
+    REQUIRE( app.m_width == 0 );
+    REQUIRE( app.m_height == 0 );
+    REQUIRE( app.m_circBuffLength == 1 );
+    REQUIRE( app.m_reconfig == true );
+
+    REQUIRE( app.whilePowerOff() == 0 );
+
+    REQUIRE( app.appShutdown() == 0 );
+    REQUIRE( app.m_syncImageStream == nullptr );
+}
+
+/// Verify acquisition startup requests EDT buffering and resets the image counter.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl startAcquisition resets frame tracking and starts EDT buffers", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::startAcquisition() );
+    #endif
+    // clang-format on
+
+    app.m_numBuffs        = 6;
+    app.m_lastImageNumber = 99;
+
+    REQUIRE( app.startAcquisition() == 0 );
+    REQUIRE( app.m_lastImageNumber == -1 );
+    REQUIRE( g_edtStubState.startImagesCalls == 1 );
+    REQUIRE( g_edtStubState.lastStartNumBuffs == 6 );
+}
+
+/// Verify frame acquisition timestamps and frame-number handling across valid and invalid sequences.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl acquireAndCheckValid handles valid, skipped, and corrupt frame numbers", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::acquireAndCheckValid() );
+    #endif
+    // clang-format on
+
+    static_cast<MagAOXAppT &>( app ).m_powerState = 1;
+    app.m_powerTargetState                        = 1;
+    app.m_modeName                                = "science";
+
+    SECTION( "first valid frame initializes the previous-frame tracker" )
+    {
+        resetStubState();
+
+        g_edtStubState.waitTimeSec  = 12;
+        g_edtStubState.waitTimeNsec = 345;
+        setStubFrameNumber( 101 );
+
+        app.m_lastImageNumber = -1;
+
+        REQUIRE( app.acquireAndCheckValid() == 0 );
+        REQUIRE( app.m_currImageTimestamp.tv_sec == 12 );
+        REQUIRE( app.m_currImageTimestamp.tv_nsec == 345 );
+        REQUIRE( app.m_currImageNumber == 101 );
+        REQUIRE( app.m_lastImageNumber == 101 );
+        REQUIRE( g_edtStubState.startImageCalls == 1 );
+    }
+
+    SECTION( "small skipped-frame gaps request reconfiguration" )
+    {
+        resetStubState();
+
+        setStubFrameNumber( 15 );
+
+        app.m_lastImageNumber = 12;
+        app.m_nextMode        = "";
+        app.m_reconfig        = false;
+
+        REQUIRE( app.acquireAndCheckValid() == 1 );
+        REQUIRE( app.m_lastImageNumber == -1 );
+        REQUIRE( app.m_nextMode == "science" );
+        REQUIRE( app.m_reconfig == true );
+    }
+
+    SECTION( "large frame-number jumps on powered hardware are treated as corruption" )
+    {
+        resetStubState();
+
+        setStubFrameNumber( 500 );
+
+        app.m_lastImageNumber = 12;
+        app.m_nextMode        = "";
+        app.m_reconfig        = false;
+
+        REQUIRE( app.acquireAndCheckValid() == 1 );
+        REQUIRE( app.m_lastImageNumber == -1 );
+        REQUIRE( app.m_nextMode == "science" );
+        REQUIRE( app.m_reconfig == true );
+    }
+
+    SECTION( "large frame-number jumps during power loss return an error instead of reconfiguring" )
+    {
+        resetStubState();
+
+        setStubFrameNumber( 500 );
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+        app.m_lastImageNumber                         = 12;
+        app.m_nextMode                                = "";
+        app.m_reconfig                                = false;
+
+        REQUIRE( app.acquireAndCheckValid() == -1 );
+        REQUIRE( app.m_nextMode == "" );
+        REQUIRE( app.m_reconfig == false );
+    }
+}
+
+/// Verify the raw image pointer is passed through to the OCAM descramble routine.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl loadImageIntoStream uses the OCAM descramble output", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test        app;
+    std::array<int16_t, 4> rawImage{ 1, 2, 3, 4 };
+    std::array<int16_t, 4> destImage{ 0, 0, 0, 0 };
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::loadImageIntoStream( nullptr ) );
+    #endif
+    // clang-format on
+
+    app.m_ocam2_id   = 7;
+    app.m_digitalBin = false;
+    app.m_image_p    = reinterpret_cast<u_char *>( rawImage.data() );
+
+    g_ocam2StubState.imageNumber = 44;
+    g_ocam2StubState.outputImage = { 10, 20, 30, 40 };
+
+    REQUIRE( app.loadImageIntoStream( destImage.data() ) == 0 );
+    REQUIRE( g_ocam2StubState.lastId == 7 );
+    REQUIRE( g_ocam2StubState.lastRaw == rawImage.data() );
+    REQUIRE( g_ocam2StubState.lastOutput == destImage.data() );
+    REQUIRE( destImage[0] == 10 );
+    REQUIRE( destImage[1] == 20 );
+    REQUIRE( destImage[2] == 30 );
+    REQUIRE( destImage[3] == 40 );
+}
+
+/// Verify the serial gain helpers accept valid responses and handle malformed or tripped ones.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl serial gain helpers handle valid and invalid responses", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::getEMGain() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setEMGain() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::resetEMProtection() );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "valid EM gain response updates the cached value" )
+    {
+        app.m_emGain = 1;
+
+        queueSerialResponse( "Gain set to 42 \n\n" );
+
+        REQUIRE( app.getEMGain() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain" );
+        REQUIRE( app.m_emGain == 42 );
+    }
+
+    SECTION( "malformed EM gain response returns an error and keeps the previous value" )
+    {
+        app.m_emGain = 77;
+
+        queueSerialResponse( "Gain set to \n\n" );
+
+        REQUIRE( app.getEMGain() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain" );
+        REQUIRE( app.m_emGain == 77 );
+    }
+
+    SECTION( "HV trip response forces the cached EM gain back to the safe minimum" )
+    {
+        app.m_emGain = 77;
+
+        queueSerialResponse( "HV trip\n" );
+
+        REQUIRE( app.getEMGain() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain" );
+        REQUIRE( app.m_emGain == 1 );
+    }
+
+    SECTION( "resetEMProtection marks the protection state as reset" )
+    {
+        app.m_protectionReset          = false;
+        app.m_protectionResetConfirmed = 2;
+
+        queueSerialResponse( "Protection reset\n" );
+
+        REQUIRE( app.resetEMProtection() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "protection reset" );
+        REQUIRE( app.m_protectionReset == true );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+    }
+
+    SECTION( "setEMGain refuses unsafe requests before protection reset" )
+    {
+        app.m_protectionReset = false;
+        app.m_emGainSet       = 10;
+
+        REQUIRE( app.setEMGain() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "setEMGain refuses out-of-range requests without serial traffic" )
+    {
+        app.m_protectionReset = true;
+        app.m_maxEMGain       = 100;
+        app.m_emGainSet       = 200;
+
+        REQUIRE( app.setEMGain() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "setEMGain sends the requested gain after protection reset" )
+    {
+        app.m_protectionReset = true;
+        app.m_maxEMGain       = 600;
+        app.m_emGainSet       = 25;
+
+        queueSerialResponse( "Gain set to 25 \n\n" );
+
+        REQUIRE( app.setEMGain() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "gain 25" );
+    }
+}
+
+/// Verify the serial setter commands send the expected OCAM command sequence.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl serial setter commands send the expected sequence", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setFPS() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setSynchro() );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "setFPS sends the requested rate and queues a reconfiguration" )
+    {
+        app.m_synchro  = false;
+        app.m_fpsSet   = 250.5f;
+        app.m_modeName = "science";
+        app.m_nextMode = "";
+        app.m_reconfig = false;
+
+        queueSerialResponse( "fps updated\n" );
+
+        REQUIRE( app.setFPS() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 250.500000" );
+        REQUIRE( app.m_nextMode == "science" );
+        REQUIRE( app.m_reconfig == true );
+    }
+
+    SECTION( "setSynchro off uses the OCAM serial path for both synchro and FPS" )
+    {
+        app.m_synchroSet = false;
+        app.m_fpsSet     = 175.0f;
+
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.setSynchro() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 3 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "synchro off" );
+        REQUIRE( g_edtStubState.serialCommands[2] == "fps 175.000000" );
+        REQUIRE( app.m_synchro == false );
+    }
+}
+
+/// Verify acquisition configuration programs the OCAM mode and handles invalid frame shapes.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl configureAcquisition handles valid and invalid OCAM modes", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test   app;
+    dev::cameraConfig config;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::configureAcquisition() );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    app.m_configDir              = "/tmp";
+    app.m_ocamDescrambleFile     = "ocam_descramble_stub.txt";
+    app.m_modeName               = "science";
+    config.m_serialCommand       = "mode science";
+    config.m_binningX            = 1;
+    config.m_binningY            = 1;
+    config.m_digitalBinX         = 2;
+    config.m_digitalBinY         = 3;
+    app.m_cameraModes["science"] = config;
+
+    SECTION( "configureAcquisition sets up the SDK, digital binning, and sync stream" )
+    {
+        app.m_raw_height = 121;
+        app.m_fpsSet     = 50.0f;
+        app.m_synchroSet = false;
+        app.m_ocam2_id   = 9;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 5 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "mode science" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "fps 50.000000" );
+        REQUIRE( g_edtStubState.serialCommands[2] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[3] == "synchro off" );
+        REQUIRE( g_edtStubState.serialCommands[4] == "fps 50.000000" );
+        REQUIRE( g_ocam2StubState.exitCalls == 1 );
+        REQUIRE( g_ocam2StubState.lastExitId == 9 );
+        REQUIRE( g_ocam2StubState.lastInitMode == OCAM2_NORMAL );
+        REQUIRE( g_ocam2StubState.lastDescrambleFile == "/tmp/ocam_descramble_stub.txt" );
+        REQUIRE( app.m_ocam2_id == 1 );
+        REQUIRE( app.m_currentROI.x == Approx( 119.5 ) );
+        REQUIRE( app.m_currentROI.y == Approx( 119.5 ) );
+        REQUIRE( app.m_currentROI.w == Approx( 240.0 ) );
+        REQUIRE( app.m_currentROI.h == Approx( 240.0 ) );
+        REQUIRE( app.m_currentROI.bin_x == 1 );
+        REQUIRE( app.m_currentROI.bin_y == 1 );
+        REQUIRE( app.m_digitalBin == true );
+        REQUIRE( app.m_width == 120 );
+        REQUIRE( app.m_height == 80 );
+        REQUIRE( app.m_dataType == _DATATYPE_UINT16 );
+        REQUIRE( app.m_syncImageStream != nullptr );
+        REQUIRE( app.state() == stateCodes::OPERATING );
+    }
+
+    SECTION( "configureAcquisition rejects unsupported raw frame heights" )
+    {
+        app.m_raw_height = 100;
+        app.m_fpsSet     = 0.0f;
+        app.m_synchroSet = false;
+
+        queueSerialResponse( "mode set\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+
+        REQUIRE( app.configureAcquisition() == -1 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 4 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "mode science" );
+        REQUIRE( g_edtStubState.serialCommands[1] == "fps 0" );
+        REQUIRE( g_edtStubState.serialCommands[2] == "synchro off" );
+        REQUIRE( g_edtStubState.serialCommands[3] == "fps 0.000000" );
+        REQUIRE( g_ocam2StubState.exitCalls == 0 );
+        REQUIRE( g_ocam2StubState.lastDescrambleFile.empty() );
+        REQUIRE( app.m_syncImageStream == nullptr );
+    }
+}
+
+/// Verify the INDI callbacks update confirmation state and sync-frequency-driven reconfiguration.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl INDI callbacks update local state", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::newCallBack_m_indiP_emProtReset( pcf::IndiProperty() ) );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::setCallBack_m_indiP_syncFreq( pcf::IndiProperty() ) );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "EM protection reset callback requires a confirmation before issuing the serial reset" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Switch );
+
+        app.m_indiP_emProtReset.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProtReset.setName( "emProtReset" );
+
+        ipRecv.setDevice( "ocam2KCtrl" );
+        ipRecv.setName( "emProtReset" );
+        ipRecv.add( pcf::IndiElement( "request", pcf::IndiElement::On ) );
+
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( ipRecv ) == 0 );
+        REQUIRE( app.m_protectionResetConfirmed == 1 );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+
+        queueSerialResponse( "Protection reset\n" );
+
+        REQUIRE( app.newCallBack_m_indiP_emProtReset( ipRecv ) == 0 );
+        REQUIRE( g_edtStubState.serialCommands.size() == 1 );
+        REQUIRE( g_edtStubState.serialCommands[0] == "protection reset" );
+        REQUIRE( app.m_protectionReset == true );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+    }
+
+    SECTION( "sync frequency callback queues a reconfiguration when synchro mode changes the effective FPS" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Number );
+
+        app.m_indiP_syncFreq.setDevice( "syncDevice" );
+        app.m_indiP_syncFreq.setName( "C1freq" );
+
+        ipRecv.setDevice( "syncDevice" );
+        ipRecv.setName( "C1freq" );
+        ipRecv.add( pcf::IndiElement( "current" ) );
+        ipRecv["current"] = 123.4;
+
+        app.m_synchro  = true;
+        app.m_fps      = 100.0f;
+        app.m_modeName = "science";
+        app.m_nextMode = "";
+        app.m_reconfig = false;
+
+        REQUIRE( app.setCallBack_m_indiP_syncFreq( ipRecv ) == 0 );
+        REQUIRE( app.m_syncFreq == Approx( 123.4f ) );
+        REQUIRE( app.m_fps == Approx( 123.4f ) );
+        REQUIRE( app.m_nextMode == "science" );
+        REQUIRE( app.m_reconfig == true );
+    }
+}
+
+/// Verify the generated static INDI wrappers forward into the instance callbacks.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl static INDI callback wrappers forward requests to the instance", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::st_newCallBack_m_indiP_emProtReset( nullptr, pcf::IndiProperty() ) );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::st_setCallBack_m_indiP_syncFreq( nullptr, pcf::IndiProperty() ) );
+    #endif
+    // clang-format on
+
+    setPoweredOn( app );
+
+    SECTION( "the new-property wrapper forwards EM protection reset requests" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Switch );
+
+        app.m_indiP_emProtReset.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProtReset.setName( "emProtReset" );
+
+        ipRecv.setDevice( "ocam2KCtrl" );
+        ipRecv.setName( "emProtReset" );
+        ipRecv.add( pcf::IndiElement( "request", pcf::IndiElement::On ) );
+
+        REQUIRE( ocam2KCtrl::st_newCallBack_m_indiP_emProtReset( &app, ipRecv ) == 0 );
+        REQUIRE( app.m_protectionResetConfirmed == 1 );
+    }
+
+    SECTION( "the set-property wrapper forwards sync frequency updates" )
+    {
+        pcf::IndiProperty ipRecv( pcf::IndiProperty::Number );
+
+        app.m_indiP_syncFreq.setDevice( "syncDevice" );
+        app.m_indiP_syncFreq.setName( "C1freq" );
+
+        ipRecv.setDevice( "syncDevice" );
+        ipRecv.setName( "C1freq" );
+        ipRecv.add( pcf::IndiElement( "current" ) );
+        ipRecv["current"] = 222.5;
+
+        app.m_synchro  = true;
+        app.m_fps      = 100.0f;
+        app.m_modeName = "science";
+
+        REQUIRE( ocam2KCtrl::st_setCallBack_m_indiP_syncFreq( &app, ipRecv ) == 0 );
+        REQUIRE( app.m_syncFreq == Approx( 222.5f ) );
+        REQUIRE( app.m_fps == Approx( 222.5f ) );
+        REQUIRE( app.m_nextMode == "science" );
+        REQUIRE( app.m_reconfig == true );
+    }
+}
+
+/// Verify telemetry wrapper helpers emit their records and interval checks trigger stale telemetry.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl telemetry wrappers record snapshots and stale intervals", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test app;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::checkRecordTimes() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::recordTelem( static_cast<const MagAOX::logger::ocam_temps *>( nullptr ) ) );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::recordTelem( static_cast<const MagAOX::logger::telem_stdcam *>( nullptr ) ) );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::recordTelem( static_cast<const MagAOX::logger::telem_fgtimings *>( nullptr ) ) );
+    #endif
+    // clang-format on
+
+    app.m_temps.CCD            = 20.1f;
+    app.m_temps.CPU            = 41.0f;
+    app.m_temps.POWER          = 34.0f;
+    app.m_temps.BIAS           = 47.0f;
+    app.m_temps.WATER          = 24.2f;
+    app.m_temps.LEFT           = 33.0f;
+    app.m_temps.RIGHT          = 38.0f;
+    app.m_temps.COOLING_POWER  = 102.0f;
+    app.m_modeName             = "science";
+    app.m_currentROI.x         = 119.5;
+    app.m_currentROI.y         = 119.5;
+    app.m_currentROI.w         = 240.0;
+    app.m_currentROI.h         = 240.0;
+    app.m_currentROI.bin_x     = 1;
+    app.m_currentROI.bin_y     = 1;
+    app.m_fps                  = 150.0f;
+    app.m_emGain               = 25.0f;
+    app.m_ccdTemp              = 20.1f;
+    app.m_ccdTempSetpt         = 20.5f;
+    app.m_tempControlStatus    = true;
+    app.m_tempControlOnTarget  = true;
+    app.m_tempControlStatusStr = "ON TARGET";
+    app.m_shutterStatus        = "open";
+    app.m_shutterState         = 1;
+    app.m_synchro              = false;
+    app.m_mna                  = 1.0;
+    app.m_vara                 = 0.01;
+    app.m_mnw                  = 2.0;
+    app.m_varw                 = 0.04;
+    app.m_mnwa                 = 3.0;
+    app.m_varwa                = 0.09;
+
+    SECTION( "recordTelem overloads forward directly to the per-type telemetry recorders" )
+    {
+        MagAOX::logger::ocam_temps::lastRecord      = { 0, 0 };
+        MagAOX::logger::telem_stdcam::lastRecord    = { 0, 0 };
+        MagAOX::logger::telem_fgtimings::lastRecord = { 0, 0 };
+
+        REQUIRE( app.recordTelem( static_cast<const MagAOX::logger::ocam_temps *>( nullptr ) ) == 0 );
+        REQUIRE( hasRecordedTime( MagAOX::logger::ocam_temps::lastRecord ) );
+
+        REQUIRE( app.recordTelem( static_cast<const MagAOX::logger::telem_stdcam *>( nullptr ) ) == 0 );
+        REQUIRE( hasRecordedTime( MagAOX::logger::telem_stdcam::lastRecord ) );
+
+        REQUIRE( app.recordTelem( static_cast<const MagAOX::logger::telem_fgtimings *>( nullptr ) ) == 0 );
+        REQUIRE( hasRecordedTime( MagAOX::logger::telem_fgtimings::lastRecord ) );
+    }
+
+    SECTION( "checkRecordTimes emits all telemetry records when their intervals have elapsed" )
+    {
+        MagAOX::logger::ocam_temps::lastRecord      = { 0, 0 };
+        MagAOX::logger::telem_stdcam::lastRecord    = { 0, 0 };
+        MagAOX::logger::telem_fgtimings::lastRecord = { 0, 0 };
+
+        app.m_maxInterval                            = 10.0;
+        static_cast<MagAOXAppT &>( app ).m_loopPause = 0;
+
+        REQUIRE( app.checkRecordTimes() == 0 );
+        REQUIRE( hasRecordedTime( MagAOX::logger::ocam_temps::lastRecord ) );
+        REQUIRE( hasRecordedTime( MagAOX::logger::telem_stdcam::lastRecord ) );
+        REQUIRE( hasRecordedTime( MagAOX::logger::telem_fgtimings::lastRecord ) );
+    }
+}
+
+/// Verify lifecycle entrypoints cover startup failure handling and the POWERON fast-return path.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl lifecycle entrypoints handle startup failures and POWERON logic", "[ocam2KCtrl]" )
+{
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appStartup() );
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appLogic() );
+    #endif
+    // clang-format on
+
+    SECTION( "appStartup reports failure when the startup mode cannot be configured" )
+    {
+        ocam2KCtrl_test app;
+
+        app.m_startupMode = "";
+
+        REQUIRE( app.appStartup() < 0 );
+    }
+
+    SECTION( "appLogic returns immediately while the app is still in POWERON" )
+    {
+        ocam2KCtrl_test app;
+
+        app.state( stateCodes::POWERON );
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+    }
+}
+
+/// Verify appLogic covers connection transitions, error handling, and READY-state housekeeping.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl appLogic handles connection and housekeeping flow", "[ocam2KCtrl]" )
+{
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::appLogic() );
+    #endif
+    // clang-format on
+
+    SECTION( "NOTCONNECTED returns early during power loss" )
+    {
+        ocam2KCtrl_test app;
+
+        app.state( stateCodes::NOTCONNECTED );
+        app.m_temps.CCD = 12.0f;
+
+        static_cast<MagAOXAppT &>( app ).m_powerState = 0;
+        app.m_powerTargetState                        = 0;
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::NOTCONNECTED );
+        REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
+        REQUIRE( g_edtStubState.serialCommands.empty() );
+    }
+
+    SECTION( "NOTCONNECTED success falls through the READY housekeeping path in the same loop" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+
+        app.state( stateCodes::NOTCONNECTED );
+        app.m_fpsSet              = 0.0f;
+        app.m_poweredOn           = true;
+        app.m_ccdTempSetpt        = 18.5f;
+        app.m_tempControlOnTarget = false;
+        app.m_indiP_emProt        = pcf::IndiProperty( pcf::IndiProperty::Text );
+        app.m_indiP_emProt.setDevice( "ocam2KCtrl" );
+        app.m_indiP_emProt.setName( "emProtReset" );
+        app.m_indiP_emProt.add( pcf::IndiElement( "status" ) );
+        app.m_indiP_emProt["status"].set( "CONFIRMED" );
+        app.m_protectionResetConfirmed = 1;
+        app.m_protectionResetReqTime   = mx::sys::get_curr_time() - 11.0;
+
+        queueSerialResponse( "camera online\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "setpoint updated\n" );
+        queueSerialResponse( "fps max\n" );
+        queueSerialResponse( "synchro off\n" );
+        queueSerialResponse( "fps restored\n" );
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[185]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "Gain set to 42 \n\n" );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::FAILURE );
+        REQUIRE( app.m_fps == Approx( 150.5f ) );
+        REQUIRE( app.m_poweredOn == false );
+        REQUIRE( app.m_synchroSet == false );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+        REQUIRE( app.m_shutdown == 1 );
+        REQUIRE( g_edtStubState.serialCommands ==
+                 std::vector<std::string>{
+                     "fps", "fps", "temp 18.500000", "fps 0", "synchro off", "fps 0.000000", "temp", "fps", "gain" } );
+    }
+
+    SECTION( "CONNECTED enters ERROR when getFPS fails on powered hardware" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::CONNECTED );
+
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::ERROR );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "fps" } );
+    }
+
+    SECTION( "READY expires stale protection resets and completes housekeeping before telemetry shutdown" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+
+        app.state( stateCodes::READY );
+        app.m_protectionResetConfirmed = 1;
+        app.m_protectionResetReqTime   = mx::sys::get_curr_time() - 11.0;
+        app.m_indiP_emProt             = pcf::IndiProperty( pcf::IndiProperty::Text );
+        app.m_indiP_emProt.add( pcf::IndiElement( "status" ) );
+        app.m_indiP_emProt["status"].set( "CONFIRM" );
+
+        queueSerialResponse( "Temperatures : CCD[20.4] CPU[41] POWER[34] BIAS[47] WATER[24.2] LEFT[33] RIGHT[38] "
+                             "SET[205]\nCooling Power [102]mW.\n\n" );
+        queueSerialResponse( "fps [150.5] Hz\n" );
+        queueSerialResponse( "Gain set to 42 \n\n" );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.m_protectionResetConfirmed == 0 );
+        REQUIRE( app.m_shutdown == 1 );
+        REQUIRE( app.state() == stateCodes::FAILURE );
+        REQUIRE( app.m_temps.CCD == Approx( 20.4f ) );
+        REQUIRE( app.m_fps == Approx( 150.5f ) );
+        REQUIRE( app.m_emGain == 42 );
+    }
+
+    SECTION( "READY moves to ERROR when temperature polling fails on powered hardware" )
+    {
+        ocam2KCtrl_test app;
+
+        setPoweredOn( app );
+        app.state( stateCodes::READY );
+
+        queueSerialResponse( "", -1 );
+
+        fgThreadScope fgThread( app );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::ERROR );
+        REQUIRE( app.m_temps.CCD == Approx( -999.0f ) );
+        REQUIRE( g_edtStubState.serialCommands == std::vector<std::string>{ "temp" } );
+    }
+}
+
+/// Verify reconfiguration reloads the requested mode and leaves the app in READY.
+/**
+ * \ingroup ocam2KCtrl_unit_test
+ */
+TEST_CASE( "ocam2KCtrl reconfig reloads the next mode through edtCamera", "[ocam2KCtrl]" )
+{
+    ocam2KCtrl_test   app;
+    dev::cameraConfig config;
+
+    resetStubState();
+
+    // clang-format off
+    #ifdef OCAM2KCTRL_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( ocam2KCtrl::reconfig() );
+    #endif
+    // clang-format on
+
+    config.m_configFile          = "stub.cfg";
+    app.m_cameraModes["science"] = config;
+    app.m_nextMode               = "science";
+    app.state( stateCodes::OPERATING );
+
+    REQUIRE( app.reconfig() == 0 );
+    REQUIRE( app.state() == stateCodes::READY );
+    REQUIRE( app.m_nextMode == "" );
+    REQUIRE( app.m_modeName == "science" );
+    REQUIRE( app.m_raw_width == 240 );
+    REQUIRE( app.m_raw_height == 121 );
+    REQUIRE( app.m_raw_depth == 16 );
+    REQUIRE( app.m_cameraType == "stub_pdv" );
+}
+
+} // namespace ocam2KCtrlTest
+} // namespace libXWCTest

--- a/libMagAOX/app/dev/frameGrabber.hpp
+++ b/libMagAOX/app/dev/frameGrabber.hpp
@@ -75,6 +75,12 @@ namespace dev
  *   For `acquireAndCheckValid` >0 will indicate no data but not an error.  In most cases,
  *   an appropriate state code, such as NOTCONNECTED, should be set as well.
  *
+ * - A derived class may optionally expose
+ *   \code
+ *       int derivedT::frameGrabberPostPublish( IMAGE *imageStream );
+ *   \endcode
+ *   to perform additional publication work immediately after the main image stream semaphores are posted.
+ *
  * - A static configuration variable must be defined in derivedT as
  *   \code
  *       static constexpr bool c_frameGrabber_flippable =true; //or: false
@@ -306,11 +312,44 @@ class frameGrabber
     /// @}
 
   private:
+    /// Call an optional derived-class hook after the main stream publication completes.
+    template <class hookT>
+    static auto postPublishHook( hookT &hookOwner,      /**< [in] derived object that may expose the hook */
+                                 IMAGE *imageStream,    /**< [in] published image stream */
+                                 int    callPriorityTag /**< [in] overload selector preferring the hook */
+                                 ) -> decltype( hookOwner.frameGrabberPostPublish( imageStream ) );
+
+    /// Return success when the derived class does not expose a post-publication hook.
+    static int postPublishHook( derivedT &hookOwner,      /**< [in] derived object lacking the optional hook */
+                                IMAGE    *imageStream,    /**< [in] published image stream */
+                                long      callPriorityTag /**< [in] fallback overload selector */
+    );
+
     derivedT &derived()
     {
         return *static_cast<derivedT *>( this );
     }
 };
+
+template <class derivedT>
+template <class hookT>
+auto frameGrabber<derivedT>::postPublishHook( hookT &hookOwner, IMAGE *imageStream, int callPriorityTag )
+    -> decltype( hookOwner.frameGrabberPostPublish( imageStream ) )
+{
+    static_cast<void>( callPriorityTag );
+
+    return hookOwner.frameGrabberPostPublish( imageStream );
+}
+
+template <class derivedT>
+int frameGrabber<derivedT>::postPublishHook( derivedT &hookOwner, IMAGE *imageStream, long callPriorityTag )
+{
+    static_cast<void>( hookOwner );
+    static_cast<void>( imageStream );
+    static_cast<void>( callPriorityTag );
+
+    return 0;
+}
 
 template <class derivedT>
 int frameGrabber<derivedT>::setupConfig( mx::app::appConfigurator &config )
@@ -707,8 +746,8 @@ int frameGrabber<derivedT>::onPowerOff()
     m_mnwa  = 0;
     m_varwa = 0;
 
-    m_width  = 0;
-    m_height = 0;
+    m_width          = 0;
+    m_height         = 0;
     m_circBuffLength = 1;
 
     updateINDI();
@@ -974,6 +1013,11 @@ void frameGrabber<derivedT>::fgThreadExec()
             m_imageStream->md->write = 0;
             ImageStreamIO_sempost( m_imageStream, -1 );
 
+            if( postPublishHook( derived(), m_imageStream, 0 ) < 0 )
+            {
+                break;
+            }
+
             // Update the latency circ. buffs
             if( m_atimes.maxEntries() > 0 )
             {
@@ -1123,9 +1167,9 @@ int frameGrabber<derivedT>::openShmim()
 
             if( rv != 0 )
             {
-                derivedT::template log<software_critical>( { errno,
-                                                             "Could not get inode for " + m_shmimName +
-                                                                 ". Source process will need to be restarted." } );
+                derivedT::template log<software_critical>(
+                    { errno,
+                      "Could not get inode for " + m_shmimName + ". Source process will need to be restarted." } );
 
                 ImageStreamIO_closeIm( m_imageStream );
 
@@ -1142,20 +1186,20 @@ int frameGrabber<derivedT>::openShmim()
 
             m_width = m_imageStream->md->size[0];
 
-            if( m_imageStream->md->naxis == 2  )
+            if( m_imageStream->md->naxis == 2 )
             {
-                m_height = m_imageStream->md->size[1];
-                m_circBuffLength  = 1;
+                m_height         = m_imageStream->md->size[1];
+                m_circBuffLength = 1;
             }
             else if( m_imageStream->md->naxis == 3 )
             {
-                m_height = m_imageStream->md->size[1];
-                m_circBuffLength  = m_imageStream->md->size[2];
+                m_height         = m_imageStream->md->size[1];
+                m_circBuffLength = m_imageStream->md->size[2];
             }
             else
             {
-                m_height = 1;
-                m_circBuffLength  = 1;
+                m_height         = 1;
+                m_circBuffLength = 1;
             }
 
             m_dataType = m_imageStream->md->datatype;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -41,11 +41,13 @@ realclean: clean
 	@rm -f test_stderr.txt
 
 .PHONY: coverage
-coverage:
+coverage: coverage_clean
 	${MAKE} all COVERAGE=1
 
 coverage_clean:
 	find .. -path '*/tests/*.gcno' -delete
 	find .. -path '*/tests/*.gcda' -delete
 	find .. -path '*/tests/*.gcov' -delete
-	${MAKE} clean COVERAGE=1
+	@rm -f testMain.gcno
+	@rm -f testMain.gcda
+	${MAKE} realclean COVERAGE=1

--- a/tests/Makefile.one
+++ b/tests/Makefile.one
@@ -64,6 +64,11 @@ else ifeq ($(notdir $(TESTNAME)),stdMotionNode_test)
     LDLIBS += -linstGraph
 else ifeq ($(notdir $(TESTNAME)),xigNode_test)
     LDLIBS += -linstGraph
+else ifeq ($(notdir $(TESTNAME)),ocam2KCtrl_test)
+	CPPFLAGS += -I$(PATHNAME)
+	CXXFLAGS := $(filter-out -DMAGAOX_NOEDT,$(CXXFLAGS))
+	CFLAGS := $(filter-out -DMAGAOX_NOEDT,$(CFLAGS))
+	CPPFLAGS := $(filter-out -DMAGAOX_NOEDT,$(CPPFLAGS))
 endif
 
 LDLIBS+=$(TESTLIBS)

--- a/tests/Makefile.one
+++ b/tests/Makefile.one
@@ -64,7 +64,7 @@ else ifeq ($(notdir $(TESTNAME)),stdMotionNode_test)
     LDLIBS += -linstGraph
 else ifeq ($(notdir $(TESTNAME)),xigNode_test)
     LDLIBS += -linstGraph
-else ifeq ($(notdir $(TESTNAME)),ocam2KCtrl_test)
+else ifneq ($(filter $(notdir $(TESTNAME)),ocam2KCtrl_test ocam2KCtrl_lifecycle_test),)
 	CPPFLAGS += -I$(PATHNAME)
 	CXXFLAGS := $(filter-out -DMAGAOX_NOEDT,$(CXXFLAGS))
 	CFLAGS := $(filter-out -DMAGAOX_NOEDT,$(CFLAGS))

--- a/tests/coverage/make_coverage_fast
+++ b/tests/coverage/make_coverage_fast
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eo pipefail
+
+#######################################################
+# update the coverage report from existing gcov data
+#
+# run in the top level MagAO-X source directory after
+# building/running one or more tests with COVERAGE=1
+#######################################################
+
+tests/coverage/update_coverage --fast

--- a/tests/coverage/update_coverage
+++ b/tests/coverage/update_coverage
@@ -5,22 +5,72 @@ set -eo pipefail
 # update the coverage report
 #
 # run in the top level MagAO-X source directory
+#
+# modes:
+#   default   zero counters, run the full test suite, then capture coverage
+#   --fast    capture coverage from the currently existing gcov counters only
 #######################################################
 
-cd tests
+usage()
+{
+    cat <<'EOF'
+Usage: tests/coverage/update_coverage [--fast]
 
-lcov --directory . --zerocounters
+  default   zero counters, run the full test suite, then refresh the HTML report
+  --fast    skip zeroing/rerunning tests and build the HTML report from existing .gcda files
 
-chmod +x testMagAOX.bash
+Typical fast-path workflow:
+  1. build one test with COVERAGE=1
+  2. run that test
+  3. run tests/coverage/update_coverage --fast
+EOF
+}
 
-bash -l testMagAOX.bash
+mode="full"
 
-cd ..
+case "${1:-}" in
+    "")
+        ;;
+    --fast)
+        mode="fast"
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "Unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+if [[ "$mode" == "full" ]]; then
+    cd tests
+
+    lcov --directory . --zerocounters
+
+    chmod +x testMagAOX.bash
+
+    bash -l testMagAOX.bash
+
+    cd ..
+else
+    gcda_count=$(find . -name '*.gcda' | wc -l)
+
+    if [[ "$gcda_count" -eq 0 ]]; then
+        echo "No .gcda files found. Build and run one or more tests with COVERAGE=1 first." >&2
+        exit 1
+    fi
+fi
 
 lcov --directory . --capture --output-file coverage.info
 
 lcov --remove coverage.info "*/tests/*" "/usr/*" "/sys/*" "/tty/*" \
-         --ignore-errors unused,unused --ignore-errors inconsistent,inconsistent --output-file coverage_filtered.info
+         --ignore-errors unused,unused \
+         --ignore-errors inconsistent,inconsistent \
+         --ignore-errors path \
+         --output-file coverage_filtered.info
 
 genhtml coverage_filtered.info --output-directory coverage_report \
                                --title "MagAOX" \
@@ -30,4 +80,3 @@ genhtml coverage_filtered.info --output-directory coverage_report \
                                --filter function \
                                --demangle-cpp \
                                --css-file tests/coverage/gcov.css
-

--- a/tests/coverage/update_coverage
+++ b/tests/coverage/update_coverage
@@ -27,6 +27,7 @@ EOF
 }
 
 mode="full"
+repo_root=$(pwd)
 
 case "${1:-}" in
     "")
@@ -78,5 +79,6 @@ genhtml coverage_filtered.info --output-directory coverage_report \
                                --merge-aliases \
                                --suppress-aliases \
                                --filter function \
+                               --prefix "$repo_root" \
                                --demangle-cpp \
                                --css-file tests/coverage/gcov.css

--- a/tests/tests.list
+++ b/tests/tests.list
@@ -46,6 +46,7 @@
 ../apps/observerCtrl/tests/observerCtrl_test
 ../apps/ocam2KCtrl/tests/ocamUtils_test
 ../apps/ocam2KCtrl/tests/ocam2KCtrl_test
+../apps/ocam2KCtrl/tests/ocam2KCtrl_lifecycle_test
 ../apps/pi335Ctrl/tests/pi335Ctrl_test
 ../apps/picoMotorCtrl/tests/picoMotorCtrl_test
 ../apps/psfAcq/tests/psfAcq_test

--- a/tests/tests.list
+++ b/tests/tests.list
@@ -45,6 +45,7 @@
 ../apps/mzmqServer/tests/mzmqServer_test
 ../apps/observerCtrl/tests/observerCtrl_test
 ../apps/ocam2KCtrl/tests/ocamUtils_test
+../apps/ocam2KCtrl/tests/ocam2KCtrl_test
 ../apps/pi335Ctrl/tests/pi335Ctrl_test
 ../apps/picoMotorCtrl/tests/picoMotorCtrl_test
 ../apps/psfAcq/tests/psfAcq_test

--- a/utils/tests/cursesINDI_test.cpp
+++ b/utils/tests/cursesINDI_test.cpp
@@ -5,6 +5,7 @@
   */
 #include "../../tests/catch2/catch.hpp"
 
+#include <filesystem>
 #include "../cursesINDI/cursesINDI.hpp"
 #include "../cursesINDI/cursesTableGrid.hpp"
 


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to ocam2K-sync-stream-tests.md.

## Summary

Implements a sync-only `ImageStreamIO` sidecar stream for `ocam2KCtrl`, adds broad hardware-free application unit coverage for the app, and stabilizes the coverage workflow so the `ocam2KCtrl` coverage report can be regenerated without rerunning the entire suite each time.

Planning doc: [`agents/plans/2026-04/ocam2K-sync-stream-tests.md`](agents/plans/2026-04/ocam2K-sync-stream-tests.md)

## What Changed

- add a secondary `1x1x1` `uint8` sync stream in `ocam2KCtrl`, intended as a minimal semaphore/meta-data sidecar stream for cross-host synchronization
- add `framegrabber.syncShmimName` support in `ocam2KCtrl`, defaulting to `<framegrabber.shmimName>_sync`
- extend `dev::frameGrabber` with an optional post-publication hook so derived apps can publish sidecar stream metadata and semaphores immediately after the main stream semaphore post
- keep the sync-stream lifecycle local to `ocam2KCtrl`, including create, validate/repair, publish, and destroy handling
- add `ocam2KCtrl` application unit tests with local EDT/OCAM stubs, covering sync-stream behavior, serial command success and bad-parse paths, helper/configuration logic, and app state-flow paths
- split the lifecycle/thread-exit coverage into a separate `ocam2KCtrl_lifecycle_test` binary so coverage can be aggregated from clean processes without the `MagAOXApp` singleton/thread teardown issue
- register the new `ocam2KCtrl` test binaries in the test harness and update the one-off test build rules so they compile the real `dev::edtCamera` path against local stubs
- add a fast coverage-refresh path via `tests/coverage/update_coverage --fast` and `tests/coverage/make_coverage_fast`
- add coverage-clean plumbing to avoid stale `gcda/gcno` mismatches during coverage capture
- clarify in `AGENTS.md` that end-application tests belong under `application_unit_test`, reserving `app_unit_test` for tests of the `libMagAOX` app namespace
- include small supporting test/build cleanups needed by the new coverage path

## Verification

- `make -C tests -B -f Makefile.one t=../apps/ocam2KCtrl/tests/ocamUtils_test.cpp COVERAGE=1`
- `../apps/ocam2KCtrl/tests/ocamUtils_test`
- `make -C tests -B -f Makefile.one t=../apps/ocam2KCtrl/tests/ocam2KCtrl_test.cpp COVERAGE=1`
- `../apps/ocam2KCtrl/tests/ocam2KCtrl_test`
- `make -C tests -B -f Makefile.one t=../apps/ocam2KCtrl/tests/ocam2KCtrl_lifecycle_test.cpp COVERAGE=1`
- `../apps/ocam2KCtrl/tests/ocam2KCtrl_lifecycle_test`
- `tests/coverage/update_coverage --fast`

## On-Sky Tests

- This was used on-sky on 20260410 to operate MagAO-X and synchronize the top-end accelerometers.

## Coverage

With the `ocam2KCtrl` test binaries rebuilt and run, the canonical report at `coverage_report/apps/ocam2KCtrl/ocam2KCtrl.hpp.gcov.html` shows:

- line coverage: `95.2%` (`658/691`)
- function coverage: `100.0%` (`42/42`)

## Notes

- the sync stream is intentionally minimal and well-formed rather than zero-sized, to avoid downstream application issues
- the sync-stream hot path relies on existing `frameGrabber` sequencing rather than adding a mutex around per-frame publication
- the sync-stream tests require shared-memory write access because `ImageStreamIO` creates shmim files
