### PR TITLE
stabilize zaberLowLevel and zaberLowLevelBinary connection handling

### DIFF
--- a/apps/zaberLowLevel/tests/zaberLowLevel_test.cpp
+++ b/apps/zaberLowLevel/tests/zaberLowLevel_test.cpp
@@ -92,6 +92,60 @@ class zaberLowLevel_test : public zaberLowLevel
         return ( m_indiDriver && m_indiDriver->good() ) ? 0 : -1;
     }
 
+    /// Configure a stage entry for discovery tests.
+    int addConfiguredStage( const std::string &stageName, const std::string &serial, int deviceAddress = -1 )
+    {
+        m_stages.emplace_back( this );
+        m_stages.back().name( stageName );
+        m_stages.back().serial( serial );
+        m_stages.back().deviceAddress( deviceAddress );
+
+        const size_t idx = m_stages.size() - 1;
+
+        m_stageName.insert( { stageName, idx } );
+        m_stageSerial.insert( { serial, idx } );
+
+        return 0;
+    }
+
+    /// Load the parsed system-serial snapshot through the production discovery code.
+    int loadParsedStages( std::string serialResponse )
+    {
+        return loadStages( serialResponse );
+    }
+
+    /// Set the cached device address for a configured stage.
+    int setDeviceAddressFor( size_t stageIndex, int deviceAddress )
+    {
+        m_stages.at( stageIndex ).deviceAddress( deviceAddress );
+        return 0;
+    }
+
+    /// Get the cached device address for a configured stage.
+    int deviceAddressFor( size_t stageIndex ) const
+    {
+        return m_stages.at( stageIndex ).deviceAddress();
+    }
+
+    /// Drive the recoverable error handler under test.
+    int recoverTransportError( bool devicePresent )
+    {
+        return recoverFromError( devicePresent );
+    }
+
+    /// Set the FSM state for recovery tests.
+    int setAppState( stateCodes::stateCodeT newState )
+    {
+        state( newState );
+        return 0;
+    }
+
+    /// Get the FSM state for recovery tests.
+    stateCodes::stateCodeT appState() const
+    {
+        return state();
+    }
+
     /// Read the value of a text or number element from a test property.
     std::string propertyValue( const pcf::IndiProperty &property, const std::string &element ) const
     {
@@ -198,6 +252,93 @@ SCENARIO( "Power-off INDI snapshot retains stage state", "[zaberLowLevel]" )
     REQUIRE( zllt.maxPosValue( "stageA" ) == "54321" );
     REQUIRE( zllt.currStateValue( "stageA" ) == "POWEROFF" );
     REQUIRE( zllt.warnValue( "stageA" ) == "Off" );
+}
+
+/// Verify discovery clears stale addresses and reports missing configured stages safely.
+/**
+ * \ingroup zaberLowLevel_unit_test
+ */
+SCENARIO( "Stage discovery resets stale device addresses", "[zaberLowLevel]" )
+{
+    // clang-format off
+    #ifdef ZABERLOWLEVEL_TEST_DOXYGEN_REF
+    zaberLowLevel::loadStages( std::declval<std::string &>() );
+    #endif
+    // clang-format on
+
+    zaberLowLevel_test zllt( "zlltest" );
+
+    REQUIRE( zllt.addConfiguredStage( "stagebs", "49820", 1 ) == 0 );
+    REQUIRE( zllt.addConfiguredStage( "stageirf", "49821", 2 ) == 0 );
+
+    std::string serialResponse = "@01 0 OK IDLE WR 49820\n";
+
+    REQUIRE( zllt.loadParsedStages( serialResponse ) == ZC_CONNECTED );
+    REQUIRE( zllt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllt.deviceAddressFor( 1 ) < 1 );
+}
+
+/// Verify a later discovery pass can find a stage that was missing initially.
+/**
+ * \ingroup zaberLowLevel_unit_test
+ */
+SCENARIO( "Stage discovery can find devices that appear later", "[zaberLowLevel]" )
+{
+    zaberLowLevel_test zllt( "zlltest_rediscover" );
+
+    REQUIRE( zllt.addConfiguredStage( "stagebs", "49820" ) == 0 );
+    REQUIRE( zllt.addConfiguredStage( "stageirf", "49821" ) == 0 );
+
+    std::string serialResponse1 = "@01 0 OK IDLE WR 49820\n";
+    std::string serialResponse2 = "@01 0 OK IDLE WR 49820\n@02 0 OK IDLE WR 49821\n";
+
+    REQUIRE( zllt.loadParsedStages( serialResponse1 ) == ZC_CONNECTED );
+    REQUIRE( zllt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllt.deviceAddressFor( 1 ) < 1 );
+
+    REQUIRE( zllt.loadParsedStages( serialResponse2 ) == ZC_CONNECTED );
+    REQUIRE( zllt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllt.deviceAddressFor( 1 ) == 2 );
+}
+
+/// Verify communication failures drop the app back into reconnectable states.
+/**
+ * \ingroup zaberLowLevel_unit_test
+ */
+SCENARIO( "Recoverable transport errors transition to reconnect states", "[zaberLowLevel]" )
+{
+    // clang-format off
+    #ifdef ZABERLOWLEVEL_TEST_DOXYGEN_REF
+    zaberLowLevel::resetConnection();
+    zaberLowLevel::recoverFromError( true );
+    #endif
+    // clang-format on
+
+    SECTION( "A present tty returns the app to NOTCONNECTED" )
+    {
+        zaberLowLevel_test zllt( "zlltest_present" );
+
+        REQUIRE( zllt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+        REQUIRE( zllt.setDeviceAddressFor( 0, 1 ) == 0 );
+        REQUIRE( zllt.setAppState( stateCodes::ERROR ) == 0 );
+
+        REQUIRE( zllt.recoverTransportError( true ) == 0 );
+        REQUIRE( zllt.appState() == stateCodes::NOTCONNECTED );
+        REQUIRE( zllt.currStateValue( "stageA" ) == "NOTCONNECTED" );
+    }
+
+    SECTION( "A missing tty returns the app to NODEVICE" )
+    {
+        zaberLowLevel_test zllt( "zlltest_missing" );
+
+        REQUIRE( zllt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+        REQUIRE( zllt.setDeviceAddressFor( 0, 1 ) == 0 );
+        REQUIRE( zllt.setAppState( stateCodes::ERROR ) == 0 );
+
+        REQUIRE( zllt.recoverTransportError( false ) == 0 );
+        REQUIRE( zllt.appState() == stateCodes::NODEVICE );
+        REQUIRE( zllt.currStateValue( "stageA" ) == "NODEVICE" );
+    }
 }
 
 } // namespace zaberLowLevelTest

--- a/apps/zaberLowLevel/tests/zaberUtils_test.cpp
+++ b/apps/zaberLowLevel/tests/zaberUtils_test.cpp
@@ -53,6 +53,20 @@ TEST_CASE( "zaberLowLevel utility helpers parse system.serial responses", "[zabe
     REQUIRE( serial[2] == "49821" );
 }
 
+/// Verify `parseSystemSerial()` rejects malformed non-numeric serial tokens.
+/**
+ * \ingroup zaberLowLevel_unit_test
+ */
+TEST_CASE( "zaberLowLevel utility helpers reject malformed system.serial snapshots", "[zaberUtils]" )
+{
+    std::string              tstr = "@09 0 OK BUSY --\n";
+    std::vector<int>         address;
+    std::vector<std::string> serial;
+    int                      rv = parseSystemSerial( address, serial, tstr );
+
+    REQUIRE( rv == ZUTILS_E_BADSERIAL );
+}
+
 } // namespace zaberLowLevelTest
 
 } // namespace libXWCTest

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -57,6 +57,8 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     std::unordered_map<std::string, size_t> m_stageSerial;
     std::unordered_map<std::string, size_t> m_stageName;
 
+    bool m_stageDiscoveryInitialized{ false };
+
   public:
     /// Default c'tor.
     zaberLowLevel();
@@ -326,6 +328,7 @@ int zaberLowLevel::loadStages( std::string &serialRes )
     std::vector<int>         addresses;
     std::vector<std::string> serials;
     std::vector<int>         oldAddresses;
+    bool                     firstDiscoveryPass = !m_stageDiscoveryInitialized;
 
     oldAddresses.reserve( m_stages.size() );
     for( size_t n = 0; n < m_stages.size(); ++n )
@@ -377,7 +380,7 @@ int zaberLowLevel::loadStages( std::string &serialRes )
         {
             if( m_stages[n].deviceAddress() < 1 )
             {
-                if( n >= oldAddresses.size() || oldAddresses[n] > 0 )
+                if( firstDiscoveryPass || n >= oldAddresses.size() || oldAddresses[n] > 0 )
                 {
                     log<text_log>( std::format( "stage {} with s/n {} not found in system.",
                                                 m_stages[n].name(),
@@ -388,6 +391,8 @@ int zaberLowLevel::loadStages( std::string &serialRes )
             }
         }
     }
+
+    m_stageDiscoveryInitialized = true;
 
     return ZC_CONNECTED;
 }

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -1,5 +1,6 @@
 /** \file zaberLowLevel.hpp
  * \brief The MagAO-X Low-Level Zaber Controller
+ * \author Jared R. Males (jaredmales@gmail.com)
  *
  * \ingroup zaberLowLevel_files
  */
@@ -40,6 +41,13 @@ namespace MagAOX
 namespace app
 {
 
+/// The low-level ASCII-protocol Zaber controller.
+/**
+ * This app manages a daisy-chained ASCII Zaber bus and keeps its discovery,
+ * recovery, and INDI reporting behavior aligned with the binary-protocol app.
+ *
+ * \ingroup zaberLowLevel
+ */
 class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
 {
 
@@ -47,60 +55,82 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     friend class zaberLowLevel_test;
 
   protected:
+    /** \name Stage Mapping - Data
+     *
+     * @{
+     */
+    /// Number of configured stages.
     int m_numStages{ 0 };
 
+    /// Connected ASCII protocol port.
     z_port m_port{ 0 };
 
+    /// Stage helpers in configuration order.
     std::vector<zaberStage<zaberLowLevel>> m_stages;
 
-    std::unordered_map<int, size_t>         m_stageAddress;
+    /// Map from ASCII device address to configured stage index.
+    std::unordered_map<int, size_t> m_stageAddress;
+
+    /// Map from configured serial number to configured stage index.
     std::unordered_map<std::string, size_t> m_stageSerial;
+
+    /// Map from configured stage name to configured stage index.
     std::unordered_map<std::string, size_t> m_stageName;
 
+    /// Whether the active connection has completed an initial discovery pass.
     bool m_stageDiscoveryInitialized{ false };
+    ///@}
 
   public:
-    /// Default c'tor.
+    /// Default constructor.
     zaberLowLevel();
 
-    /// D'tor, declared and defined for noexcept.
+    /// Destructor, declared and defined for noexcept.
     ~zaberLowLevel() noexcept
     {
     }
 
+    /// Set up application configuration.
     virtual void setupConfig();
 
+    /// Load application configuration.
     virtual void loadConfig();
 
+    /// Connect to the ASCII-protocol stage chain and discover configured devices.
     int connect();
 
-    int loadStages( std::string &serialRes );
+    /// Apply a parsed `system.serial` snapshot to the configured stages.
+    int loadStages( std::string &serialRes /**< [in] the raw response to `/ get system.serial` */ );
 
+    /// Refresh discovery on an already-connected ASCII bus.
     int refreshStageDiscovery();
 
+    /// Reset the active ASCII connection bookkeeping.
     int resetConnection();
 
+    /// Recover from an ASCII-transport error without terminating the app.
     int recoverFromError( bool devicePresent /**< [in] True if the USB tty still exists in udev. */ );
 
-    /// Startup functions
-    /** Sets up the INDI vars.
-     *
-     */
+    /// Set up the INDI properties and restore retained stage state.
     virtual int appStartup();
 
-    /// Implementation of the FSM for zaberLowLevel.
+    /// Execute the main FSM for `zaberLowLevel`.
     virtual int appLogic();
 
-    /// Implementation of the on-power-off FSM logic
+    /// Handle the transition into the powered-off state.
     virtual int onPowerOff();
 
-    /// Implementation of the while-powered-off FSM
+    /// Execute the powered-off loop.
     virtual int whilePowerOff();
 
-    /// Do any needed shutdown tasks.  Currently nothing in this app.
+    /// Perform any shutdown tasks before exit.
     virtual int appShutdown();
 
   protected:
+    /** \name INDI Stage State - Data
+     *
+     * @{
+     */
     /// Current state of the stage.
     pcf::IndiProperty m_indiP_curr_state;
 
@@ -110,7 +140,7 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     /// Parked state of the stage.
     pcf::IndiProperty m_indiP_parked;
 
-    /// Time of last homing for the state
+    /// Time of last homing for the stage.
     pcf::IndiProperty m_indiP_lastHomed;
 
     /// Current raw position of the stage.
@@ -137,13 +167,18 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     /// Command a stage to safely immediately halt.
     pcf::IndiProperty m_indiP_req_ehalt;
 
-    /// Enable or disable a stages potentiometer
+    /// Enable or disable a stage's potentiometer.
     pcf::IndiProperty m_indiP_knob_enable;
 
-    /// Enable or disable a stages LED
+    /// Enable or disable a stage's LED.
     pcf::IndiProperty m_indiP_led_enable;
+    ///@}
 
   public:
+    /** \name INDI Stage State
+     *
+     * @{
+     */
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_tgt_pos );
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_req_home );
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_req_home_all );
@@ -151,6 +186,7 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_req_ehalt );
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_knob_enable );
     INDI_NEWCALLBACK_DECL( zaberLowLevel, m_indiP_led_enable );
+    ///@}
 };
 
 zaberLowLevel::zaberLowLevel() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -74,6 +74,12 @@ class zaberLowLevel : public MagAOXAppT, public tty::usbDevice
 
     int loadStages( std::string &serialRes );
 
+    int refreshStageDiscovery();
+
+    int resetConnection();
+
+    int recoverFromError( bool devicePresent /**< [in] True if the USB tty still exists in udev. */ );
+
     /// Startup functions
     /** Sets up the INDI vars.
      *
@@ -319,6 +325,13 @@ int zaberLowLevel::loadStages( std::string &serialRes )
 {
     std::vector<int>         addresses;
     std::vector<std::string> serials;
+    std::vector<int>         oldAddresses;
+
+    oldAddresses.reserve( m_stages.size() );
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        oldAddresses.push_back( m_stages[n].deviceAddress() );
+    }
 
     int rv = parseSystemSerial( addresses, serials, serialRes );
 
@@ -332,15 +345,26 @@ int zaberLowLevel::loadStages( std::string &serialRes )
     {
         log<text_log>( "Found " + std::to_string( addresses.size() ) + " stages." );
         m_stageAddress.clear(); // We clear this map before re-populating.
+
+        for( size_t n = 0; n < m_stages.size(); ++n )
+        {
+            m_stages[n].deviceAddress( -1 );
+        }
+
         for( size_t n = 0; n < addresses.size(); ++n )
         {
             if( m_stageSerial.count( serials[n] ) == 1 )
             {
-                m_stages[m_stageSerial[serials[n]]].deviceAddress( addresses[n] );
+                const size_t stageIndex = m_stageSerial[serials[n]];
 
-                m_stageAddress.insert( { addresses[n], m_stageSerial[serials[n]] } );
-                log<text_log>( "stage @" + std::to_string( addresses[n] ) + " with s/n " + serials[n] +
-                               " corresponds to " + m_stages[m_stageSerial[serials[n]]].name() );
+                m_stages[stageIndex].deviceAddress( addresses[n] );
+
+                m_stageAddress.insert( { addresses[n], stageIndex } );
+                if( stageIndex >= oldAddresses.size() || oldAddresses[stageIndex] != addresses[n] )
+                {
+                    log<text_log>( "stage @" + std::to_string( addresses[n] ) + " with s/n " + serials[n] +
+                                   " corresponds to " + m_stages[stageIndex].name() );
+                }
             }
             else
             {
@@ -353,16 +377,116 @@ int zaberLowLevel::loadStages( std::string &serialRes )
         {
             if( m_stages[n].deviceAddress() < 1 )
             {
-
-                log<text_log>(
-                    std::format( "stage {} with s/n {} not found in system.", m_stages[n].name(), serials[n] ),
-                    logPrio::LOG_ERROR );
-                state( state(), true );
+                if( n >= oldAddresses.size() || oldAddresses[n] > 0 )
+                {
+                    log<text_log>( std::format( "stage {} with s/n {} not found in system.",
+                                                m_stages[n].name(),
+                                                m_stages[n].serial() ),
+                                   logPrio::LOG_ERROR );
+                    state( state(), true );
+                }
             }
         }
     }
 
     return ZC_CONNECTED;
+}
+
+int zaberLowLevel::refreshStageDiscovery()
+{
+    if( m_port <= 0 )
+    {
+        return ZC_NOT_CONNECTED;
+    }
+
+    int rv = za_drain( m_port );
+
+    if( rv != Z_SUCCESS )
+    {
+        log<software_error>( { rv, "error from za_drain" } );
+        state( stateCodes::ERROR );
+        return ZC_ERROR;
+    }
+
+    char        buffer[256];
+    std::string gss = "/ get system.serial";
+    int         nwr = za_send( m_port, gss.c_str(), gss.size() );
+
+    if( nwr == Z_ERROR_SYSTEM_ERROR )
+    {
+        log<text_log>( "Error sending system.serial query to stages", logPrio::LOG_ERROR );
+        state( stateCodes::ERROR );
+        return ZC_ERROR;
+    }
+
+    std::string serialRes;
+    while( 1 )
+    {
+        int nrd = za_receive( m_port, buffer, sizeof( buffer ) );
+        if( nrd >= 0 )
+        {
+            buffer[nrd] = '\0';
+            log<text_log>( std::string( "Received: " ) + buffer, logPrio::LOG_DEBUG );
+            serialRes += buffer;
+        }
+        else if( nrd != Z_ERROR_TIMEOUT )
+        {
+            log<text_log>( "Error receiving from stages", logPrio::LOG_ERROR );
+            state( stateCodes::ERROR );
+            return ZC_ERROR;
+        }
+        else
+        {
+            log<text_log>( "TIMEOUT", logPrio::LOG_DEBUG );
+            break; // Timeout ok.
+        }
+    }
+
+    return loadStages( serialRes );
+}
+
+int zaberLowLevel::resetConnection()
+{
+    if( m_port > 0 )
+    {
+        int rv = za_disconnect( m_port );
+        if( rv < 0 )
+        {
+            log<text_log>( "Error disconnecting from zaber system.", logPrio::LOG_ERROR );
+        }
+    }
+
+    m_port = 0;
+
+    return 0;
+}
+
+int zaberLowLevel::recoverFromError( bool devicePresent )
+{
+    resetConnection();
+
+    if( devicePresent )
+    {
+        state( stateCodes::NOTCONNECTED );
+    }
+    else
+    {
+        state( stateCodes::NODEVICE );
+    }
+
+    for( size_t i = 0; i < m_stages.size(); ++i )
+    {
+        if( devicePresent && m_stages[i].deviceAddress() > 0 )
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NOTCONNECTED" ) );
+        }
+        else
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+        }
+    }
+
+    return 0;
 }
 
 int zaberLowLevel::appStartup()
@@ -516,13 +640,12 @@ int zaberLowLevel::appLogic()
                 return 0; // means we're powering off
             }
 
-            state( stateCodes::FAILURE );
-
             if( !stateLogged() )
             {
-                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+                log<software_error>( { rv, tty::ttyErrorString( rv ) } );
             }
-            return -1;
+
+            return 0;
         }
 
         if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
@@ -643,6 +766,22 @@ int zaberLowLevel::appLogic()
 
     if( state() == stateCodes::READY )
     {
+        { // mutex scope
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+
+            int rv = refreshStageDiscovery();
+
+            if( rv == ZC_ERROR )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0; // means we're powering off
+                }
+
+                return 0;
+            }
+        }
+
         // Here we check complete stage state.
         for( size_t i = 0; i < m_stages.size(); ++i )
         {
@@ -825,16 +964,12 @@ int zaberLowLevel::appLogic()
                 return 0; // means we're powering off
             }
 
-            state( stateCodes::FAILURE );
-            for( size_t i = 0; i < m_stages.size(); ++i )
-            {
-                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
-            }
             if( !stateLogged() )
             {
-                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+                log<software_error>( { rv, tty::ttyErrorString( rv ) } );
             }
-            return rv;
+
+            return recoverFromError( false );
         }
 
         if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
@@ -844,20 +979,13 @@ int zaberLowLevel::appLogic()
                 return 0; // means we're powering off
             }
 
-            state( stateCodes::NODEVICE );
-
-            for( size_t i = 0; i < m_stages.size(); ++i )
-            {
-                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
-            }
-
             if( !stateLogged() )
             {
                 log<text_log>(
                     std::format( "USB Device {}:{}:{} not found in udev", m_idVendor, m_idProduct, m_serial ) );
             }
 
-            return 0;
+            return recoverFromError( false );
         }
 
         if( powerState() != 1 || powerStateTarget() != 1 )
@@ -865,15 +993,13 @@ int zaberLowLevel::appLogic()
             return 0; // means we're powering off
         }
 
-        state( stateCodes::FAILURE );
-
-        for( size_t i = 0; i < m_stages.size(); ++i )
+        if( !stateLogged() )
         {
-            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
+            log<text_log>( "Recovering from stage communication error by resetting the connection.",
+                           logPrio::LOG_WARNING );
         }
 
-        log<software_critical>();
-        log<text_log>( "Error NOT due to loss of USB connection.  I can't fix it myself.", logPrio::LOG_CRITICAL );
+        return recoverFromError( true );
     }
 
     if( powerState() != 1 || powerStateTarget() != 1 )

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -329,11 +329,16 @@ int zaberLowLevel::loadStages( std::string &serialRes )
     std::vector<std::string> serials;
     std::vector<int>         oldAddresses;
     bool                     firstDiscoveryPass = !m_stageDiscoveryInitialized;
+    size_t                   oldPresentCount    = 0;
 
     oldAddresses.reserve( m_stages.size() );
     for( size_t n = 0; n < m_stages.size(); ++n )
     {
         oldAddresses.push_back( m_stages[n].deviceAddress() );
+        if( m_stages[n].deviceAddress() > 0 )
+        {
+            ++oldPresentCount;
+        }
     }
 
     int rv = parseSystemSerial( addresses, serials, serialRes );
@@ -346,7 +351,11 @@ int zaberLowLevel::loadStages( std::string &serialRes )
     }
     else
     {
-        log<text_log>( "Found " + std::to_string( addresses.size() ) + " stages." );
+        if( firstDiscoveryPass || addresses.size() != oldPresentCount )
+        {
+            log<text_log>( "Found " + std::to_string( addresses.size() ) + " stages." );
+        }
+
         m_stageAddress.clear(); // We clear this map before re-populating.
 
         for( size_t n = 0; n < m_stages.size(); ++n )

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -372,7 +372,8 @@ int zaberLowLevel::loadStages( std::string &serialRes )
                 m_stages[stageIndex].deviceAddress( addresses[n] );
 
                 m_stageAddress.insert( { addresses[n], stageIndex } );
-                if( stageIndex >= oldAddresses.size() || oldAddresses[stageIndex] != addresses[n] )
+                if( firstDiscoveryPass || stageIndex >= oldAddresses.size() ||
+                    oldAddresses[stageIndex] != addresses[n] )
                 {
                     log<text_log>( "stage @" + std::to_string( addresses[n] ) + " with s/n " + serials[n] +
                                    " corresponds to " + m_stages[stageIndex].name() );
@@ -470,7 +471,8 @@ int zaberLowLevel::resetConnection()
         }
     }
 
-    m_port = 0;
+    m_port                      = 0;
+    m_stageDiscoveryInitialized = false;
 
     return 0;
 }
@@ -1031,13 +1033,7 @@ int zaberLowLevel::appLogic()
 
 inline int zaberLowLevel::onPowerOff()
 {
-    int rv = za_disconnect( m_port );
-    if( rv < 0 )
-    {
-        log<text_log>( "Error disconnecting from zaber system.", logPrio::LOG_ERROR );
-    }
-
-    m_port = 0;
+    resetConnection();
 
     std::lock_guard<std::mutex> lock( m_indiMutex );
 

--- a/apps/zaberLowLevel/zaberLowLevel.hpp
+++ b/apps/zaberLowLevel/zaberLowLevel.hpp
@@ -356,6 +356,18 @@ int zaberLowLevel::connect()
         }
     }
 
+    {
+        std::vector<int>         addresses;
+        std::vector<std::string> serials;
+
+        rv = parseSystemSerial( addresses, serials, serialRes );
+        if( rv == ZUTILS_E_BADSERIAL )
+        {
+            log<text_log>( "Ignoring inconclusive system.serial snapshot during stage activity.", logPrio::LOG_DEBUG );
+            return ZC_CONNECTED;
+        }
+    }
+
     return loadStages( serialRes );
 }
 
@@ -821,7 +833,21 @@ int zaberLowLevel::appLogic()
         { // mutex scope
             std::lock_guard<std::mutex> guard( m_indiMutex );
 
-            int rv = refreshStageDiscovery();
+            bool canRefreshDiscovery = true;
+            for( size_t i = 0; i < m_stages.size(); ++i )
+            {
+                if( m_stages[i].deviceAddress() > 0 && m_stages[i].deviceStatus() == 'B' )
+                {
+                    canRefreshDiscovery = false;
+                    break;
+                }
+            }
+
+            int rv = ZC_CONNECTED;
+            if( canRefreshDiscovery )
+            {
+                rv = refreshStageDiscovery();
+            }
 
             if( rv == ZC_ERROR )
             {

--- a/apps/zaberLowLevel/zaberStage.hpp
+++ b/apps/zaberLowLevel/zaberStage.hpp
@@ -722,13 +722,37 @@ bool zaberStage<parentT>::isCommandReply( const za_reply &rep )
 template <class parentT>
 int zaberStage<parentT>::sendCommand( std::string &response, z_port port, const std::string &command )
 {
-    za_send( port, command.c_str(), command.size() );
+    if( port <= 0 )
+    {
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        {
+            return -1; // don't log, but propagate error
+        }
+
+        MagAOXAppT::log<software_error>( { 0, "invalid zaber port" } );
+        response = "";
+        return -1;
+    }
+
+    int rv = za_send( port, command.c_str(), command.size() );
+
+    if( rv < 0 )
+    {
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        {
+            return rv; // don't log, but propagate error
+        }
+
+        MagAOXAppT::log<software_error>( { rv, "za_send !=Z_SUCCESS" } );
+        response = "";
+        return -1;
+    }
 
     char buff[256];
 
     while( 1 )
     {
-        int rv = za_receive( port, buff, sizeof( buff ) );
+        rv = za_receive( port, buff, sizeof( buff ) );
 
         if( rv == Z_ERROR_TIMEOUT )
         {
@@ -752,7 +776,7 @@ int zaberStage<parentT>::sendCommand( std::string &response, z_port port, const 
         }
         za_reply rep;
 
-        rv = za_decode( &rep, buff, sizeof( buff ) );
+        rv = za_decode( &rep, buff, static_cast<size_t>( rv ) );
         if( rv != Z_SUCCESS )
         {
             if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )

--- a/apps/zaberLowLevel/zaberUtils.hpp
+++ b/apps/zaberLowLevel/zaberUtils.hpp
@@ -1,19 +1,21 @@
 /** \file zaberUtils.hpp
-  * \brief utilties for working with zaber stages
-  *
-  * \ingroup zaberLowLevel_files
-  */
+ * \brief utilties for working with zaber stages
+ *
+ * \ingroup zaberLowLevel_files
+ */
 
 #ifndef zaberUtils_hpp
 #define zaberUtils_hpp
 
+#include <algorithm>
+#include <cctype>
 #include <iostream>
 
-
-#define ZUTILS_E_NOAT       (-100)
-#define ZUTILS_E_NOSP       (-101)
-#define ZUTILS_E_BADADD     (-102)
-#define ZUTILS_E_SERIALSIZE (-103)
+#define ZUTILS_E_NOAT ( -100 )
+#define ZUTILS_E_NOSP ( -101 )
+#define ZUTILS_E_BADADD ( -102 )
+#define ZUTILS_E_SERIALSIZE ( -103 )
+#define ZUTILS_E_BADSERIAL ( -104 )
 
 namespace MagAOX
 {
@@ -22,61 +24,65 @@ namespace app
 
 /// Parse the system.serial query
 /**
-  * \returns 0 on success
-  * \returns \<0 on error with error code primarily meant for unit testing
-  *
-  * \ingroup zaberLowLevel
-  */
-int parseSystemSerial( std::vector<int> & address,
-                       std::vector<std::string> & serial,
-                       const std::string & response
-                     )
+ * \returns 0 on success
+ * \returns \<0 on error with error code primarily meant for unit testing
+ *
+ * \ingroup zaberLowLevel
+ */
+int parseSystemSerial( std::vector<int> &address, std::vector<std::string> &serial, const std::string &response )
 {
-   size_t at = response.find('@', 0);
+    size_t at = response.find( '@', 0 );
 
-   if(at == std::string::npos)
-   {
-      return ZUTILS_E_NOAT;
-   }
+    if( at == std::string::npos )
+    {
+        return ZUTILS_E_NOAT;
+    }
 
-   while(at != std::string::npos)
-   {
-      size_t sp = response.find(' ', at);
+    while( at != std::string::npos )
+    {
+        size_t sp = response.find( ' ', at );
 
-      if(sp == std::string::npos)
-      {
-         return ZUTILS_E_NOSP;
-      }
+        if( sp == std::string::npos )
+        {
+            return ZUTILS_E_NOSP;
+        }
 
-      if(sp-at  != 3 ) //Address should be 2 characters
-      {
-         return ZUTILS_E_BADADD;
-      }
+        if( sp - at != 3 ) // Address should be 2 characters
+        {
+            return ZUTILS_E_BADADD;
+        }
 
-      int add = std::stoi( response.substr(at+1, sp-at-1));
+        int add = std::stoi( response.substr( at + 1, sp - at - 1 ) );
 
-      address.push_back(add);
+        address.push_back( add );
 
-      at = response.find('@', at+1);
+        at = response.find( '@', at + 1 );
 
-      sp = response.rfind(' ', at);
-      size_t ed = response.find_first_of("\n@", sp);
-      if(ed == std::string::npos) ed = response.size();
+        sp        = response.rfind( ' ', at );
+        size_t ed = response.find_first_of( "\n@", sp );
+        if( ed == std::string::npos )
+            ed = response.size();
 
-      if(ed-sp-1 > 6)
-      {
-         return ZUTILS_E_SERIALSIZE;
-      }
+        if( ed - sp - 1 > 6 )
+        {
+            return ZUTILS_E_SERIALSIZE;
+        }
 
-      std::string ser = response.substr(sp+1, ed - sp-1);
+        std::string ser = response.substr( sp + 1, ed - sp - 1 );
 
-      serial.push_back(ser);
-   }
+        if( ser.size() == 0 ||
+            !std::all_of( ser.begin(), ser.end(), []( unsigned char c ) { return std::isdigit( c ) != 0; } ) )
+        {
+            return ZUTILS_E_BADSERIAL;
+        }
 
-   return 0;
+        serial.push_back( ser );
+    }
+
+    return 0;
 }
 
-} //namespace app
-} //namespace MagAOX
+} // namespace app
+} // namespace MagAOX
 
-#endif //zaberUtils_hpp
+#endif // zaberUtils_hpp

--- a/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
+++ b/apps/zaberLowLevelBinary/tests/zaberLowLevelBinary_test.cpp
@@ -90,6 +90,60 @@ class zaberLowLevelBinary_test : public zaberLowLevelBinary
         return ( m_indiDriver && m_indiDriver->good() ) ? 0 : -1;
     }
 
+    /// Configure a stage entry for discovery and recovery tests.
+    int addConfiguredStage( const std::string &stageName, const std::string &serial, int deviceAddress = -1 )
+    {
+        m_stages.emplace_back( this );
+        m_stages.back().name( stageName );
+        m_stages.back().serial( serial );
+        m_stages.back().deviceAddress( deviceAddress );
+
+        const size_t idx = m_stages.size() - 1;
+
+        m_stageName.insert( { stageName, idx } );
+        m_stageSerial.insert( { serial, idx } );
+
+        return 0;
+    }
+
+    /// Load a discovery snapshot through the production mapping code.
+    int loadDiscoverySnapshot( const std::vector<int> &addresses, const std::vector<std::string> &serials )
+    {
+        return loadStages( addresses, serials );
+    }
+
+    /// Set the cached device address for a configured stage.
+    int setDeviceAddressFor( size_t stageIndex, int deviceAddress )
+    {
+        m_stages.at( stageIndex ).deviceAddress( deviceAddress );
+        return 0;
+    }
+
+    /// Get the cached device address for a configured stage.
+    int deviceAddressFor( size_t stageIndex ) const
+    {
+        return m_stages.at( stageIndex ).deviceAddress();
+    }
+
+    /// Drive the recoverable error handler under test.
+    int recoverTransportError( bool devicePresent )
+    {
+        return recoverFromError( devicePresent );
+    }
+
+    /// Set the FSM state for recovery tests.
+    int setAppState( stateCodes::stateCodeT newState )
+    {
+        state( newState );
+        return 0;
+    }
+
+    /// Get the FSM state for recovery tests.
+    stateCodes::stateCodeT appState() const
+    {
+        return state();
+    }
+
     /// Read the value of a text, number, or switch element from a test property.
     std::string propertyValue( const pcf::IndiProperty &property, const std::string &element ) const
     {
@@ -247,6 +301,88 @@ SCENARIO( "Binary last-home timestamps refresh after homing completes", "[zaberL
 
         REQUIRE( stage.refreshLastHomed( false ) == 0 );
         REQUIRE( stage.lastHomedSec() == 77 );
+    }
+}
+
+/// Verify discovery clears stale addresses and reports missing configured stages safely.
+/**
+ * \ingroup zaberLowLevelBinary_unit_test
+ */
+SCENARIO( "Binary discovery resets stale device addresses", "[zaberLowLevelBinary]" )
+{
+    // clang-format off
+    #ifdef ZABERLOWLEVELBINARY_TEST_DOXYGEN_REF
+    zaberLowLevelBinary::loadStages( std::declval<const std::vector<int> &>(), std::declval<const std::vector<std::string> &>() );
+    #endif
+    // clang-format on
+
+    zaberLowLevelBinary_test zllbt( "zllbtest" );
+
+    REQUIRE( zllbt.addConfiguredStage( "stagebs", "64040", 1 ) == 0 );
+    REQUIRE( zllbt.addConfiguredStage( "stageirf", "122400", 2 ) == 0 );
+
+    REQUIRE( zllbt.loadDiscoverySnapshot( { 1 }, { "64040" } ) == ZBC_CONNECTED );
+    REQUIRE( zllbt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllbt.deviceAddressFor( 1 ) < 1 );
+}
+
+/// Verify a later discovery pass can find a stage that was missing initially.
+/**
+ * \ingroup zaberLowLevelBinary_unit_test
+ */
+SCENARIO( "Binary discovery can find devices that appear later", "[zaberLowLevelBinary]" )
+{
+    zaberLowLevelBinary_test zllbt( "zllbtest_rediscover" );
+
+    REQUIRE( zllbt.addConfiguredStage( "stagebs", "64040" ) == 0 );
+    REQUIRE( zllbt.addConfiguredStage( "stageirf", "122400" ) == 0 );
+
+    REQUIRE( zllbt.loadDiscoverySnapshot( { 1 }, { "64040" } ) == ZBC_CONNECTED );
+    REQUIRE( zllbt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllbt.deviceAddressFor( 1 ) < 1 );
+
+    REQUIRE( zllbt.loadDiscoverySnapshot( { 1, 2 }, { "64040", "122400" } ) == ZBC_CONNECTED );
+    REQUIRE( zllbt.deviceAddressFor( 0 ) == 1 );
+    REQUIRE( zllbt.deviceAddressFor( 1 ) == 2 );
+}
+
+/// Verify communication failures drop the binary app back into reconnectable states.
+/**
+ * \ingroup zaberLowLevelBinary_unit_test
+ */
+SCENARIO( "Recoverable binary transport errors transition to reconnect states", "[zaberLowLevelBinary]" )
+{
+    // clang-format off
+    #ifdef ZABERLOWLEVELBINARY_TEST_DOXYGEN_REF
+    zaberLowLevelBinary::resetConnection();
+    zaberLowLevelBinary::recoverFromError( true );
+    #endif
+    // clang-format on
+
+    SECTION( "A present tty returns the app to NOTCONNECTED" )
+    {
+        zaberLowLevelBinary_test zllbt( "zllbtest_present" );
+
+        REQUIRE( zllbt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+        REQUIRE( zllbt.setDeviceAddressFor( 0, 1 ) == 0 );
+        REQUIRE( zllbt.setAppState( stateCodes::ERROR ) == 0 );
+
+        REQUIRE( zllbt.recoverTransportError( true ) == 0 );
+        REQUIRE( zllbt.appState() == stateCodes::NOTCONNECTED );
+        REQUIRE( zllbt.currStateValue( "stageA" ) == "NOTCONNECTED" );
+    }
+
+    SECTION( "A missing tty returns the app to NODEVICE" )
+    {
+        zaberLowLevelBinary_test zllbt( "zllbtest_missing" );
+
+        REQUIRE( zllbt.setupPowerOffSnapshot( "stageA", 12345, true, 54321, 77 ) == 0 );
+        REQUIRE( zllbt.setDeviceAddressFor( 0, 1 ) == 0 );
+        REQUIRE( zllbt.setAppState( stateCodes::ERROR ) == 0 );
+
+        REQUIRE( zllbt.recoverTransportError( false ) == 0 );
+        REQUIRE( zllbt.appState() == stateCodes::NODEVICE );
+        REQUIRE( zllbt.currStateValue( "stageA" ) == "NODEVICE" );
     }
 }
 

--- a/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
+++ b/apps/zaberLowLevelBinary/zaberBinaryStage.hpp
@@ -636,6 +636,16 @@ int zaberBinaryStage<parentT>::queryCommand(
             std::format( "stage {} with s/n {} not found in system.", m_name, m_serial ) );
     }
 
+    if( port <= 0 )
+    {
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        {
+            return -1;
+        }
+
+        return MagAOXAppT::log<software_error, -1>( { 0, "invalid zaber binary port" } );
+    }
+
     uint8_t command[6];
     if( zb_encode( command, static_cast<uint8_t>( m_deviceAddress ), commandNumber, data ) != Z_SUCCESS )
     {
@@ -695,6 +705,16 @@ int zaberBinaryStage<parentT>::sendCommandNoReply( z_port port, uint8_t commandN
     {
         return MagAOXAppT::log<software_error, -1>(
             std::format( "stage {} with s/n {} not found in system.", m_name, m_serial ) );
+    }
+
+    if( port <= 0 )
+    {
+        if( m_parent->powerState() != 1 || m_parent->powerStateTarget() != 1 )
+        {
+            return -1;
+        }
+
+        return MagAOXAppT::log<software_error, -1>( { 0, "invalid zaber binary port" } );
     }
 
     uint8_t command[6];

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -90,6 +90,9 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
     /// Map from configured stage name to configured stage index.
     std::unordered_map<std::string, size_t> m_stageName;
 
+    /// Whether the active connection has completed an initial discovery pass.
+    bool m_stageDiscoveryInitialized{ false };
+
     ///@}
 
   public:
@@ -113,6 +116,14 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
     /// Discover configured stages on the binary bus.
     int loadStages();
 
+    /// Apply a discovered address-to-serial snapshot to the configured stages.
+    int loadStages( const std::vector<int>         &addresses, /**< [in] discovered device addresses */
+                    const std::vector<std::string> &serials    /**< [in] discovered device serial numbers */
+    );
+
+    /// Refresh discovery on an already-connected binary bus.
+    int refreshStageDiscovery();
+
     /// Query a device directly for discovery-time replies.
     int queryDevice( int32_t &response,      /**< [out] decoded reply data */
                      uint8_t  deviceAddress, /**< [in] device address */
@@ -126,6 +137,12 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
                             uint8_t commandNumber, /**< [in] command number */
                             int32_t data           /**< [in] command data */
     );
+
+    /// Reset the active binary connection bookkeeping.
+    int resetConnection();
+
+    /// Recover from a binary-transport error without terminating the app.
+    int recoverFromError( bool devicePresent /**< [in] true if the USB tty still exists in udev */ );
 
     /// Startup logic.
     virtual int appStartup();
@@ -358,7 +375,7 @@ int zaberLowLevelBinary::sendCommandNoReply( uint8_t deviceAddress, uint8_t comm
     return 0;
 }
 
-int zaberLowLevelBinary::connect()
+int zaberLowLevelBinary::resetConnection()
 {
     if( m_port > 0 )
     {
@@ -367,8 +384,45 @@ int zaberLowLevelBinary::connect()
         {
             log<text_log>( "Error disconnecting from zaber binary system.", logPrio::LOG_ERROR );
         }
-        m_port = 0;
     }
+
+    m_port                      = 0;
+    m_stageDiscoveryInitialized = false;
+
+    return 0;
+}
+
+int zaberLowLevelBinary::recoverFromError( bool devicePresent )
+{
+    resetConnection();
+
+    if( devicePresent )
+    {
+        state( stateCodes::NOTCONNECTED );
+    }
+    else
+    {
+        state( stateCodes::NODEVICE );
+    }
+
+    for( size_t i = 0; i < m_stages.size(); ++i )
+    {
+        if( devicePresent && m_stages[i].deviceAddress() > 0 )
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NOTCONNECTED" ) );
+        }
+        else
+        {
+            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+        }
+    }
+
+    return 0;
+}
+
+int zaberLowLevelBinary::connect()
+{
+    resetConnection();
 
     int zrv;
     { // mutex scope
@@ -378,11 +432,7 @@ int zaberLowLevelBinary::connect()
 
     if( zrv != Z_SUCCESS || m_port <= 0 )
     {
-        if( m_port > 0 )
-        {
-            zb_disconnect( m_port );
-            m_port = 0;
-        }
+        resetConnection();
 
         if( !stateLogged() )
         {
@@ -424,11 +474,14 @@ int zaberLowLevelBinary::connect()
 
 int zaberLowLevelBinary::loadStages()
 {
-    m_stageAddress.clear();
+    std::vector<int>         addresses;
+    std::vector<std::string> serials;
 
-    for( size_t n = 0; n < m_stages.size(); ++n )
+    if( zb_drain( m_port ) != Z_SUCCESS )
     {
-        m_stages[n].deviceAddress( -1 );
+        log<software_error>( { "error draining binary port" } );
+        state( stateCodes::ERROR );
+        return ZBC_ERROR;
     }
 
     for( int address = 1; address <= m_maxDiscoveryAddress; ++address )
@@ -443,14 +496,60 @@ int zaberLowLevelBinary::loadStages()
             continue;
         }
 
-        std::string serial = std::to_string( serialNumber );
+        addresses.push_back( address );
+        serials.push_back( std::to_string( serialNumber ) );
+    }
+
+    return loadStages( addresses, serials );
+}
+
+int zaberLowLevelBinary::loadStages( const std::vector<int> &addresses, const std::vector<std::string> &serials )
+{
+    std::vector<int> oldAddresses;
+    bool             firstDiscoveryPass = !m_stageDiscoveryInitialized;
+    size_t           oldPresentCount    = 0;
+
+    oldAddresses.reserve( m_stages.size() );
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        oldAddresses.push_back( m_stages[n].deviceAddress() );
+        if( m_stages[n].deviceAddress() > 0 )
+        {
+            ++oldPresentCount;
+        }
+    }
+
+    if( addresses.size() != serials.size() )
+    {
+        return log<software_error, ZBC_ERROR>( { "discovery address/serial vector size mismatch" } );
+    }
+
+    if( firstDiscoveryPass || addresses.size() != oldPresentCount )
+    {
+        log<text_log>( "Found " + std::to_string( addresses.size() ) + " stages." );
+    }
+
+    m_stageAddress.clear();
+
+    for( size_t n = 0; n < m_stages.size(); ++n )
+    {
+        m_stages[n].deviceAddress( -1 );
+    }
+
+    for( size_t n = 0; n < addresses.size(); ++n )
+    {
+        const int         address = addresses[n];
+        const std::string serial  = serials[n];
         if( m_stageSerial.count( serial ) == 1 )
         {
             size_t idx = m_stageSerial[serial];
             m_stages[idx].deviceAddress( address );
             m_stageAddress.insert( { address, idx } );
-            log<text_log>( "stage @" + std::to_string( address ) + " with s/n " + serial + " corresponds to " +
-                           m_stages[idx].name() );
+            if( firstDiscoveryPass || idx >= oldAddresses.size() || oldAddresses[idx] != address )
+            {
+                log<text_log>( "stage @" + std::to_string( address ) + " with s/n " + serial + " corresponds to " +
+                               m_stages[idx].name() );
+            }
         }
         else
         {
@@ -463,14 +562,30 @@ int zaberLowLevelBinary::loadStages()
     {
         if( m_stages[n].deviceAddress() < 1 )
         {
-            log<text_log>(
-                std::format( "stage {} with s/n {} not found in system.", m_stages[n].name(), m_stages[n].serial() ),
-                logPrio::LOG_ERROR );
-            state( state(), true );
+            if( firstDiscoveryPass || n >= oldAddresses.size() || oldAddresses[n] > 0 )
+            {
+                log<text_log>( std::format( "stage {} with s/n {} not found in system.",
+                                            m_stages[n].name(),
+                                            m_stages[n].serial() ),
+                               logPrio::LOG_ERROR );
+                state( state(), true );
+            }
         }
     }
 
+    m_stageDiscoveryInitialized = true;
+
     return ZBC_CONNECTED;
+}
+
+int zaberLowLevelBinary::refreshStageDiscovery()
+{
+    if( m_port <= 0 )
+    {
+        return ZBC_NOT_CONNECTED;
+    }
+
+    return loadStages();
 }
 
 int zaberLowLevelBinary::appStartup()
@@ -600,12 +715,11 @@ int zaberLowLevelBinary::appLogic()
                 return 0;
             }
 
-            state( stateCodes::FAILURE );
             if( !stateLogged() )
             {
-                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+                log<software_error>( { rv, tty::ttyErrorString( rv ) } );
             }
-            return -1;
+            return 0;
         }
 
         if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
@@ -730,10 +844,26 @@ int zaberLowLevelBinary::appLogic()
 
     if( state() == stateCodes::READY )
     {
+        { // mutex scope
+            std::lock_guard<std::mutex> guard( m_indiMutex );
+
+            int rv = refreshStageDiscovery();
+            if( rv == ZBC_ERROR )
+            {
+                if( powerState() != 1 || powerStateTarget() != 1 )
+                {
+                    return 0;
+                }
+
+                return 0;
+            }
+        }
+
         for( size_t i = 0; i < m_stages.size(); ++i )
         {
             if( m_stages[i].deviceAddress() < 1 )
             {
+                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
                 continue;
             }
 
@@ -853,26 +983,21 @@ int zaberLowLevelBinary::appLogic()
                 return 0;
             }
 
-            state( stateCodes::FAILURE );
-            for( size_t i = 0; i < m_stages.size(); ++i )
-            {
-                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
-            }
             if( !stateLogged() )
             {
-                log<software_critical>( { rv, tty::ttyErrorString( rv ) } );
+                log<software_error>( { rv, tty::ttyErrorString( rv ) } );
             }
-            return rv;
+            return recoverFromError( false );
         }
 
         if( rv == TTY_E_DEVNOTFOUND || rv == TTY_E_NODEVNAMES )
         {
-            state( stateCodes::NODEVICE );
-            for( size_t i = 0; i < m_stages.size(); ++i )
+            if( !stateLogged() )
             {
-                updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "NODEVICE" ) );
+                log<text_log>(
+                    std::format( "USB Device {}:{}:{} not found in udev", m_idVendor, m_idProduct, m_serial ) );
             }
-            return 0;
+            return recoverFromError( false );
         }
 
         if( powerState() != 1 || powerStateTarget() != 1 )
@@ -880,14 +1005,13 @@ int zaberLowLevelBinary::appLogic()
             return 0;
         }
 
-        state( stateCodes::FAILURE );
-        for( size_t i = 0; i < m_stages.size(); ++i )
+        if( !stateLogged() )
         {
-            updateIfChanged( m_indiP_curr_state, m_stages[i].name(), std::string( "FAILURE" ) );
+            log<text_log>( "Recovering from binary stage communication error by resetting the connection.",
+                           logPrio::LOG_WARNING );
         }
 
-        log<software_critical>();
-        log<text_log>( "Binary-protocol error not due to loss of USB connection.", logPrio::LOG_CRITICAL );
+        return recoverFromError( true );
     }
 
     if( powerState() != 1 || powerStateTarget() != 1 )
@@ -905,16 +1029,7 @@ int zaberLowLevelBinary::appLogic()
 
 inline int zaberLowLevelBinary::onPowerOff()
 {
-    if( m_port > 0 )
-    {
-        int rv = zb_disconnect( m_port );
-        if( rv < 0 )
-        {
-            log<text_log>( "Error disconnecting from zaber binary system.", logPrio::LOG_ERROR );
-        }
-    }
-
-    m_port = 0;
+    resetConnection();
 
     std::lock_guard<std::mutex> lock( m_indiMutex );
     for( size_t i = 0; i < m_stages.size(); ++i )

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -144,19 +144,19 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
     /// Recover from a binary-transport error without terminating the app.
     int recoverFromError( bool devicePresent /**< [in] true if the USB tty still exists in udev */ );
 
-    /// Startup logic.
+    /// Set up the INDI properties and restore retained stage state.
     virtual int appStartup();
 
-    /// Main FSM implementation.
+    /// Execute the main FSM for `zaberLowLevelBinary`.
     virtual int appLogic();
 
-    /// Power-off transition handler.
+    /// Handle the transition into the powered-off state.
     virtual int onPowerOff();
 
-    /// Powered-off loop handler.
+    /// Execute the powered-off loop.
     virtual int whilePowerOff();
 
-    /// Shutdown handler.
+    /// Perform any shutdown tasks before exit.
     virtual int appShutdown();
 
   protected:
@@ -200,7 +200,7 @@ class zaberLowLevelBinary : public MagAOXAppT, public tty::usbDevice
     /// Per-stage emergency-halt requests.
     pcf::IndiProperty m_indiP_req_ehalt;
 
-    /// Enable or disable a stages potentiometer
+    /// Enable or disable a stage's potentiometer.
     pcf::IndiProperty m_indiP_knob_enable;
 
     ///@}
@@ -1008,7 +1008,7 @@ int zaberLowLevelBinary::appLogic()
         if( !stateLogged() )
         {
             log<text_log>( "Recovering from binary stage communication error by resetting the connection.",
-                           logPrio::LOG_WARNING );
+                           logPrio::LOG_INFO );
         }
 
         return recoverFromError( true );

--- a/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
+++ b/apps/zaberLowLevelBinary/zaberLowLevelBinary.hpp
@@ -847,7 +847,22 @@ int zaberLowLevelBinary::appLogic()
         { // mutex scope
             std::lock_guard<std::mutex> guard( m_indiMutex );
 
-            int rv = refreshStageDiscovery();
+            bool canRefreshDiscovery = true;
+            for( size_t i = 0; i < m_stages.size(); ++i )
+            {
+                if( m_stages[i].deviceAddress() > 0 && m_stages[i].deviceStatus() == 'B' )
+                {
+                    canRefreshDiscovery = false;
+                    break;
+                }
+            }
+
+            int rv = ZBC_CONNECTED;
+            if( canRefreshDiscovery )
+            {
+                rv = refreshStageDiscovery();
+            }
+
             if( rv == ZBC_ERROR )
             {
                 if( powerState() != 1 || powerStateTarget() != 1 )


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to  "Stabilize `zaberLowLevel`, keep it from dying after errors, support reconnect/rediscovery behavior, and bring `zaberLowLevelBinary` to the same standard."

## Summary

This PR hardens both low-level Zaber apps against transient communication failures and missing-stage conditions, while reducing discovery-log noise and keeping rediscovery behavior consistent between the ASCII and binary implementations.

### `zaberLowLevel`
- Fixes a discovery-path bug that could read past the parsed serial list when configured stages were missing.
- Clears stale cached device addresses before rebuilding discovery state.
- Treats communication failures as recoverable:
  - resets the port
  - transitions back to `NOTCONNECTED` or `NODEVICE`
  - allows the normal reconnect path to recover the app
- Guards stage command paths against invalid/disconnected ports.
- Adds rediscovery while in `READY`, but only when all connected stages are idle.
- Re-logs full discovery information after reconnect/power-cycle recovery.
- Reduces repeated discovery log spam:
  - missing configured stages log on first discovery or on change
  - `Found N stages` logs on first discovery or when the discovered count changes
- Rejects malformed `system.serial` snapshots with non-numeric serial tokens such as `--`, and ignores inconclusive snapshots during active stage motion.

### `zaberLowLevelBinary`
- Brings FSM recovery behavior in line with `zaberLowLevel`.
- Adds connection reset/recovery helpers and reconnectable `ERROR` handling.
- Adds change-aware rediscovery/logging behavior matching the ASCII app.
- Re-logs full discovery information after reconnect/power-cycle recovery.
- Guards binary command paths against invalid/disconnected ports.
- Skips rediscovery while any connected binary stage is still moving.

### Documentation / style
- Refreshes Doxygen/class/member documentation in both low-level headers.
- Keeps declaration grouping and named sections aligned with project conventions.

## Testing

### Unit-test coverage added/updated
- stale discovery address reset
- later device appearance on rediscovery
- recoverable transport-error transitions
- malformed `system.serial` snapshot rejection

### Validation
- Hardware testing on the feature branch looked good during iterative validation of reconnect, power-cycle, and rediscovery behavior.

## Notes
- Rediscovery is now intentionally conservative during motion: hot-plug detection waits until connected stages are idle to avoid false missing-stage reports from contaminated discovery snapshots.
- A remaining power-off race where USB power disappears before upstream power-state signaling appears to be upstream of this PR.
