### PR TITLE
Fix cameraStatus preset label lookup and `none` fallback

### DIFF
--- a/agents/plans/2026-03/stage-parking-gui-updates.md
+++ b/agents/plans/2026-03/stage-parking-gui-updates.md
@@ -74,6 +74,7 @@ Because `cameraGUI` stage rows are built from `stageStatus`, fixing the shared w
 
 In `gui/rtimv/plugins/cameraStatus/cameraStatus.cpp`:
 
+- register subscribable placeholder keys for both `presetName` and `filterName` (`device.property.element`) so `indiDictionary` actually requests those switch properties even when no other widget has subscribed to them yet
 - subscribe to each filter/stage device `parked` property in addition to `fsm.state` and preset property blobs
 - treat `POWEROFF && parked` as eligible for preset lookup, just like `READY` and `OPERATING`
 - if no preset switch is active, optionally show the parked numeric position if that is already available in the plugin dictionary; otherwise keep the existing state text fallback

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -1,11 +1,36 @@
 
 /** \file cameraStatus.cpp
  * \brief Overlay status rendering for camera-associated devices.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
  */
 
 #include "cameraStatus.hpp"
 
 #define errPrint( expl ) std::cerr << "cameraStatus: " << __FILE__ << " " << __LINE__ << " " << expl << std::endl;
+
+namespace
+{
+std::string preferredPresetProperty( const std::string &deviceName )
+{
+    if( deviceName.find( "fw" ) == 0 )
+    {
+        return "filterName";
+    }
+
+    return "presetName";
+}
+
+std::string alternatePresetProperty( const std::string &propertyName )
+{
+    if( propertyName == "filterName" )
+    {
+        return "presetName";
+    }
+
+    return "filterName";
+}
+} // namespace
 
 cameraStatus::cameraStatus() : rtimvOverlayInterface()
 {
@@ -61,20 +86,16 @@ int cameraStatus::attachOverlay( rtimvOverlayAccess &roa, mx::app::appConfigurat
         ( *m_roa.m_dictionary )[m_deviceName + ".shutter_status.status"].setBlob( nullptr, 0 );
         ( *m_roa.m_dictionary )[m_deviceName + ".shutter.toggle"].setBlob( nullptr, 0 );
 
-        m_presetNames.resize( m_filterDeviceNames.size() );
+        m_primaryPresetProperties.resize( m_filterDeviceNames.size() );
 
         for( size_t f = 0; f < m_filterDeviceNames.size(); ++f )
         {
-            if( m_filterDeviceNames[f].find( "fw" ) == 0 )
-                m_presetNames[f] = ".filterName";
-            else if( m_filterDeviceNames[f].find( "flip" ) == 0 )
-                m_presetNames[f] = ".presetName";
-            else
-                m_presetNames[f] = ".presetName";
+            m_primaryPresetProperties[f] = preferredPresetProperty( m_filterDeviceNames[f] );
 
             ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".fsm.state"].setBlob( nullptr, 0 );
             ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".parked.current"].setBlob( nullptr, 0 );
-            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + m_presetNames[f]].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".filterName.current"].setBlob( nullptr, 0 );
+            ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".presetName.current"].setBlob( nullptr, 0 );
             ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".position.current"].setBlob( nullptr, 0 );
             ( *m_roa.m_dictionary )[m_filterDeviceNames[f] + ".filter.current"].setBlob( nullptr, 0 );
         }
@@ -141,6 +162,66 @@ bool cameraStatus::getBlobStr( const std::string &deviceName, const std::string 
 bool cameraStatus::getBlobStr( const std::string &propel )
 {
     return getBlobStr( m_deviceName, propel );
+}
+
+bool cameraStatus::findActivePropertySelection( const std::string &deviceName,
+                                                const std::string &propertyName,
+                                                std::string       &selection )
+{
+    if( m_roa.m_dictionary == nullptr )
+    {
+        return false;
+    }
+
+    std::string propertyPrefix = deviceName + "." + propertyName + ".";
+
+    dictionaryIteratorT it = m_roa.m_dictionary->lower_bound( propertyPrefix );
+
+    while( it != m_roa.m_dictionary->end() )
+    {
+        if( it->first.rfind( propertyPrefix, 0 ) != 0 )
+        {
+            break;
+        }
+
+        if( ( it->second.getBlobStr( m_blob, sizeof( m_blob ) ) ) == sizeof( m_blob ) )
+        {
+            errPrint( "bad string" );
+        }
+
+        if( m_blob[0] != '\0' && std::string( m_blob ) == "on" )
+        {
+            size_t elementPos = it->first.rfind( '.' );
+
+            if( elementPos != std::string::npos && elementPos < it->first.size() - 1 )
+            {
+                selection = it->first.substr( elementPos + 1 );
+                return true;
+            }
+        }
+
+        ++it;
+    }
+
+    return false;
+}
+
+bool cameraStatus::findActivePresetSelection( size_t deviceIndex, std::string &selection )
+{
+    if( deviceIndex >= m_filterDeviceNames.size() || deviceIndex >= m_primaryPresetProperties.size() )
+    {
+        return false;
+    }
+
+    if( findActivePropertySelection(
+            m_filterDeviceNames[deviceIndex], m_primaryPresetProperties[deviceIndex], selection ) )
+    {
+        return true;
+    }
+
+    return findActivePropertySelection( m_filterDeviceNames[deviceIndex],
+                                        alternatePresetProperty( m_primaryPresetProperties[deviceIndex] ),
+                                        selection );
 }
 
 template <>
@@ -361,33 +442,11 @@ int cameraStatus::updateOverlay()
                               fwstate == "LOGGEDIN" || fwstate == "CONFIGURING" || fwstate == "CONNECTED" ||
                               fwstate == "NOTHOMED" ) ) )
             {
-                dictionaryIteratorT start =
-                    m_roa.m_dictionary->lower_bound( m_filterDeviceNames[f] + m_presetNames[f] );
-                dictionaryIteratorT end =
-                    m_roa.m_dictionary->upper_bound( m_filterDeviceNames[f] + m_presetNames[f] + "Z" );
-
-                std::string fkey;
-                while( start != end )
-                {
-                    if( ( start->second.getBlobStr( m_blob, sizeof( m_blob ) ) ) == sizeof( m_blob ) )
-                        errPrint( "bad string" ); // Don't trust this as a string
-
-                    if( m_blob[0] != '\0' )
-                    {
-                        if( std::string( m_blob ) == "on" )
-                        {
-                            fkey = start->first;
-                            break;
-                        }
-                    }
-                    ++start;
-                }
-
-                size_t      pp = fkey.rfind( '.' );
                 std::string filn;
-                if( pp != std::string::npos && pp < fkey.size() - 1 ) // need to be able to add 1
+
+                if( findActivePresetSelection( f, filn ) )
                 {
-                    filn = m_filterDeviceNames[f] + ": " + fkey.substr( pp + 1 ).c_str();
+                    filn = m_filterDeviceNames[f] + ": " + filn;
                 }
                 else
                 {

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -444,7 +444,7 @@ int cameraStatus::updateOverlay()
             {
                 std::string filn;
 
-                if( findActivePresetSelection( f, filn ) )
+                if( findActivePresetSelection( f, filn ) && filn != "none" )
                 {
                     filn = m_filterDeviceNames[f] + ": " + filn;
                 }

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
@@ -1,84 +1,139 @@
+/** \file cameraStatus.hpp
+ * \brief Declares the camera-status rtimv overlay plugin.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ */
+
 #ifndef cameraStatus_hpp
 #define cameraStatus_hpp
 
 #include <rtimv/rtimvInterfaces.hpp>
 #include <rtimv/StretchBox.hpp>
 
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include <QObject>
 #include <QtPlugin>
-// #include <QGraphicsLineItem>
 
 #include <iostream>
 
+/// Overlay plugin which renders camera telemetry and associated stage status.
 class cameraStatus : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
-    Q_INTERFACES(rtimvOverlayInterface)
+    Q_PLUGIN_METADATA( IID "rtimv.overlayInterface/1.4" )
+    Q_INTERFACES( rtimvOverlayInterface )
 
-protected:
+  protected:
+    /// Access to selected rtimv GUI and dictionary state.
     rtimvOverlayAccess m_roa;
 
-    bool m_enabled{false};
+    /// True when the plugin is currently allowed to update state.
+    bool m_enabled{ false };
 
-    bool m_enableable{false};
+    /// True when configuration was sufficient to enable this plugin.
+    bool m_enableable{ false };
 
+    /// Camera device prefix used when forming dictionary keys.
     std::string m_deviceName;
 
+    /// Associated filter-wheel or stage device names shown in the overlay.
     std::vector<std::string> m_filterDeviceNames;
-    std::vector<std::string> m_presetNames; //one per filter device, based on its name
+    /// Preferred preset-property name to check first for each associated device.
+    std::vector<std::string> m_primaryPresetProperties;
 
-    QGraphicsScene *m_qgs{nullptr};
+    /// Cached graphics scene used for ROI-box lifetime management.
+    QGraphicsScene *m_qgs{ nullptr };
 
-    StretchBox *m_roiBox{nullptr};
+    /// Pending ROI box used to preview target subframes.
+    StretchBox *m_roiBox{ nullptr };
 
+    /// Protects creation, updates, and removal of the preview ROI box.
     std::mutex m_roiBoxMutex;
 
-    char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
+    /// Scratch buffer used when copying dictionary blobs as strings.
+    char m_blob[512];
 
-    int m_width{0};
-    int m_height{0};
+    /// Cached detector width used when mapping ROI coordinates into the view.
+    int m_width{ 0 };
+    /// Cached detector height used when mapping ROI coordinates into the view.
+    int m_height{ 0 };
 
-public:
+  public:
+    /// Construct the camera-status plugin.
     cameraStatus();
 
+    /// Destruct the camera-status plugin.
     virtual ~cameraStatus();
 
-    virtual int attachOverlay(rtimvOverlayAccess &,
-                              mx::app::appConfigurator &config);
+    /// Attach the overlay plugin to rtimv.
+    virtual int
+    attachOverlay( rtimvOverlayAccess       &roa, /**< [in] exposed main-window, graphics-view, and dictionary access */
+                   mx::app::appConfigurator &config /**< [in] configuration source for plugin options */
+    );
 
+    /// Update the overlay text and ROI preview from the current dictionary values.
     virtual int updateOverlay();
 
-    virtual void keyPressEvent(QKeyEvent *ke);
+    /// Handle key presses passed through by rtimv.
+    virtual void keyPressEvent( QKeyEvent *ke /**< [in] key event to inspect */ );
 
+    /// Report whether this overlay is currently enabled.
     virtual bool overlayEnabled();
 
-    bool blobExists(const std::string & propel);
+    /// Return true when the camera dictionary entry exists and currently holds data.
+    bool blobExists( const std::string &propel /**< [in] camera property.element suffix to inspect */ );
 
-    bool getBlobStr(const std::string &deviceName,
-                    const std::string &propel);
+    /// Copy a device property value into the internal string buffer.
+    bool getBlobStr( const std::string &deviceName, /**< [in] device prefix used when forming the dictionary key */
+                     const std::string &propel      /**< [in] property.element suffix to copy from the dictionary */
+    );
 
-    bool getBlobStr(const std::string &propel);
+    /// Copy a camera property value into the internal string buffer.
+    bool getBlobStr( const std::string &propel /**< [in] camera property.element suffix to copy */ );
 
+    /// Return a numeric dictionary value or a supplied default.
     template <typename realT>
-    realT getBlobVal(const std::string &propel, realT defVal);
+    realT getBlobVal( const std::string &propel, /**< [in] camera property.element suffix to convert */
+                      realT              defVal  /**< [in] default value returned when the blob is unavailable */
+    );
 
+    /// Enable the overlay if configuration allows it.
     virtual void enableOverlay();
 
+    /// Disable the overlay and clear any status text it owns.
     virtual void disableOverlay();
 
-signals:
+  signals:
+    /// Request insertion of a newly created ROI preview box into the scene.
+    void newStretchBox( StretchBox *sb /**< [in] ROI preview box to add to the view */ );
 
-    void newStretchBox(StretchBox *);
+    /// Report the current save-state indicator for the camera stream.
+    void savingState( rtimv::savingState state /**< [in] current save-state display mode */ );
 
-    void savingState(rtimv::savingState);
+  public slots:
+    /// Clear the cached ROI preview pointer when the view removes it.
+    void stretchBoxRemove( StretchBox *sb /**< [in] ROI box being removed from the scene */ );
 
-public slots:
-
-    void stretchBoxRemove(StretchBox * );
-
-public:
+  public:
+    /// Return user-visible plugin information for the `i` overlay.
     virtual std::vector<std::string> info();
+
+  protected:
+    /// Return true when the named switch property exposes an active element.
+    bool findActivePropertySelection(
+        const std::string &deviceName,   /**< [in] associated filter or stage device name */
+        const std::string &propertyName, /**< [in] switch-property name such as `presetName` or `filterName` */
+        std::string       &selection     /**< [out] active element name when one switch is on */
+    );
+
+    /// Return true when any known preset property exposes an active element.
+    bool findActivePresetSelection( size_t       deviceIndex, /**< [in] index of the associated device being rendered */
+                                    std::string &selection    /**< [out] active element name when one switch is on */
+    );
 };
 
 #endif // cameraStatus_hpp


### PR DESCRIPTION

This work was performed by Codex in response to the prompt: "the stage entries in the gui/rtimv/plugins/cameraStatus overlay are always showing positions rather than preset names, at least on some displays... if \"none\" is selected as the presetName, then it should show numeric position."

## Summary
This updates the `cameraStatus` rtimv overlay so stage/filter entries prefer active preset labels reliably and only fall back to numeric position when appropriate.

Specifically, this change:
- registers subscribable placeholder keys for both `presetNaFix cameraStatus preset label lookup and `none` fallbackme` and `filterName` so `indiDictionary` actually requests those switch properties
- checks both preset-property families when resolving the active stage/filter label
- preserves the numeric-position fallback when no usable preset label is active
- treats an active preset label of `none` as a fallback case and shows numeric position instead

## Files Changed
- `gui/rtimv/plugins/cameraStatus/cameraStatus.cpp`
- `gui/rtimv/plugins/cameraStatus/cameraStatus.hpp`
- `agents/plans/2026-03/stage-parking-gui-updates.md`

## Verification
- `make -C gui/rtimv/plugins/cameraStatus`
- runtime-tested in the affected GUI workflow; stage entries now show preset names correctly, and `none` falls back to numeric position
