### PR TITLE
Fix cameraStatus save box updates and add real status-text overflow warnings

### DIFF
--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -267,12 +267,14 @@ int cameraStatus::updateOverlay()
     std::string sstr;
     bool        statusTextOverflowed{ false };
 
-    auto statusTextSlotAvailable = [&]( size_t slotIndex )
+    auto appendStatusText = [&]( const char *text )
     {
         size_t slotCount = m_roa.m_graphicsView->statusTextNo();
 
-        if( slotIndex < slotCount )
+        if( n < slotCount )
         {
+            m_roa.m_graphicsView->statusTextText( n, text );
+            ++n;
             return true;
         }
 
@@ -280,10 +282,8 @@ int cameraStatus::updateOverlay()
 
         if( !m_statusTextOverflowWarned )
         {
-            pluginLogError( std::format( "status text overflow for {}: need slot {}, only {} configured",
-                                         m_deviceName,
-                                         slotIndex + 1,
-                                         slotCount ) );
+            pluginLogError( std::format(
+                "status text overflow for {}: need slot {}, only {} configured", m_deviceName, n + 1, slotCount ) );
             m_statusTextOverflowWarned = true;
         }
 
@@ -325,11 +325,9 @@ int cameraStatus::updateOverlay()
     if( getBlobStr( "temp_ccd.current" ) )
     {
         snprintf( tstr, sizeof( tstr ), "%0.1f C", strtod( m_blob, 0 ) );
-        m_roa.m_graphicsView->statusTextText( n, tstr );
-        ++n;
+        if( !appendStatusText( tstr ) )
+            return 0;
     }
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
 
     // Get curr size
     m_width = -1;
@@ -361,8 +359,8 @@ int cameraStatus::updateOverlay()
             snprintf( tstr, sizeof( tstr ), "%dx%d [%dx%d]", w, h, ibx, iby );
 
             //****************
-            m_roa.m_graphicsView->statusTextText( n, tstr );
-            ++n;
+            if( !appendStatusText( tstr ) )
+                return 0;
 
             float bx = ibx;
             float by = iby;
@@ -424,9 +422,6 @@ int cameraStatus::updateOverlay()
     } // if(blobExists("roi_region_w.current") ...
 
     //***********************
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
-
     float et = getBlobVal<float>( "exptime.current", -1 );
     if( et >= 0 )
     {
@@ -454,31 +449,25 @@ int cameraStatus::updateOverlay()
             }
         }
 
-        m_roa.m_graphicsView->statusTextText( n, tstr );
-        ++n;
+        if( !appendStatusText( tstr ) )
+            return 0;
     }
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
 
     float fps = getBlobVal<float>( "fps.current", -1 );
     if( fps >= 0 )
     {
         snprintf( tstr, sizeof( tstr ), "%0.1f FPS", fps );
-        m_roa.m_graphicsView->statusTextText( n, tstr );
-        ++n;
+        if( !appendStatusText( tstr ) )
+            return 0;
     }
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
 
     int emg = getBlobVal<int>( "emgain.current", -1 );
     if( emg >= 0 )
     {
         snprintf( tstr, sizeof( tstr ), "EMG: %d", emg );
-        m_roa.m_graphicsView->statusTextText( n, tstr );
-        ++n;
+        if( !appendStatusText( tstr ) )
+            return 0;
     }
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
 
     for( size_t f = 0; f < m_filterDeviceNames.size(); ++f )
     {
@@ -530,18 +519,16 @@ int cameraStatus::updateOverlay()
                         filn = m_filterDeviceNames[f] + ": unk";
                     }
                 }
-                m_roa.m_graphicsView->statusTextText( n, filn.c_str() );
-                ++n;
+                if( !appendStatusText( filn.c_str() ) )
+                    return 0;
             }
             else
             {
                 fwstate = m_filterDeviceNames[f] + ": " + fwstate;
-                m_roa.m_graphicsView->statusTextText( n, fwstate.c_str() );
-                ++n;
+                if( !appendStatusText( fwstate.c_str() ) )
+                    return 0;
             }
         }
-        if( !statusTextSlotAvailable( n ) )
-            return 0;
     }
 
     if( getBlobStr( "shutter_status.status" ) )
@@ -557,20 +544,18 @@ int cameraStatus::updateOverlay()
                     sstr = "sh SHUT";
                 else
                     sstr = "sh OPEN";
-                m_roa.m_graphicsView->statusTextText( n, sstr.c_str() );
-                ++n;
+                if( !appendStatusText( sstr.c_str() ) )
+                    return 0;
             }
         }
         else
         {
 
             sstr = "sh " + sstr;
-            m_roa.m_graphicsView->statusTextText( n, sstr.c_str() );
-            ++n;
+            if( !appendStatusText( sstr.c_str() ) )
+                return 0;
         }
     }
-    if( !statusTextSlotAvailable( n ) )
-        return 0;
 
     if( !statusTextOverflowed )
     {

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -184,6 +184,62 @@ int cameraStatus::updateOverlay()
     // char * str;
     char        tstr[128];
     std::string sstr;
+    bool        statusTextOverflowed{ false };
+
+    auto statusTextSlotAvailable = [&]( size_t slotIndex )
+    {
+        size_t slotCount = m_roa.m_graphicsView->statusTextNo();
+
+        if( slotIndex < slotCount )
+        {
+            return true;
+        }
+
+        statusTextOverflowed = true;
+
+        if( !m_statusTextOverflowWarned )
+        {
+            pluginLogError( std::format( "status text overflow for {}: need slot {}, only {} configured",
+                                         m_deviceName,
+                                         slotIndex + 1,
+                                         slotCount ) );
+            m_statusTextOverflowWarned = true;
+        }
+
+        return false;
+    };
+
+    if( getBlobStr( m_deviceName + "-sw", "fsm.state" ) )
+    {
+        std::string fsmstr = std::string( m_blob );
+
+        std::string swtstr = "off";
+
+        if( getBlobStr( m_deviceName + "-sw", "writing.toggle" ) )
+        {
+            swtstr = std::string( m_blob );
+        }
+
+        if( fsmstr == "OPERATING" )
+        {
+            if( swtstr == "on" )
+            {
+                emit savingState( rtimv::savingState::on );
+            }
+            else
+            {
+                emit savingState( rtimv::savingState::waiting );
+            }
+        }
+        else
+        {
+            emit savingState( rtimv::savingState::off );
+        }
+    }
+    else
+    {
+        emit savingState( rtimv::savingState::off );
+    }
 
     if( getBlobStr( "temp_ccd.current" ) )
     {
@@ -191,7 +247,7 @@ int cameraStatus::updateOverlay()
         m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
     // Get curr size
@@ -287,7 +343,7 @@ int cameraStatus::updateOverlay()
     } // if(blobExists("roi_region_w.current") ...
 
     //***********************
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
     float et = getBlobVal<float>( "exptime.current", -1 );
@@ -320,7 +376,7 @@ int cameraStatus::updateOverlay()
         m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
     float fps = getBlobVal<float>( "fps.current", -1 );
@@ -330,7 +386,7 @@ int cameraStatus::updateOverlay()
         m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
     int emg = getBlobVal<int>( "emgain.current", -1 );
@@ -340,7 +396,7 @@ int cameraStatus::updateOverlay()
         m_roa.m_graphicsView->statusTextText( n, tstr );
         ++n;
     }
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
     for( size_t f = 0; f < m_filterDeviceNames.size(); ++f )
@@ -425,7 +481,7 @@ int cameraStatus::updateOverlay()
                 ++n;
             }
         }
-        if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+        if( !statusTextSlotAvailable( n ) )
             return 0;
     }
 
@@ -454,39 +510,12 @@ int cameraStatus::updateOverlay()
             ++n;
         }
     }
-    if( n > m_roa.m_graphicsView->statusTextNo() - 1 )
+    if( !statusTextSlotAvailable( n ) )
         return 0;
 
-    if( getBlobStr( m_deviceName + "-sw", "fsm.state" ) )
+    if( !statusTextOverflowed )
     {
-        std::string fsmstr = std::string( m_blob );
-
-        std::string swtstr = "off";
-
-        if( getBlobStr( m_deviceName + "-sw", "writing.toggle" ) )
-        {
-            swtstr = std::string( m_blob );
-        }
-
-        if( fsmstr == "OPERATING" )
-        {
-            if( swtstr == "on" )
-            {
-                emit savingState( rtimv::savingState::on );
-            }
-            else
-            {
-                emit savingState( rtimv::savingState::waiting );
-            }
-        }
-        else
-        {
-            emit savingState( rtimv::savingState::off );
-        }
-    }
-    else
-    {
-        emit savingState( rtimv::savingState::off );
+        m_statusTextOverflowWarned = false;
     }
 
     return 0;

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.cpp
@@ -484,6 +484,10 @@ int cameraStatus::updateOverlay()
             emit savingState( rtimv::savingState::off );
         }
     }
+    else
+    {
+        emit savingState( rtimv::savingState::off );
+    }
 
     return 0;
 }

--- a/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
+++ b/gui/rtimv/plugins/cameraStatus/cameraStatus.hpp
@@ -13,71 +13,71 @@
 class cameraStatus : public rtimvOverlayInterface
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "rtimv.overlayInterface/1.4")
-    Q_INTERFACES(rtimvOverlayInterface)
+    Q_PLUGIN_METADATA( IID "rtimv.overlayInterface/1.4" )
+    Q_INTERFACES( rtimvOverlayInterface )
 
-protected:
+  protected:
     rtimvOverlayAccess m_roa;
 
-    bool m_enabled{false};
+    bool m_enabled{ false };
 
-    bool m_enableable{false};
+    bool m_enableable{ false };
 
     std::string m_deviceName;
 
     std::vector<std::string> m_filterDeviceNames;
-    std::vector<std::string> m_presetNames; //one per filter device, based on its name
+    std::vector<std::string> m_presetNames; // one per filter device, based on its name
 
-    QGraphicsScene *m_qgs{nullptr};
+    QGraphicsScene *m_qgs{ nullptr };
 
-    StretchBox *m_roiBox{nullptr};
+    StretchBox *m_roiBox{ nullptr };
 
     std::mutex m_roiBoxMutex;
 
     char m_blob[512]; ///< Memory for copying rtimvDictionary blobs
 
-    int m_width{0};
-    int m_height{0};
+    int m_width{ 0 };
+    int m_height{ 0 };
 
-public:
+    bool m_statusTextOverflowWarned{ false }; ///< True after logging one status-text overflow warning.
+
+  public:
     cameraStatus();
 
     virtual ~cameraStatus();
 
-    virtual int attachOverlay(rtimvOverlayAccess &,
-                              mx::app::appConfigurator &config);
+    virtual int attachOverlay( rtimvOverlayAccess &, mx::app::appConfigurator &config );
 
     virtual int updateOverlay();
 
-    virtual void keyPressEvent(QKeyEvent *ke);
+    virtual void keyPressEvent( QKeyEvent *ke );
 
     virtual bool overlayEnabled();
 
-    bool blobExists(const std::string & propel);
+    bool blobExists( const std::string &propel );
 
-    bool getBlobStr(const std::string &deviceName,
-                    const std::string &propel);
+    bool getBlobStr( const std::string &deviceName, const std::string &propel );
 
-    bool getBlobStr(const std::string &propel);
+    bool getBlobStr( const std::string &propel );
 
     template <typename realT>
-    realT getBlobVal(const std::string &propel, realT defVal);
+    realT getBlobVal( const std::string &propel, realT defVal );
 
     virtual void enableOverlay();
 
     virtual void disableOverlay();
 
-signals:
+  signals:
 
-    void newStretchBox(StretchBox *);
+    void newStretchBox( StretchBox * );
 
-    void savingState(rtimv::savingState);
+    void savingState( rtimv::savingState );
 
-public slots:
+  public slots:
 
-    void stretchBoxRemove(StretchBox * );
+    void stretchBoxRemove( StretchBox * );
 
-public:
+  public:
     virtual std::vector<std::string> info();
 };
 


### PR DESCRIPTION
This work was performed by Codex 5.4.

## Summary
This updates the `cameraStatus` rtimv overlay to make the save box reliable across `rtimv` and `rtimvClient`, and to report real status-text overflow instead of failing silently.

## Root Cause
The save-box issue was not the same subscription bug as the earlier preset-name problem.

`cameraStatus::updateOverlay()` updated the save state near the end of the function, but the function could return early when the status-text grid filled up. In configurations with one more stage line, the overlay could exit before reaching the save-state code, which led to:
- stale `X`/`S` state in some `rtimv` sessions
- blank save box in some `rtimvClient` sessions
- apparently correct behavior in layouts with one fewer status line

## Changes
- move the save-state update so it runs before any status-text early returns
- keep the explicit fallback to `savingState::off` when the streamwriter FSM state is unavailable
- add a one-shot overflow warning for the status-text grid in `cameraStatus`
- tighten the overflow logic so the warning only fires when a real write would exceed the configured number of status slots, not just when the next slot might be needed
- preserve the newer `cameraStatus` header/docs and preset-selection helpers while resolving the `dev` merge conflict

## Files Changed
- `gui/rtimv/plugins/cameraStatus/cameraStatus.cpp`
- `gui/rtimv/plugins/cameraStatus/cameraStatus.hpp`
- `agents/plans/2026-03/stage-parking-gui-updates.md`

## Verification
- `make -C gui/rtimv/plugins/cameraStatus`
- verified behavior across:
  - `rtimv -c rtimv_camsci1.conf`
  - `rtimvClient -c rtimv_camsci1.conf`
  - `rtimvClient -c rtimv_camsci1_avg.conf`

## Notes
The overflow warning now reflects actual dropped status lines rather than boundary conditions where the last valid slot was filled but no additional line was ultimately written.
