### PR TITLE
Accept zero-flow IPMI status in flowRPM

### DIFF
--- a/agents/plans/2026-04/flowRPM-app.md
+++ b/agents/plans/2026-04/flowRPM-app.md
@@ -75,7 +75,8 @@ The original prompt leaves a few points ambiguous. This plan resolves them as fo
 - the parser should validate that the units token in the file is literally `RPM`
   - even though the numeric value is then converted as though it represents `mL/min`
   - this preserves the explicit requested parse check while following the requested conversion behavior
-- the status token requirement is interpreted as requiring the literal token `'OK'`
+- the status token requirement accepts the literal token `'OK'` and the IPMI zero-flow threshold token
+  - `'At or Below (<=) Lower Non-Recoverable Threshold'` is treated as a valid zero-flow reading
   - any other status string is a parse failure
 - `status.flow_rate` and `status.age` should be implemented as two elements of a single RO INDI number property named `status`
 - `status.age` should be computed from the timestamp in line 1, not from filesystem metadata
@@ -199,7 +200,7 @@ Split the app-specific logic so tests can cover it without depending on the full
 4. Semantic validation
    - descriptor must equal configured `m_fanDescriptor`
    - units must equal `RPM`
-   - status must equal `'OK'`
+   - status must equal `'OK'` or the IPMI zero-flow threshold token
    - numeric field must parse as `double`
 
 5. Conversion

--- a/apps/flowRPM/flowRPM.hpp
+++ b/apps/flowRPM/flowRPM.hpp
@@ -285,6 +285,12 @@ inline std::vector<std::string> splitPipeDelimited( const std::string &line )
     return fields;
 }
 
+/// Determine whether the IPMI sensor status token represents a valid flow reading.
+inline bool isValidStatusField( const std::string &statusField )
+{
+    return statusField == "'OK'" || statusField == "'At or Below (<=) Lower Non-Recoverable Threshold'";
+}
+
 /// Split file contents into non-empty logical lines.
 inline std::vector<std::string> splitLogicalLines( const std::string &contents )
 {
@@ -515,7 +521,7 @@ inline flowRPM::parseStatus flowRPM::parseRecordLine( double &flowRate, const st
         return parseStatus::wrongUnits;
     }
 
-    if( fields[5] != "'OK'" )
+    if( !flowRPMDetail::isValidStatusField( fields[5] ) )
     {
         return parseStatus::badStatus;
     }

--- a/apps/flowRPM/tests/flowRPM_test.cpp
+++ b/apps/flowRPM/tests/flowRPM_test.cpp
@@ -310,6 +310,15 @@ TEST_CASE( "flowRPM record-line parsing covers all parse branches", "[flowRPM]" 
         REQUIRE( flowRate == Approx( 1.9 ) );
     }
 
+    SECTION( "the zero-flow threshold status is accepted as a valid reading" )
+    {
+        REQUIRE(
+            app.parseRecordLine(
+                flowRate, "36 | CHA_FAN1 | Fan | 0.00 | RPM | 'At or Below (<=) Lower Non-Recoverable Threshold'" ) ==
+            flowRPM::parseStatus::success );
+        REQUIRE( flowRate == Approx( 0.0 ) );
+    }
+
     SECTION( "the wrong field count is rejected" )
     {
         REQUIRE( app.parseRecordLine( flowRate, "36 | CHA_FAN1 | Fan | 1900.00 | RPM" ) ==
@@ -376,6 +385,18 @@ TEST_CASE( "flowRPM file parsing", "[flowRPM]" )
         REQUIRE( app.parseFileContents( result, contents, now ) == 0 );
         REQUIRE( result.m_status == flowRPM::parseStatus::success );
         REQUIRE( result.m_flowRate == Approx( 1.9 ) );
+        REQUIRE( result.m_age == Approx( 3.0 ) );
+    }
+
+    SECTION( "zero-flow threshold status parses as a valid zero reading" )
+    {
+        const std::string contents = "1775430287 145131374\n"
+                                     "36 | CHA_FAN1         | Fan          | 0.00       | RPM   | "
+                                     "'At or Below (<=) Lower Non-Recoverable Threshold'\n";
+
+        REQUIRE( app.parseFileContents( result, contents, now ) == 0 );
+        REQUIRE( result.m_status == flowRPM::parseStatus::success );
+        REQUIRE( result.m_flowRate == Approx( 0.0 ) );
         REQUIRE( result.m_age == Approx( 3.0 ) );
     }
 


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "when the flowRPM app is reading 0 flow, the IPMI result will say 'At or Below (<=) Lower Non-Recoverable Threshold' instead of 'Ok'. We should treat this as valid instead of an error, so that we just report 0.0 LPM"

## Summary
- accept the IPMI lower non-recoverable threshold status as a valid `flowRPM` sensor state
- continue converting the reported value to LPM so zero flow publishes as `0.0`
- add unit-test coverage for both direct record parsing and full file parsing of the zero-flow case
- update the flowRPM planning note so the documented parsing behavior matches the implementation

## Why
When the source sensor reports zero flow, IPMI returns a threshold-status string instead of `'OK'`. `flowRPM` was treating that status as a parse failure and publishing the bad-value sentinel instead of a valid zero reading.

## Validation
- `clang-format -i apps/flowRPM/flowRPM.hpp apps/flowRPM/tests/flowRPM_test.cpp`
- `make -C /home/jrmales/Source/MagAOX/apps/flowRPM`

## Edge Cases
- this remains intentionally narrow: only `'OK'` and `'At or Below (<=) Lower Non-Recoverable Threshold'` are accepted as valid statuses
