### PR TITLE
Stabilize GUI widget state handling and motion recovery

### DIFF
--- a/Make/magAOXGUI.mk
+++ b/Make/magAOXGUI.mk
@@ -28,6 +28,14 @@ ifeq "$(QMAKE_PATH)" ""
   QMAKE=qmake-qt5
 endif
 
+QMAKE_PROJECT := $(TARGET).pro
+QMAKE_MAKEFILE := makefile.$(TARGET)
+
+# Most GUIs share the common qmake settings in gui/apps/magaoxQtApp.pri.
+# Generate the qmake makefile only when those inputs change instead of
+# regenerating it on every install pass.
+QMAKE_DEPS := $(QMAKE_PROJECT) ../magaoxQtApp.pri
+
 
 ##############################
 
@@ -35,17 +43,19 @@ endif
 all: $(TARGET)
 
 .PHONY: $(TARGET)
-$(TARGET):
-	$(QMAKE) -makefile $(TARGET).pro
-	$(MAKE) -f makefile.$(TARGET)
+$(TARGET): $(QMAKE_MAKEFILE)
+	$(MAKE) -f $(QMAKE_MAKEFILE)
+
+$(QMAKE_MAKEFILE): $(QMAKE_DEPS)
+	$(QMAKE) -makefile $(QMAKE_PROJECT)
 
 install: $(TARGET)
 	sudo install bin/$(TARGET) /usr/local/bin
 
 clean:
-ifneq (,$(wildcard ./makefile.$(TARGET)))  #Test if the generated makefile exists to avoid errors on 2nd make clean
-	$(MAKE) -f makefile.$(TARGET) distclean
+ifneq (,$(wildcard ./$(QMAKE_MAKEFILE)))  #Test if the generated makefile exists to avoid errors on 2nd make clean
+	$(MAKE) -f $(QMAKE_MAKEFILE) distclean
 endif
 	rm -f *~
 	rm -f bin/$(TARGET)
-	rm -rf bin moc obj res
+	rm -rf bin moc obj res ui

--- a/gui/apps/magaoxQtApp.pri
+++ b/gui/apps/magaoxQtApp.pri
@@ -7,7 +7,9 @@ INCLUDEPATH += ../../lib ../../widgets ../../widgets/xWidgets
 MOC_DIR = moc/
 OBJECTS_DIR = obj/
 RCC_DIR = res/
-UI_DIR = ../../widgets/pwr
+# Keep generated ui_*.h files local to each GUI build so one GUI does not
+# dirty another GUI's dependencies during a later build or install pass.
+UI_DIR = ui/
 
 CONFIG(release, debug|release) {
     CONFIG += optimize_full

--- a/gui/apps/pwr/pwrGUI.pro
+++ b/gui/apps/pwr/pwrGUI.pro
@@ -6,6 +6,8 @@ TARGET = pwrGUI
 include(../magaoxQtApp.pri)
 
 # Input
+INCLUDEPATH += ../../widgets/pwr
+
 HEADERS += ../../widgets/xWidgets/app.hpp \
            ../../widgets/xWidgets/xWidget.hpp \
            ../../widgets/pwr/pwr.hpp \

--- a/gui/widgets/coronAlign/coronAlign.hpp
+++ b/gui/widgets/coronAlign/coronAlign.hpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <QWidget>
+#include <QElapsedTimer>
 #include <QMutex>
 #include <QTimer>
 
@@ -25,88 +26,127 @@ class coronAlign : public xWidget
 protected:
    QMutex m_mutex;
 
-   int m_camera {CAMSCIS};
+   int m_camera{ CAMSCIS };
 
-   //Pico Motors
+   // Pico Motors
    std::string m_picoState;
+   /// Tracks a just-issued pico move until the controller publishes an FSM update.
+   bool m_picoCommandPending{ false };
+   /// Timeout interval in milliseconds before a non-pico pending latch requests a refresh or falls back locally.
+   static constexpr int m_pendingTimeoutMs{ 2000 };
 
-   //Pupil Plane
+   // Pupil Plane
 
    std::string m_fwPupilState;
-
+   /// Tracks a just-issued pupil filter-wheel move until the controller publishes an FSM update.
+   bool m_fwPupilCommandPending{ false };
+   /// Measures how long the current pupil filter-wheel pending latch has been active.
+   QElapsedTimer m_fwPupilPendingTimer;
+   /// Records whether the GUI has already requested a fresh pupil filter-wheel status during this pending latch.
+   bool m_fwPupilPendingRefreshRequested{ false };
+   /// Last pupil filter-wheel target requested by the GUI.
+   double m_fwPupilTarget{ 0 };
 
    double m_fwPupilPos;
-   long m_picoPupilPos;
+   long   m_picoPupilPos;
 
-   double m_fwPupilStepSize {0.0001};
-   double m_picoPupilStepSize {100};
+   double m_fwPupilStepSize{ 0.0001 };
+   double m_picoPupilStepSize{ 100 };
 
-   int m_pupilScale {100};
+   int m_pupilScale{ 100 };
 
-   //Focal Plane
+   // Focal Plane
 
    std::string m_fwFocalState;
-
+   /// Tracks a just-issued focal filter-wheel move until the controller publishes an FSM update.
+   bool m_fwFocalCommandPending{ false };
+   /// Measures how long the current focal filter-wheel pending latch has been active.
+   QElapsedTimer m_fwFocalPendingTimer;
+   /// Records whether the GUI has already requested a fresh focal filter-wheel status during this pending latch.
+   bool m_fwFocalPendingRefreshRequested{ false };
+   /// Last focal filter-wheel target requested by the GUI.
+   double m_fwFocalTarget{ 0 };
 
    double m_fwFocalPos;
-   long m_picoFocalPos;
+   long   m_picoFocalPos;
 
-   double m_fwFocalStepSize {0.0001};
-   double m_picoFocalStepSize {100};
+   double m_fwFocalStepSize{ 0.0001 };
+   double m_picoFocalStepSize{ 100 };
 
-   int m_focalScale {100};
+   int m_focalScale{ 100 };
 
-   //Lyot Plane
+   // Lyot Plane
 
    std::string m_fwLyotState;
-
+   /// Tracks a just-issued Lyot filter-wheel move until the controller publishes an FSM update.
+   bool m_fwLyotCommandPending{ false };
+   /// Measures how long the current Lyot filter-wheel pending latch has been active.
+   QElapsedTimer m_fwLyotPendingTimer;
+   /// Records whether the GUI has already requested a fresh Lyot filter-wheel status during this pending latch.
+   bool m_fwLyotPendingRefreshRequested{ false };
+   /// Last Lyot filter-wheel target requested by the GUI.
+   double m_fwLyotTarget{ 0 };
 
    double m_fwLyotPos;
-   long m_picoLyotPos;
+   long   m_picoLyotPos;
 
-   double m_fwLyotStepSize {0.0001};
-   double m_picoLyotStepSize {100};
+   double m_fwLyotStepSize{ 0.0001 };
+   double m_picoLyotStepSize{ 100 };
 
-   int m_lyotScale {100};
+   int m_lyotScale{ 100 };
 
-    //PIAA
-    std::string m_piaaState;
-    double m_piaaPos;
-    int m_piaaScale {1};
-    double m_piaaStepSize {0.1};
+   // PIAA
+   std::string m_piaaState;
+   /// Tracks a just-issued PIAA stage move until the controller publishes an FSM update.
+   bool m_piaaCommandPending{ false };
+   /// Measures how long the current PIAA stage pending latch has been active.
+   QElapsedTimer m_piaaPendingTimer;
+   /// Records whether the GUI has already requested a fresh PIAA stage status during this pending latch.
+   bool m_piaaPendingRefreshRequested{ false };
+   /// Last PIAA stage target requested by the GUI.
+   double m_piaaTarget{ 0 };
+   double m_piaaPos;
+   int    m_piaaScale{ 1 };
+   double m_piaaStepSize{ 0.1 };
 
-    //PIAA0;
-    long m_piaa0xPos;
-    int m_piaa0Scale {1};
-    double m_piaa0StepSize {20};
+   // PIAA0;
+   long   m_piaa0xPos;
+   int    m_piaa0Scale{ 1 };
+   double m_piaa0StepSize{ 20 };
 
-    //PIAA1;
-    long m_piaa1xPos;
-    long m_piaa1yPos;
-    int m_piaa1Scale {1};
-    double m_piaa1StepSize {20};
+   // PIAA1;
+   long   m_piaa1xPos;
+   long   m_piaa1yPos;
+   int    m_piaa1Scale{ 1 };
+   double m_piaa1StepSize{ 20 };
 
-    //iPIAA
-    std::string m_ipiaaState;
-    double m_ipiaaPos;
-    int m_ipiaaScale {1};
-    double m_ipiaaStepSize {0.1};
+   // iPIAA
+   std::string m_ipiaaState;
+   /// Tracks a just-issued iPIAA stage move until the controller publishes an FSM update.
+   bool m_ipiaaCommandPending{ false };
+   /// Measures how long the current iPIAA stage pending latch has been active.
+   QElapsedTimer m_ipiaaPendingTimer;
+   /// Records whether the GUI has already requested a fresh iPIAA stage status during this pending latch.
+   bool m_ipiaaPendingRefreshRequested{ false };
+   /// Last iPIAA stage target requested by the GUI.
+   double m_ipiaaTarget{ 0 };
+   double m_ipiaaPos;
+   int    m_ipiaaScale{ 1 };
+   double m_ipiaaStepSize{ 0.1 };
 
-    //iPIAA0;
-    long m_ipiaa0xPos;
-    int m_ipiaa0Scale {1};
-    double m_ipiaa0StepSize {20};
+   // iPIAA0;
+   long   m_ipiaa0xPos;
+   int    m_ipiaa0Scale{ 1 };
+   double m_ipiaa0StepSize{ 20 };
 
-    //iPIAA1;
-    long m_ipiaa1xPos;
-    long m_ipiaa1yPos;
-    int m_ipiaa1Scale {1};
-    double m_ipiaa1StepSize {20};
+   // iPIAA1;
+   long   m_ipiaa1xPos;
+   long   m_ipiaa1yPos;
+   int    m_ipiaa1Scale{ 1 };
+   double m_ipiaa1StepSize{ 20 };
 
-public:
-   coronAlign( QWidget * Parent = 0,
-               Qt::WindowFlags f = Qt::WindowFlags()
-             );
+ public:
+   coronAlign( QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
 
    ~coronAlign();
 
@@ -115,9 +155,36 @@ public:
    virtual void onConnect();
    virtual void onDisconnect();
 
-   void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
-   void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
-   void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+   void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
+   void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
+   void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
+
+   /// Starts a non-pico pending latch and its timeout timer.
+   void
+   startPendingCommand( bool          &pending /**< [in,out] pending flag to assert */,
+                        QElapsedTimer &pendingTimer /**< [in,out] timer tracking the pending age */,
+                        bool &refreshRequested /**< [in,out] refresh flag tracking whether a status query was sent */ );
+
+   /// Clears a non-pico pending latch and invalidates its timeout timer.
+   void
+   clearPendingCommand( bool          &pending /**< [in,out] pending flag to clear */,
+                        QElapsedTimer &pendingTimer /**< [in,out] timer tracking the pending age */,
+                        bool &refreshRequested /**< [in,out] refresh flag tracking whether a status query was sent */ );
+
+   /// Requests a fresh motion-property and FSM update for a pending non-pico device.
+   void requestPendingRefresh( const std::string &device /**< [in] Device name to query. */,
+                               const std::string &property /**< [in] Motion property name to query. */ );
+
+   /// Handles timeout processing for a single non-pico pending latch.
+   void
+   expirePendingCommand( bool          &pending /**< [in,out] pending flag under evaluation */,
+                         QElapsedTimer &pendingTimer /**< [in,out] timer tracking the pending age */,
+                         bool &refreshRequested /**< [in,out] refresh flag tracking whether a status query was sent */,
+                         const std::string &device /**< [in] Device name to query on timeout */,
+                         const std::string &property /**< [in] Motion property name to query on timeout */ );
+
+   /// Processes stale non-pico pending latches by refreshing state once, then falling back locally if still unresolved.
+   void expirePendingCommands();
 
    void enablePicoButtons();
    void disablePicoButtons();
@@ -201,66 +268,144 @@ private:
    Ui::coronAlign ui;
 };
 
-coronAlign::coronAlign( QWidget * Parent, Qt::WindowFlags f) : xWidget(Parent, f)
+coronAlign::coronAlign( QWidget *Parent, Qt::WindowFlags f ) : xWidget( Parent, f )
 {
-   ui.setupUi(this);
-   ui.button_pupil_scale->setProperty("isScaleButton", true);
-   ui.button_focal_scale->setProperty("isScaleButton", true);
-   ui.button_lyot_scale->setProperty("isScaleButton", true);
-   ui.button_piaa_scale->setProperty("isScaleButton", true);
-   ui.button_piaa0_scale->setProperty("isScaleButton", true);
-   ui.button_piaa1_scale->setProperty("isScaleButton", true);
-   ui.button_ipiaa_scale->setProperty("isScaleButton", true);
-   ui.button_ipiaa0_scale->setProperty("isScaleButton", true);
-   ui.button_ipiaa1_scale->setProperty("isScaleButton", true);
+    ui.setupUi( this );
+    ui.button_pupil_scale->setProperty( "isScaleButton", true );
+    ui.button_focal_scale->setProperty( "isScaleButton", true );
+    ui.button_lyot_scale->setProperty( "isScaleButton", true );
+    ui.button_piaa_scale->setProperty( "isScaleButton", true );
+    ui.button_piaa0_scale->setProperty( "isScaleButton", true );
+    ui.button_piaa1_scale->setProperty( "isScaleButton", true );
+    ui.button_ipiaa_scale->setProperty( "isScaleButton", true );
+    ui.button_ipiaa0_scale->setProperty( "isScaleButton", true );
+    ui.button_ipiaa1_scale->setProperty( "isScaleButton", true );
 
-   QTimer *timer = new QTimer(this);
-   connect(timer, SIGNAL(timeout()), this, SLOT(updateGUI()));
-   timer->start(250);
+    QTimer *timer = new QTimer( this );
+    connect( timer, SIGNAL( timeout() ), this, SLOT( updateGUI() ) );
+    timer->start( 250 );
 
-   char ss[5];
-   snprintf(ss, 5, "%d", m_pupilScale);
-   ui.button_pupil_scale->setText(ss);
+    char ss[5];
+    snprintf( ss, 5, "%d", m_pupilScale );
+    ui.button_pupil_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_focalScale);
-   ui.button_focal_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_focalScale );
+    ui.button_focal_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_lyotScale);
-   ui.button_lyot_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_lyotScale );
+    ui.button_lyot_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_piaaScale);
-   ui.button_piaa_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_piaaScale );
+    ui.button_piaa_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_piaa0Scale);
-   ui.button_piaa0_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_piaa0Scale );
+    ui.button_piaa0_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_piaa1Scale);
-   ui.button_piaa1_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_piaa1Scale );
+    ui.button_piaa1_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_ipiaaScale);
-   ui.button_ipiaa_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_ipiaaScale );
+    ui.button_ipiaa_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_ipiaa0Scale);
-   ui.button_ipiaa0_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_ipiaa0Scale );
+    ui.button_ipiaa0_scale->setText( ss );
 
-   snprintf(ss, 5, "%d", m_ipiaa1Scale);
-   ui.button_ipiaa1_scale->setText(ss);
+    snprintf( ss, 5, "%d", m_ipiaa1Scale );
+    ui.button_ipiaa1_scale->setText( ss );
 
-   ui.checkCamllowfs->setEnabled(false);
+    ui.checkCamllowfs->setEnabled( false );
 
-   ui.fwpupil->setup("fwpupil");
-   //ui.fwpupil->setup("fwpupil", "filterName", "", "fwpupil", "");
+    ui.fwpupil->setup( "fwpupil" );
+    // ui.fwpupil->setup("fwpupil", "filterName", "", "fwpupil", "");
 
-   ui.fwfpm->setup("fwfpm");
-   ui.fwlyot->setup("fwlyot");
-   ui.stagepiaa->setup("stagepiaa");
-   ui.stageipiaa->setup("stageipiaa");
+    ui.fwfpm->setup( "fwfpm" );
+    ui.fwlyot->setup( "fwlyot" );
+    ui.stagepiaa->setup( "stagepiaa" );
+    ui.stageipiaa->setup( "stageipiaa" );
 
-   onDisconnect();
+    onDisconnect();
 }
 
 coronAlign::~coronAlign()
 {
+}
+
+void coronAlign::startPendingCommand( bool &pending, QElapsedTimer &pendingTimer, bool &refreshRequested )
+{
+    pending          = true;
+    refreshRequested = false;
+    pendingTimer.start();
+}
+
+void coronAlign::clearPendingCommand( bool &pending, QElapsedTimer &pendingTimer, bool &refreshRequested )
+{
+    pending          = false;
+    refreshRequested = false;
+    pendingTimer.invalidate();
+}
+
+void coronAlign::requestPendingRefresh( const std::string &device, const std::string &property )
+{
+    pcf::IndiProperty ipReq;
+
+    ipReq.setDevice( device );
+    ipReq.setName( property );
+    sendGetProperties( ipReq );
+
+    ipReq.setName( "fsm" );
+    sendGetProperties( ipReq );
+}
+
+void coronAlign::expirePendingCommand( bool              &pending,
+                                       QElapsedTimer     &pendingTimer,
+                                       bool              &refreshRequested,
+                                       const std::string &device,
+                                       const std::string &property )
+{
+    if( !pending || ( pendingTimer.isValid() && pendingTimer.elapsed() < m_pendingTimeoutMs ) )
+    {
+        return;
+    }
+
+    if( !refreshRequested )
+    {
+        requestPendingRefresh( device, property );
+        refreshRequested = true;
+        pendingTimer.start();
+        return;
+    }
+
+    clearPendingCommand( pending, pendingTimer, refreshRequested );
+}
+
+void coronAlign::expirePendingCommands()
+{
+    expirePendingCommand(
+        m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested, "fwpupil", "filter" );
+
+    expirePendingCommand( m_fwFocalCommandPending,
+                          m_fwFocalPendingTimer,
+                          m_fwFocalPendingRefreshRequested,
+                          "fwfpm",
+                          "filter" );
+
+    expirePendingCommand( m_fwLyotCommandPending,
+                          m_fwLyotPendingTimer,
+                          m_fwLyotPendingRefreshRequested,
+                          "fwlyot",
+                          "filter" );
+
+    expirePendingCommand( m_piaaCommandPending,
+                          m_piaaPendingTimer,
+                          m_piaaPendingRefreshRequested,
+                          "stagepiaa",
+                          "position" );
+
+    expirePendingCommand( m_ipiaaCommandPending,
+                          m_ipiaaPendingTimer,
+                          m_ipiaaPendingRefreshRequested,
+                          "stageipiaa",
+                          "position" );
 }
 
 void coronAlign::subscribe()
@@ -374,100 +519,106 @@ void coronAlign::onConnect()
    ui.fwlyot->setEnabled(true);
    ui.fwlyot->onConnect();
 
-   ui.stagepiaa->setEnabled(true);
+   ui.stagepiaa->setEnabled( true );
    ui.stagepiaa->onConnect();
 
-   ui.stageipiaa->setEnabled(true);
+   ui.stageipiaa->setEnabled( true );
    ui.stageipiaa->onConnect();
 
-   setWindowTitle("Coronagraph Alignment");
+   setWindowTitle( "Coronagraph Alignment" );
 }
 
 void coronAlign::onDisconnect()
 {
-   m_picoState = "";
-   m_fwPupilState = "";
-   m_fwFocalState = "";
-   m_fwLyotState = "";
-   m_piaaState = "";
-   m_ipiaaState = "";
+    m_picoState          = "";
+    m_picoCommandPending = false;
+    m_fwPupilState       = "";
+    clearPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+    m_fwFocalState = "";
+    clearPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+    m_fwLyotState = "";
+    clearPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+    m_piaaState = "";
+    clearPendingCommand( m_piaaCommandPending, m_piaaPendingTimer, m_piaaPendingRefreshRequested );
+    m_ipiaaState = "";
+    clearPendingCommand( m_ipiaaCommandPending, m_ipiaaPendingTimer, m_ipiaaPendingRefreshRequested );
 
-   ui.labelPupil->setEnabled(false);
-   ui.labelFocal->setEnabled(false);
-   ui.labelLyot->setEnabled(false);
+    ui.labelPupil->setEnabled( false );
+    ui.labelFocal->setEnabled( false );
+    ui.labelLyot->setEnabled( false );
 
-   ui.button_pupil_u->setEnabled(false);
-   ui.button_pupil_d->setEnabled(false);
-   ui.button_pupil_l->setEnabled(false);
-   ui.button_pupil_r->setEnabled(false);
-   ui.button_pupil_scale->setEnabled(false);
+    ui.button_pupil_u->setEnabled( false );
+    ui.button_pupil_d->setEnabled( false );
+    ui.button_pupil_l->setEnabled( false );
+    ui.button_pupil_r->setEnabled( false );
+    ui.button_pupil_scale->setEnabled( false );
 
-   ui.button_focal_u->setEnabled(false);
-   ui.button_focal_d->setEnabled(false);
-   ui.button_focal_l->setEnabled(false);
-   ui.button_focal_r->setEnabled(false);
-   ui.button_focal_scale->setEnabled(false);
+    ui.button_focal_u->setEnabled( false );
+    ui.button_focal_d->setEnabled( false );
+    ui.button_focal_l->setEnabled( false );
+    ui.button_focal_r->setEnabled( false );
+    ui.button_focal_scale->setEnabled( false );
 
-   ui.button_lyot_u->setEnabled(false);
-   ui.button_lyot_d->setEnabled(false);
-   ui.button_lyot_l->setEnabled(false);
-   ui.button_lyot_r->setEnabled(false);
-   ui.button_lyot_scale->setEnabled(false);
+    ui.button_lyot_u->setEnabled( false );
+    ui.button_lyot_d->setEnabled( false );
+    ui.button_lyot_l->setEnabled( false );
+    ui.button_lyot_r->setEnabled( false );
+    ui.button_lyot_scale->setEnabled( false );
 
-   ui.labelPIAA->setEnabled(false);
-   ui.button_piaa_l->setEnabled(false);
-   ui.button_piaa_r->setEnabled(false);
-   ui.button_piaa_u->setEnabled(false);
-   ui.button_piaa_d->setEnabled(false);
-   ui.button_piaa_scale->setEnabled(false);
+    ui.labelPIAA->setEnabled( false );
+    ui.button_piaa_l->setEnabled( false );
+    ui.button_piaa_r->setEnabled( false );
+    ui.button_piaa_u->setEnabled( false );
+    ui.button_piaa_d->setEnabled( false );
+    ui.button_piaa_scale->setEnabled( false );
 
-   ui.labelPIAA0->setEnabled(false);
-   ui.button_piaa0_l->setEnabled(false);
-   ui.button_piaa0_r->setEnabled(false);
-   ui.button_piaa0_scale->setEnabled(false);
+    ui.labelPIAA0->setEnabled( false );
+    ui.button_piaa0_l->setEnabled( false );
+    ui.button_piaa0_r->setEnabled( false );
+    ui.button_piaa0_scale->setEnabled( false );
 
-   ui.labelPIAA1->setEnabled(false);
-   ui.button_piaa1_l->setEnabled(false);
-   ui.button_piaa1_r->setEnabled(false);
-   ui.button_piaa1_u->setEnabled(false);
-   ui.button_piaa1_d->setEnabled(false);
-   ui.button_piaa1_scale->setEnabled(false);
+    ui.labelPIAA1->setEnabled( false );
+    ui.button_piaa1_l->setEnabled( false );
+    ui.button_piaa1_r->setEnabled( false );
+    ui.button_piaa1_u->setEnabled( false );
+    ui.button_piaa1_d->setEnabled( false );
+    ui.button_piaa1_scale->setEnabled( false );
 
-   ui.labeliPIAA->setEnabled(false);
-   ui.button_ipiaa_l->setEnabled(false);
-   ui.button_ipiaa_r->setEnabled(false);
-   ui.button_ipiaa_u->setEnabled(false);
-   ui.button_ipiaa_d->setEnabled(false);
-   ui.button_ipiaa_scale->setEnabled(false);
+    ui.labeliPIAA->setEnabled( false );
+    ui.button_ipiaa_l->setEnabled( false );
+    ui.button_ipiaa_r->setEnabled( false );
+    ui.button_ipiaa_u->setEnabled( false );
+    ui.button_ipiaa_d->setEnabled( false );
+    ui.button_ipiaa_scale->setEnabled( false );
 
-   ui.labeliPIAA0->setEnabled(false);
-   ui.button_ipiaa0_l->setEnabled(false);
-   ui.button_ipiaa0_r->setEnabled(false);
-   ui.button_ipiaa0_scale->setEnabled(false);
+    ui.labeliPIAA0->setEnabled( false );
+    ui.button_ipiaa0_l->setEnabled( false );
+    ui.button_ipiaa0_r->setEnabled( false );
+    ui.button_ipiaa0_scale->setEnabled( false );
 
-   ui.labeliPIAA1->setEnabled(false);
-   ui.button_ipiaa1_l->setEnabled(false);
-   ui.button_ipiaa1_r->setEnabled(false);
-   ui.button_ipiaa1_u->setEnabled(false);
-   ui.button_ipiaa1_d->setEnabled(false);
-   ui.button_ipiaa1_scale->setEnabled(false);
+    ui.labeliPIAA1->setEnabled( false );
+    ui.button_ipiaa1_l->setEnabled( false );
+    ui.button_ipiaa1_r->setEnabled( false );
+    ui.button_ipiaa1_u->setEnabled( false );
+    ui.button_ipiaa1_d->setEnabled( false );
+    ui.button_ipiaa1_scale->setEnabled( false );
 
-   ui.fwpupil->setEnabled(false);
-   ui.fwpupil->onDisconnect();
+    ui.fwpupil->setEnabled( false );
+    ui.fwpupil->onDisconnect();
 
-   ui.fwfpm->setEnabled(true);
-   ui.fwfpm->onDisconnect();
+    ui.fwfpm->setEnabled( true );
+    ui.fwfpm->onDisconnect();
 
-   ui.fwlyot->setEnabled(true);
-   ui.fwlyot->onDisconnect();
+    ui.fwlyot->setEnabled( true );
+    ui.fwlyot->onDisconnect();
 
-   ui.stagepiaa->setEnabled(true);
-   ui.stagepiaa->onDisconnect();
+    ui.stagepiaa->setEnabled( true );
+    ui.stagepiaa->onDisconnect();
 
-   ui.stageipiaa->setEnabled(true);
-   ui.stageipiaa->onDisconnect();
+    ui.stageipiaa->setEnabled( true );
+    ui.stageipiaa->onDisconnect();
 
-   setWindowTitle("Coronagraph Alignment (disconnected)");
+    setWindowTitle( "Coronagraph Alignment (disconnected)" );
 }
 
 void coronAlign::handleDefProperty( const pcf::IndiProperty & ipRecv)
@@ -487,856 +638,939 @@ void coronAlign::handleDefProperty( const pcf::IndiProperty & ipRecv)
    return;
 }
 
-void coronAlign::handleDelProperty( const pcf::IndiProperty & ipRecv)
+void coronAlign::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
-   std::string dev = ipRecv.getDevice();
-   if( dev == "picomotors" ||
-       dev == "fwpupil" ||
-       dev == "fwlyot" ||
-       dev == "fwfpm" ||
-       dev == "stagepiaa" ||
-       dev == "stageipiaa" )
-   {
-      onDisconnect();
-   }
+    std::string dev = ipRecv.getDevice();
+    if( dev == "picomotors" || dev == "fwpupil" || dev == "fwlyot" || dev == "fwfpm" || dev == "stagepiaa" ||
+        dev == "stageipiaa" )
+    {
+        onDisconnect();
+    }
 }
 
-void coronAlign::handleSetProperty( const pcf::IndiProperty & ipRecv)
+void coronAlign::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
-   std::string dev = ipRecv.getDevice();
+    std::string dev = ipRecv.getDevice();
 
-   if(dev == "fwpupil")
-   {
-      if(ipRecv.getName() == "filter")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_fwPupilPos = ipRecv["current"].get<double>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_fwPupilState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
-   else if(dev == "fwfpm")
-   {
-      if(ipRecv.getName() == "filter")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_fwFocalPos = ipRecv["current"].get<double>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_fwFocalState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
-   else if(dev == "fwlyot")
-   {
-      if(ipRecv.getName() == "filter")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_fwLyotPos = ipRecv["current"].get<double>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_fwLyotState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
-   else if(dev == "stagepiaa")
-   {
-      if(ipRecv.getName() == "position")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_piaaPos = ipRecv["current"].get<double>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_piaaState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
-   else if(dev == "stageipiaa")
-   {
-      if(ipRecv.getName() == "position")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_ipiaaPos = ipRecv["current"].get<double>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_ipiaaState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
-   else if(dev == "picomotors")
-   {
-      if(ipRecv.getName() == "picopupil_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_picoPupilPos = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "picofpm_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_picoFocalPos = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "picolyot_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_picoLyotPos = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "piaa0x_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_piaa0xPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "piaa1x_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_piaa1xPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "piaa1y_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_piaa1yPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "ipiaa0x_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_ipiaa0xPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "ipiaa1x_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_ipiaa1xPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "ipiaa1y_pos")
-      {
-         if(ipRecv.find("current"))
-         {
-            m_ipiaa1yPos  = ipRecv["current"].get<long>();
-            return;
-         }
-      }
-      else if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_picoState = ipRecv["state"].get();
-            return;
-         }
-      }
-   }
+    if( dev == "fwpupil" )
+    {
+        if( ipRecv.getName() == "filter" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_fwPupilPos = ipRecv["current"].get<double>();
+                if( m_fwPupilCommandPending && std::fabs( m_fwPupilPos - m_fwPupilTarget ) <= 0.25 * m_fwPupilStepSize )
+                {
+                    clearPendingCommand(
+                        m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+                }
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_fwPupilState = ipRecv["state"].get();
+                clearPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+                return;
+            }
+        }
+    }
+    else if( dev == "fwfpm" )
+    {
+        if( ipRecv.getName() == "filter" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_fwFocalPos = ipRecv["current"].get<double>();
+                if( m_fwFocalCommandPending && std::fabs( m_fwFocalPos - m_fwFocalTarget ) <= 0.25 * m_fwFocalStepSize )
+                {
+                    clearPendingCommand(
+                        m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+                }
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_fwFocalState = ipRecv["state"].get();
+                clearPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+                return;
+            }
+        }
+    }
+    else if( dev == "fwlyot" )
+    {
+        if( ipRecv.getName() == "filter" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_fwLyotPos = ipRecv["current"].get<double>();
+                if( m_fwLyotCommandPending && std::fabs( m_fwLyotPos - m_fwLyotTarget ) <= 0.25 * m_fwLyotStepSize )
+                {
+                    clearPendingCommand(
+                        m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+                }
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_fwLyotState = ipRecv["state"].get();
+                clearPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+                return;
+            }
+        }
+    }
+    else if( dev == "stagepiaa" )
+    {
+        if( ipRecv.getName() == "position" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_piaaPos = ipRecv["current"].get<double>();
+                if( m_piaaCommandPending && std::fabs( m_piaaPos - m_piaaTarget ) <= 0.25 * m_piaaStepSize )
+                {
+                    clearPendingCommand( m_piaaCommandPending, m_piaaPendingTimer, m_piaaPendingRefreshRequested );
+                }
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_piaaState = ipRecv["state"].get();
+                clearPendingCommand( m_piaaCommandPending, m_piaaPendingTimer, m_piaaPendingRefreshRequested );
+                return;
+            }
+        }
+    }
+    else if( dev == "stageipiaa" )
+    {
+        if( ipRecv.getName() == "position" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_ipiaaPos = ipRecv["current"].get<double>();
+                if( m_ipiaaCommandPending && std::fabs( m_ipiaaPos - m_ipiaaTarget ) <= 0.25 * m_ipiaaStepSize )
+                {
+                    clearPendingCommand( m_ipiaaCommandPending, m_ipiaaPendingTimer, m_ipiaaPendingRefreshRequested );
+                }
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_ipiaaState = ipRecv["state"].get();
+                clearPendingCommand( m_ipiaaCommandPending, m_ipiaaPendingTimer, m_ipiaaPendingRefreshRequested );
+                return;
+            }
+        }
+    }
+    else if( dev == "picomotors" )
+    {
+        if( ipRecv.getName() == "picopupil_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_picoPupilPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "picofpm_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_picoFocalPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "picolyot_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_picoLyotPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "piaa0x_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_piaa0xPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "piaa1x_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_piaa1xPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "piaa1y_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_piaa1yPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "ipiaa0x_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_ipiaa0xPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "ipiaa1x_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_ipiaa1xPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "ipiaa1y_pos" )
+        {
+            if( ipRecv.find( "current" ) )
+            {
+                m_ipiaa1yPos = ipRecv["current"].get<long>();
+                return;
+            }
+        }
+        else if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_picoState          = ipRecv["state"].get();
+                m_picoCommandPending = false;
+                return;
+            }
+        }
+    }
 
-   return;
-
+    return;
 }
 
 void coronAlign::updateGUI()
 {
+    expirePendingCommands();
 
-   if(m_fwPupilState != "READY")
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_pupil_l->setEnabled(false);
-         ui.button_pupil_r->setEnabled(false);
-         ui.button_pupil_scale->setEnabled(false);
-         ui.labelPupil->setEnabled(false);
-      }
-      else
-      {
-         ui.button_pupil_u->setEnabled(false);
-         ui.button_pupil_d->setEnabled(false);
-         ui.button_pupil_scale->setEnabled(false);
-         ui.labelPupil->setEnabled(false);
-      }
-   }
-   else
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_pupil_l->setEnabled(true);
-         ui.button_pupil_r->setEnabled(true);
-         ui.button_pupil_scale->setEnabled(true);
-         ui.labelPupil->setEnabled(true);
-      }
-      else
-      {
-         ui.button_pupil_u->setEnabled(true);
-         ui.button_pupil_d->setEnabled(true);
-         ui.button_pupil_scale->setEnabled(true);
-         ui.labelPupil->setEnabled(true);
-      }
-   }
+    if( m_fwPupilCommandPending || m_fwPupilState != "READY" )
+    {
+        if( m_camera == FLOWFS )
+        {
+            ui.button_pupil_l->setEnabled( false );
+            ui.button_pupil_r->setEnabled( false );
+            ui.button_pupil_scale->setEnabled( false );
+            ui.labelPupil->setEnabled( false );
+        }
+        else
+        {
+            ui.button_pupil_u->setEnabled( false );
+            ui.button_pupil_d->setEnabled( false );
+            ui.button_pupil_scale->setEnabled( false );
+            ui.labelPupil->setEnabled( false );
+        }
+    }
+    else
+    {
+        if( m_camera == FLOWFS )
+        {
+            ui.button_pupil_l->setEnabled( true );
+            ui.button_pupil_r->setEnabled( true );
+            ui.button_pupil_scale->setEnabled( true );
+            ui.labelPupil->setEnabled( true );
+        }
+        else
+        {
+            ui.button_pupil_u->setEnabled( true );
+            ui.button_pupil_d->setEnabled( true );
+            ui.button_pupil_scale->setEnabled( true );
+            ui.labelPupil->setEnabled( true );
+        }
+    }
 
-   if(m_fwFocalState != "READY")
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_focal_l->setEnabled(false);
-         ui.button_focal_r->setEnabled(false);
-         ui.button_focal_scale->setEnabled(false);
-         ui.labelFocal->setEnabled(false);
-      }
-      else
-      {
-         ui.button_focal_u->setEnabled(false);
-         ui.button_focal_d->setEnabled(false);
-         ui.button_focal_scale->setEnabled(false);
-         ui.labelFocal->setEnabled(false);
-      }
-   }
-   else
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_focal_l->setEnabled(true);
-         ui.button_focal_r->setEnabled(true);
-         ui.button_focal_scale->setEnabled(true);
-         ui.labelFocal->setEnabled(true);
-      }
-      else
-      {
-         ui.button_focal_u->setEnabled(true);
-         ui.button_focal_d->setEnabled(true);
-         ui.button_focal_scale->setEnabled(true);
-         ui.labelFocal->setEnabled(true);
-      }
-   }
+    if( m_fwFocalCommandPending || m_fwFocalState != "READY" )
+    {
+        if( m_camera == FLOWFS )
+        {
+            ui.button_focal_l->setEnabled( false );
+            ui.button_focal_r->setEnabled( false );
+            ui.button_focal_scale->setEnabled( false );
+            ui.labelFocal->setEnabled( false );
+        }
+        else
+        {
+            ui.button_focal_u->setEnabled( false );
+            ui.button_focal_d->setEnabled( false );
+            ui.button_focal_scale->setEnabled( false );
+            ui.labelFocal->setEnabled( false );
+        }
+    }
+    else
+    {
+        if( m_camera == FLOWFS )
+        {
+            ui.button_focal_l->setEnabled( true );
+            ui.button_focal_r->setEnabled( true );
+            ui.button_focal_scale->setEnabled( true );
+            ui.labelFocal->setEnabled( true );
+        }
+        else
+        {
+            ui.button_focal_u->setEnabled( true );
+            ui.button_focal_d->setEnabled( true );
+            ui.button_focal_scale->setEnabled( true );
+            ui.labelFocal->setEnabled( true );
+        }
+    }
 
-   if(m_fwLyotState != "READY")
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_lyot_u->setEnabled(false);
-         ui.button_lyot_d->setEnabled(false);
-         ui.button_lyot_scale->setEnabled(false);
-         ui.labelLyot->setEnabled(false);
-      }
-      else
-      {
-         ui.button_lyot_l->setEnabled(false);
-         ui.button_lyot_r->setEnabled(false);
-         ui.button_lyot_scale->setEnabled(false);
-         ui.labelLyot->setEnabled(false);
-      }
-   }
-   else
-   {
-      if(m_camera == FLOWFS)
-      {
-         ui.button_lyot_u->setEnabled(true);
-         ui.button_lyot_d->setEnabled(true);
-         ui.button_lyot_scale->setEnabled(true);
-         ui.labelLyot->setEnabled(true);
-      }
-      else
-      {
-         ui.button_lyot_l->setEnabled(true);
-         ui.button_lyot_r->setEnabled(true);
-         ui.button_lyot_scale->setEnabled(true);
-         ui.labelLyot->setEnabled(true);
-      }
-   }
+    if( m_fwLyotCommandPending || m_fwLyotState != "READY" )
+    {
+        if( m_camera == LLOWFS )
+        {
+            ui.button_lyot_l->setEnabled( false );
+            ui.button_lyot_r->setEnabled( false );
+            ui.button_lyot_scale->setEnabled( false );
+            ui.labelLyot->setEnabled( false );
+        }
+        else
+        {
+            ui.button_lyot_u->setEnabled( false );
+            ui.button_lyot_d->setEnabled( false );
+            ui.button_lyot_scale->setEnabled( false );
+            ui.labelLyot->setEnabled( false );
+        }
+    }
+    else
+    {
+        if( m_camera == LLOWFS )
+        {
+            ui.button_lyot_l->setEnabled( true );
+            ui.button_lyot_r->setEnabled( true );
+            ui.button_lyot_scale->setEnabled( true );
+            ui.labelLyot->setEnabled( true );
+        }
+        else
+        {
+            ui.button_lyot_u->setEnabled( true );
+            ui.button_lyot_d->setEnabled( true );
+            ui.button_lyot_scale->setEnabled( true );
+            ui.labelLyot->setEnabled( true );
+        }
+    }
 
-   if(m_piaaState != "READY")
-   {
-      ui.button_piaa_u->setEnabled(false);
-      ui.button_piaa_d->setEnabled(false);
-      ui.button_piaa_scale->setEnabled(false);
-      ui.labelPIAA->setEnabled(false);
-   }
-   else
-   {
-      ui.button_piaa_u->setEnabled(true);
-      ui.button_piaa_d->setEnabled(true);
-      ui.button_piaa_scale->setEnabled(true);
-      ui.labelPIAA->setEnabled(true);
-   }
+    if( m_piaaCommandPending || m_piaaState != "READY" )
+    {
+        ui.button_piaa_u->setEnabled( false );
+        ui.button_piaa_d->setEnabled( false );
+        ui.button_piaa_scale->setEnabled( false );
+        ui.labelPIAA->setEnabled( false );
+    }
+    else
+    {
+        ui.button_piaa_u->setEnabled( true );
+        ui.button_piaa_d->setEnabled( true );
+        ui.button_piaa_scale->setEnabled( true );
+        ui.labelPIAA->setEnabled( true );
+    }
 
-   if(m_ipiaaState != "READY")
-   {
-      ui.button_ipiaa_u->setEnabled(false);
-      ui.button_ipiaa_d->setEnabled(false);
-      ui.button_ipiaa_scale->setEnabled(false);
-      ui.labeliPIAA->setEnabled(false);
-   }
-   else
-   {
-      ui.button_ipiaa_u->setEnabled(true);
-      ui.button_ipiaa_d->setEnabled(true);
-      ui.button_ipiaa_scale->setEnabled(true);
-      ui.labeliPIAA->setEnabled(true);
-   }
+    if( m_ipiaaCommandPending || m_ipiaaState != "READY" )
+    {
+        ui.button_ipiaa_u->setEnabled( false );
+        ui.button_ipiaa_d->setEnabled( false );
+        ui.button_ipiaa_scale->setEnabled( false );
+        ui.labeliPIAA->setEnabled( false );
+    }
+    else
+    {
+        ui.button_ipiaa_u->setEnabled( true );
+        ui.button_ipiaa_d->setEnabled( true );
+        ui.button_ipiaa_scale->setEnabled( true );
+        ui.labeliPIAA->setEnabled( true );
+    }
 
-   if(m_picoState != "READY")
-   {
-      disablePicoButtons();
-   }
-   else
-   {
-      enablePicoButtons();
-   }
+    if( m_picoCommandPending || m_picoState != "READY" )
+    {
+        disablePicoButtons();
+    }
+    else
+    {
+        enablePicoButtons();
+    }
 
+    if( m_camera == FLOWFS )
+    {
+        ui.checkCamflowfs->setCheckState( Qt::Checked );
+        ui.checkCamllowfs->setCheckState( Qt::Unchecked );
+        ui.checkCamsci12->setCheckState( Qt::Unchecked );
+    }
+    else if( m_camera == LLOWFS )
+    {
+        ui.checkCamflowfs->setCheckState( Qt::Unchecked );
+        ui.checkCamllowfs->setCheckState( Qt::Checked );
+        ui.checkCamsci12->setCheckState( Qt::Unchecked );
+    }
+    else
+    {
+        ui.checkCamflowfs->setCheckState( Qt::Unchecked );
+        ui.checkCamllowfs->setCheckState( Qt::Unchecked );
+        ui.checkCamsci12->setCheckState( Qt::Checked );
+    }
 
-   if(m_camera == FLOWFS)
-   {
-      ui.checkCamflowfs->setCheckState(Qt::Checked);
-      ui.checkCamllowfs->setCheckState(Qt::Unchecked);
-      ui.checkCamsci12->setCheckState(Qt::Unchecked);
-   }
-   else if(m_camera == LLOWFS)
-   {
-      ui.checkCamflowfs->setCheckState(Qt::Unchecked);
-      ui.checkCamllowfs->setCheckState(Qt::Checked);
-      ui.checkCamsci12->setCheckState(Qt::Unchecked);
-   }
-   else
-   {
-      ui.checkCamflowfs->setCheckState(Qt::Unchecked);
-      ui.checkCamllowfs->setCheckState(Qt::Unchecked);
-      ui.checkCamsci12->setCheckState(Qt::Checked);
-   }
+    ui.fwpupil->updateGUI();
 
-   ui.fwpupil->updateGUI();
-
-} //updateGUI()
+} // updateGUI()
 
 void coronAlign::enablePicoButtons()
 {
-   if(m_camera == FLOWFS)
-   {
-      ui.button_pupil_u->setEnabled(true);
-      ui.button_pupil_d->setEnabled(true);
-      ui.button_focal_u->setEnabled(true);
-      ui.button_focal_d->setEnabled(true);
-      ui.button_lyot_l->setEnabled(true);
-      ui.button_lyot_r->setEnabled(true);
-   }
-   else
-   {
-      ui.button_pupil_l->setEnabled(true);
-      ui.button_pupil_r->setEnabled(true);
-      ui.button_focal_l->setEnabled(true);
-      ui.button_focal_r->setEnabled(true);
-      ui.button_lyot_u->setEnabled(true);
-      ui.button_lyot_d->setEnabled(true);
-   }
+    if( m_camera == FLOWFS )
+    {
+        ui.button_pupil_u->setEnabled( true );
+        ui.button_pupil_d->setEnabled( true );
+        ui.button_focal_u->setEnabled( true );
+        ui.button_focal_d->setEnabled( true );
+    }
+    else
+    {
+        ui.button_pupil_l->setEnabled( true );
+        ui.button_pupil_r->setEnabled( true );
+        ui.button_focal_l->setEnabled( true );
+        ui.button_focal_r->setEnabled( true );
+    }
 
-   ui.button_piaa_l->setEnabled(true);
-   ui.button_piaa_r->setEnabled(true);
+    if( m_camera == LLOWFS )
+    {
+        ui.button_lyot_u->setEnabled( true );
+        ui.button_lyot_d->setEnabled( true );
+    }
+    else
+    {
+        ui.button_lyot_l->setEnabled( true );
+        ui.button_lyot_r->setEnabled( true );
+    }
 
-   ui.button_piaa0_l->setEnabled(true);
-   ui.button_piaa0_r->setEnabled(true);
-   ui.button_piaa0_scale->setEnabled(true);
+    ui.button_piaa_l->setEnabled( true );
+    ui.button_piaa_r->setEnabled( true );
 
-   ui.button_piaa1_l->setEnabled(true);
-   ui.button_piaa1_r->setEnabled(true);
-   ui.button_piaa1_u->setEnabled(true);
-   ui.button_piaa1_d->setEnabled(true);
-   ui.button_piaa1_scale->setEnabled(true);
+    ui.button_piaa0_l->setEnabled( true );
+    ui.button_piaa0_r->setEnabled( true );
+    ui.button_piaa0_scale->setEnabled( true );
 
-   ui.button_ipiaa_l->setEnabled(true);
-   ui.button_ipiaa_r->setEnabled(true);
+    ui.button_piaa1_l->setEnabled( true );
+    ui.button_piaa1_r->setEnabled( true );
+    ui.button_piaa1_u->setEnabled( true );
+    ui.button_piaa1_d->setEnabled( true );
+    ui.button_piaa1_scale->setEnabled( true );
 
-   ui.button_ipiaa0_l->setEnabled(true);
-   ui.button_ipiaa0_r->setEnabled(true);
-   ui.button_ipiaa0_scale->setEnabled(true);
+    ui.button_ipiaa_l->setEnabled( true );
+    ui.button_ipiaa_r->setEnabled( true );
 
-   ui.button_ipiaa1_l->setEnabled(true);
-   ui.button_ipiaa1_r->setEnabled(true);
-   ui.button_ipiaa1_u->setEnabled(true);
-   ui.button_ipiaa1_d->setEnabled(true);
-   ui.button_ipiaa1_scale->setEnabled(true);
+    ui.button_ipiaa0_l->setEnabled( true );
+    ui.button_ipiaa0_r->setEnabled( true );
+    ui.button_ipiaa0_scale->setEnabled( true );
+
+    ui.button_ipiaa1_l->setEnabled( true );
+    ui.button_ipiaa1_r->setEnabled( true );
+    ui.button_ipiaa1_u->setEnabled( true );
+    ui.button_ipiaa1_d->setEnabled( true );
+    ui.button_ipiaa1_scale->setEnabled( true );
 }
 
 void coronAlign::disablePicoButtons()
 {
-   if(m_camera == FLOWFS)
-   {
-      ui.button_pupil_u->setEnabled(false);
-      ui.button_pupil_d->setEnabled(false);
-      ui.button_focal_u->setEnabled(false);
-      ui.button_focal_d->setEnabled(false);
-      ui.button_lyot_l->setEnabled(false);
-      ui.button_lyot_r->setEnabled(false);
-   }
-   else
-   {
-      ui.button_pupil_l->setEnabled(false);
-      ui.button_pupil_r->setEnabled(false);
-      ui.button_focal_l->setEnabled(false);
-      ui.button_focal_r->setEnabled(false);
-      ui.button_lyot_u->setEnabled(false);
-      ui.button_lyot_d->setEnabled(false);
-   }
+    if( m_picoState == "READY" )
+    {
+        m_picoCommandPending = true;
+    }
 
-   ui.button_piaa_l->setEnabled(false);
-   ui.button_piaa_r->setEnabled(false);
+    if( m_camera == FLOWFS )
+    {
+        ui.button_pupil_u->setEnabled( false );
+        ui.button_pupil_d->setEnabled( false );
+        ui.button_focal_u->setEnabled( false );
+        ui.button_focal_d->setEnabled( false );
+    }
+    else
+    {
+        ui.button_pupil_l->setEnabled( false );
+        ui.button_pupil_r->setEnabled( false );
+        ui.button_focal_l->setEnabled( false );
+        ui.button_focal_r->setEnabled( false );
+    }
 
-   ui.button_piaa0_l->setEnabled(false);
-   ui.button_piaa0_r->setEnabled(false);
-   ui.button_piaa0_scale->setEnabled(false);
+    if( m_camera == LLOWFS )
+    {
+        ui.button_lyot_u->setEnabled( false );
+        ui.button_lyot_d->setEnabled( false );
+    }
+    else
+    {
+        ui.button_lyot_l->setEnabled( false );
+        ui.button_lyot_r->setEnabled( false );
+    }
 
-   ui.button_piaa1_l->setEnabled(false);
-   ui.button_piaa1_r->setEnabled(false);
-   ui.button_piaa1_u->setEnabled(false);
-   ui.button_piaa1_d->setEnabled(false);
-   ui.button_piaa1_scale->setEnabled(false);
+    ui.button_piaa_l->setEnabled( false );
+    ui.button_piaa_r->setEnabled( false );
 
-   ui.button_ipiaa_l->setEnabled(false);
-   ui.button_ipiaa_r->setEnabled(false);
+    ui.button_piaa0_l->setEnabled( false );
+    ui.button_piaa0_r->setEnabled( false );
+    ui.button_piaa0_scale->setEnabled( false );
 
-   ui.button_ipiaa0_l->setEnabled(false);
-   ui.button_ipiaa0_r->setEnabled(false);
-   ui.button_ipiaa0_scale->setEnabled(false);
+    ui.button_piaa1_l->setEnabled( false );
+    ui.button_piaa1_r->setEnabled( false );
+    ui.button_piaa1_u->setEnabled( false );
+    ui.button_piaa1_d->setEnabled( false );
+    ui.button_piaa1_scale->setEnabled( false );
 
-   ui.button_ipiaa1_l->setEnabled(false);
-   ui.button_ipiaa1_r->setEnabled(false);
-   ui.button_ipiaa1_u->setEnabled(false);
-   ui.button_ipiaa1_d->setEnabled(false);
-   ui.button_ipiaa1_scale->setEnabled(false);
+    ui.button_ipiaa_l->setEnabled( false );
+    ui.button_ipiaa_r->setEnabled( false );
+
+    ui.button_ipiaa0_l->setEnabled( false );
+    ui.button_ipiaa0_r->setEnabled( false );
+    ui.button_ipiaa0_scale->setEnabled( false );
+
+    ui.button_ipiaa1_l->setEnabled( false );
+    ui.button_ipiaa1_r->setEnabled( false );
+    ui.button_ipiaa1_u->setEnabled( false );
+    ui.button_ipiaa1_d->setEnabled( false );
+    ui.button_ipiaa1_scale->setEnabled( false );
 }
 
 void coronAlign::on_button_pupil_u_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picopupil_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoPupilPos + m_pupilScale*m_picoPupilStepSize;
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picopupil_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoPupilPos + m_pupilScale * m_picoPupilStepSize;
 
-      disablePicoButtons();
-   }
-   else
-   {
-      ip.setDevice("fwpupil");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwPupilPos + m_pupilScale*m_fwPupilStepSize;
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwpupil" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwPupilTarget = m_fwPupilPos + m_pupilScale * m_fwPupilStepSize;
+        ip["target"]    = m_fwPupilTarget;
 
-      ui.button_pupil_l->setEnabled(false);
-      ui.button_pupil_r->setEnabled(false);
-   }
+        startPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+        ui.button_pupil_u->setEnabled( false );
+        ui.button_pupil_d->setEnabled( false );
+        ui.button_pupil_scale->setEnabled( false );
+        ui.labelPupil->setEnabled( false );
+    }
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_pupil_d_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picopupil_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoPupilPos - m_pupilScale*m_picoPupilStepSize;
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picopupil_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoPupilPos - m_pupilScale * m_picoPupilStepSize;
 
-      disablePicoButtons();
-   }
-   else
-   {
-      ip.setDevice("fwpupil");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwPupilPos - m_pupilScale*m_fwPupilStepSize;
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwpupil" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwPupilTarget = m_fwPupilPos - m_pupilScale * m_fwPupilStepSize;
+        ip["target"]    = m_fwPupilTarget;
 
-      ui.button_pupil_l->setEnabled(false);
-      ui.button_pupil_r->setEnabled(false);
-   }
-   sendNewProperty(ip);
+        startPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+        ui.button_pupil_u->setEnabled( false );
+        ui.button_pupil_d->setEnabled( false );
+        ui.button_pupil_scale->setEnabled( false );
+        ui.labelPupil->setEnabled( false );
+    }
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_pupil_l_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("fwpupil");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwPupilPos + m_pupilScale*m_fwPupilStepSize;
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "fwpupil" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwPupilTarget = m_fwPupilPos + m_pupilScale * m_fwPupilStepSize;
+        ip["target"]    = m_fwPupilTarget;
 
-      ui.button_pupil_l->setEnabled(false);
-      ui.button_pupil_r->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picopupil_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoPupilPos + m_pupilScale*m_picoPupilStepSize;
+        startPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+        ui.button_pupil_l->setEnabled( false );
+        ui.button_pupil_r->setEnabled( false );
+        ui.button_pupil_scale->setEnabled( false );
+        ui.labelPupil->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picopupil_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoPupilPos + m_pupilScale * m_picoPupilStepSize;
 
-      disablePicoButtons();
-   }
+        disablePicoButtons();
+    }
 
-   sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_pupil_r_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("fwpupil");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwPupilPos - m_pupilScale*m_fwPupilStepSize;
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "fwpupil" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwPupilTarget = m_fwPupilPos - m_pupilScale * m_fwPupilStepSize;
+        ip["target"]    = m_fwPupilTarget;
 
-      ui.button_pupil_l->setEnabled(false);
-      ui.button_pupil_r->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picopupil_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoPupilPos - m_pupilScale*m_picoPupilStepSize;
+        startPendingCommand( m_fwPupilCommandPending, m_fwPupilPendingTimer, m_fwPupilPendingRefreshRequested );
+        ui.button_pupil_l->setEnabled( false );
+        ui.button_pupil_r->setEnabled( false );
+        ui.button_pupil_scale->setEnabled( false );
+        ui.labelPupil->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picopupil_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoPupilPos - m_pupilScale * m_picoPupilStepSize;
 
-      disablePicoButtons();
-   }
+        disablePicoButtons();
+    }
 
-   sendNewProperty(ip);
-
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_pupil_scale_pressed()
 {
-   if( m_pupilScale == 100)
-   {
-      m_pupilScale = 10;
-   }
-   else if(m_pupilScale == 10)
-   {
-      m_pupilScale = 5;
-   }
-   else if(m_pupilScale == 5)
-   {
-      m_pupilScale = 1;
-   }
-   else if(m_pupilScale == 1)
-   {
-      m_pupilScale = 100;
-   }
-   else
-   {
-      m_pupilScale = 1;
-   }
+    if( m_pupilScale == 100 )
+    {
+        m_pupilScale = 10;
+    }
+    else if( m_pupilScale == 10 )
+    {
+        m_pupilScale = 5;
+    }
+    else if( m_pupilScale == 5 )
+    {
+        m_pupilScale = 1;
+    }
+    else if( m_pupilScale == 1 )
+    {
+        m_pupilScale = 100;
+    }
+    else
+    {
+        m_pupilScale = 1;
+    }
 
-   char ss[5];
-   snprintf(ss, 5, "%d", m_pupilScale);
-   std::cerr << m_pupilScale << " " << ss << "\n";
-   ui.button_pupil_scale->setText(ss);
-
-
+    char ss[5];
+    snprintf( ss, 5, "%d", m_pupilScale );
+    std::cerr << m_pupilScale << " " << ss << "\n";
+    ui.button_pupil_scale->setText( ss );
 }
-
 
 void coronAlign::on_button_focal_u_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picofpm_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoFocalPos + m_focalScale*m_picoFocalStepSize;
-   }
-   else
-   {
-      ip.setDevice("fwfpm");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwFocalPos - m_focalScale*m_fwFocalStepSize;
-      ui.button_focal_l->setEnabled(false);
-      ui.button_focal_r->setEnabled(false);
-   }
-   disablePicoButtons();
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picofpm_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoFocalPos + m_focalScale * m_picoFocalStepSize;
 
-   sendNewProperty(ip);
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwfpm" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwFocalTarget = m_fwFocalPos - m_focalScale * m_fwFocalStepSize;
+        ip["target"]    = m_fwFocalTarget;
+        startPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+        ui.button_focal_u->setEnabled( false );
+        ui.button_focal_d->setEnabled( false );
+        ui.button_focal_scale->setEnabled( false );
+        ui.labelFocal->setEnabled( false );
+    }
 
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_focal_d_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picofpm_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoFocalPos - m_focalScale*m_picoFocalStepSize;
-   }
-   else
-   {
-      ip.setDevice("fwfpm");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwFocalPos + m_focalScale*m_fwFocalStepSize;
-      ui.button_focal_l->setEnabled(false);
-      ui.button_focal_r->setEnabled(false);
-   }
-   disablePicoButtons();
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picofpm_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoFocalPos - m_focalScale * m_picoFocalStepSize;
 
-   sendNewProperty(ip);
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwfpm" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwFocalTarget = m_fwFocalPos + m_focalScale * m_fwFocalStepSize;
+        ip["target"]    = m_fwFocalTarget;
+        startPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+        ui.button_focal_u->setEnabled( false );
+        ui.button_focal_d->setEnabled( false );
+        ui.button_focal_scale->setEnabled( false );
+        ui.labelFocal->setEnabled( false );
+    }
 
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_focal_l_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("fwfpm");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwFocalPos + m_focalScale*m_fwFocalStepSize;
-      ui.button_focal_l->setEnabled(false);
-      ui.button_focal_r->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picofpm_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoFocalPos - m_focalScale*m_picoFocalStepSize;
-   }
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "fwfpm" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwFocalTarget = m_fwFocalPos + m_focalScale * m_fwFocalStepSize;
+        ip["target"]    = m_fwFocalTarget;
+        startPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+        ui.button_focal_l->setEnabled( false );
+        ui.button_focal_r->setEnabled( false );
+        ui.button_focal_scale->setEnabled( false );
+        ui.labelFocal->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picofpm_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoFocalPos - m_focalScale * m_picoFocalStepSize;
 
-   sendNewProperty(ip);
+        disablePicoButtons();
+    }
+
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_focal_r_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS)
-   {
-      ip.setDevice("fwfpm");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwFocalPos - m_focalScale*m_fwFocalStepSize;
-      ui.button_focal_l->setEnabled(false);
-      ui.button_focal_r->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picofpm_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoFocalPos + m_focalScale*m_picoFocalStepSize;
-   }
-   sendNewProperty(ip);
+    if( m_camera == FLOWFS )
+    {
+        ip.setDevice( "fwfpm" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwFocalTarget = m_fwFocalPos - m_focalScale * m_fwFocalStepSize;
+        ip["target"]    = m_fwFocalTarget;
+        startPendingCommand( m_fwFocalCommandPending, m_fwFocalPendingTimer, m_fwFocalPendingRefreshRequested );
+        ui.button_focal_l->setEnabled( false );
+        ui.button_focal_r->setEnabled( false );
+        ui.button_focal_scale->setEnabled( false );
+        ui.labelFocal->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picofpm_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoFocalPos + m_focalScale * m_picoFocalStepSize;
+
+        disablePicoButtons();
+    }
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_focal_scale_pressed()
 {
-   if( m_focalScale == 100)
-   {
-      m_focalScale = 10;
-   }
-   else if(m_focalScale == 10)
-   {
-      m_focalScale = 5;
-   }
-   else if(m_focalScale == 5)
-   {
-      m_focalScale = 1;
-   }
-   else if(m_focalScale == 1)
-   {
-      m_focalScale = 100;
-   }
-   else
-   {
-      m_focalScale = 1;
-   }
+    if( m_focalScale == 100 )
+    {
+        m_focalScale = 10;
+    }
+    else if( m_focalScale == 10 )
+    {
+        m_focalScale = 5;
+    }
+    else if( m_focalScale == 5 )
+    {
+        m_focalScale = 1;
+    }
+    else if( m_focalScale == 1 )
+    {
+        m_focalScale = 100;
+    }
+    else
+    {
+        m_focalScale = 1;
+    }
 
-   char ss[5];
-   snprintf(ss, 5, "%d", m_focalScale);
-   ui.button_focal_scale->setText(ss);
-
-
+    char ss[5];
+    snprintf( ss, 5, "%d", m_focalScale );
+    ui.button_focal_scale->setText( ss );
 }
-
 
 void coronAlign::on_button_lyot_u_pressed()
 {
 
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS || m_camera == CAMSCIS)
-   {
-      ip.setDevice("fwlyot");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwLyotPos - m_lyotScale*m_fwLyotStepSize;
+    if( m_camera == FLOWFS || m_camera == CAMSCIS )
+    {
+        ip.setDevice( "fwlyot" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwLyotTarget = m_fwLyotPos - m_lyotScale * m_fwLyotStepSize;
+        ip["target"]   = m_fwLyotTarget;
 
-      ui.button_lyot_u->setEnabled(false);
-      ui.button_lyot_d->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picolyot_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoLyotPos - m_lyotScale*m_picoLyotStepSize;
+        startPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+        ui.button_lyot_u->setEnabled( false );
+        ui.button_lyot_d->setEnabled( false );
+        ui.button_lyot_scale->setEnabled( false );
+        ui.labelLyot->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picolyot_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoLyotPos - m_lyotScale * m_picoLyotStepSize;
 
-      disablePicoButtons();
-   }
+        disablePicoButtons();
+    }
 
-   sendNewProperty(ip);
-
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_lyot_d_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS || m_camera == CAMSCIS)
-   {
-      ip.setDevice("fwlyot");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwLyotPos + m_lyotScale*m_fwLyotStepSize;
+    if( m_camera == FLOWFS || m_camera == CAMSCIS )
+    {
+        ip.setDevice( "fwlyot" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwLyotTarget = m_fwLyotPos + m_lyotScale * m_fwLyotStepSize;
+        ip["target"]   = m_fwLyotTarget;
 
-      ui.button_lyot_u->setEnabled(false);
-      ui.button_lyot_d->setEnabled(false);
-   }
-   else
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picolyot_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoLyotPos + m_lyotScale*m_picoLyotStepSize;
+        startPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+        ui.button_lyot_u->setEnabled( false );
+        ui.button_lyot_d->setEnabled( false );
+        ui.button_lyot_scale->setEnabled( false );
+        ui.labelLyot->setEnabled( false );
+    }
+    else
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picolyot_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoLyotPos + m_lyotScale * m_picoLyotStepSize;
 
-      disablePicoButtons();
-   }
+        disablePicoButtons();
+    }
 
-   sendNewProperty(ip);
-
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_lyot_l_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS || m_camera == CAMSCIS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picolyot_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoLyotPos + m_lyotScale*m_picoLyotStepSize;
+    if( m_camera == FLOWFS || m_camera == CAMSCIS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picolyot_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoLyotPos + m_lyotScale * m_picoLyotStepSize;
 
-      disablePicoButtons();
-   }
-   else
-   {
-      ip.setDevice("fwlyot");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwLyotPos - m_lyotScale*m_fwLyotStepSize;
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwlyot" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwLyotTarget = m_fwLyotPos - m_lyotScale * m_fwLyotStepSize;
+        ip["target"]   = m_fwLyotTarget;
 
-      ui.button_lyot_u->setEnabled(false);
-      ui.button_lyot_d->setEnabled(false);
-   }
+        startPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+        ui.button_lyot_l->setEnabled( false );
+        ui.button_lyot_r->setEnabled( false );
+        ui.button_lyot_scale->setEnabled( false );
+        ui.labelLyot->setEnabled( false );
+    }
 
-   sendNewProperty(ip);
-
-
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_lyot_r_pressed()
 {
-   pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-   if(m_camera == FLOWFS || m_camera == CAMSCIS)
-   {
-      ip.setDevice("picomotors");
-      ip.setName("picolyot_pos");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_picoLyotPos - m_lyotScale*m_picoLyotStepSize;
+    if( m_camera == FLOWFS || m_camera == CAMSCIS )
+    {
+        ip.setDevice( "picomotors" );
+        ip.setName( "picolyot_pos" );
+        ip.add( pcf::IndiElement( "target" ) );
+        ip["target"] = m_picoLyotPos - m_lyotScale * m_picoLyotStepSize;
 
-      disablePicoButtons();
-   }
-   else
-   {
-      ip.setDevice("fwlyot");
-      ip.setName("filter");
-      ip.add(pcf::IndiElement("target"));
-      ip["target"] = m_fwLyotPos + m_lyotScale*m_fwLyotStepSize;
+        disablePicoButtons();
+    }
+    else
+    {
+        ip.setDevice( "fwlyot" );
+        ip.setName( "filter" );
+        ip.add( pcf::IndiElement( "target" ) );
+        m_fwLyotTarget = m_fwLyotPos + m_lyotScale * m_fwLyotStepSize;
+        ip["target"]   = m_fwLyotTarget;
 
-      ui.button_lyot_u->setEnabled(false);
-      ui.button_lyot_d->setEnabled(false);
-   }
+        startPendingCommand( m_fwLyotCommandPending, m_fwLyotPendingTimer, m_fwLyotPendingRefreshRequested );
+        ui.button_lyot_l->setEnabled( false );
+        ui.button_lyot_r->setEnabled( false );
+        ui.button_lyot_scale->setEnabled( false );
+        ui.labelLyot->setEnabled( false );
+    }
 
-   sendNewProperty(ip);
-
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_lyot_scale_pressed()
@@ -1353,20 +1587,18 @@ void coronAlign::on_button_lyot_scale_pressed()
    {
       m_lyotScale = 1;
    }
-   else if(m_lyotScale == 1)
+   else if( m_lyotScale == 1 )
    {
-      m_lyotScale = 100;
+       m_lyotScale = 100;
    }
    else
    {
-      m_lyotScale = 1;
+       m_lyotScale = 1;
    }
 
    char ss[5];
-   snprintf(ss, 5, "%d", m_lyotScale);
-   ui.button_lyot_scale->setText(ss);
-
-
+   snprintf( ss, 5, "%d", m_lyotScale );
+   ui.button_lyot_scale->setText( ss );
 }
 
 void coronAlign::on_button_piaa_l_pressed()
@@ -1374,43 +1606,42 @@ void coronAlign::on_button_piaa_l_pressed()
 
     disablePicoButtons();
 
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("picomotors");
-    ip.setName("piaa0x_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaa0xPos - m_piaaScale*m_piaa0StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "piaa0x_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_piaa0xPos - m_piaaScale * m_piaa0StepSize;
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 
-    pcf::IndiProperty ip1(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip1( pcf::IndiProperty::Number );
 
-    ip1.setDevice("picomotors");
-    ip1.setName("piaa1x_pos");
-    ip1.add(pcf::IndiElement("target"));
-    ip1["target"] = m_piaa1xPos - m_piaaScale*m_piaa1StepSize;
+    ip1.setDevice( "picomotors" );
+    ip1.setName( "piaa1x_pos" );
+    ip1.add( pcf::IndiElement( "target" ) );
+    ip1["target"] = m_piaa1xPos - m_piaaScale * m_piaa1StepSize;
 
-    sendNewProperty(ip1);
-
+    sendNewProperty( ip1 );
 }
 
 void coronAlign::on_button_piaa_r_pressed()
 {
     disablePicoButtons();
 
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("picomotors");
-    ip.setName("piaa0x_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaa0xPos + m_piaaScale*m_piaa0StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "piaa0x_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_piaa0xPos + m_piaaScale * m_piaa0StepSize;
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 
-    pcf::IndiProperty ip1(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip1( pcf::IndiProperty::Number );
 
-    ip1.setDevice("picomotors");
-    ip1.setName("piaa1x_pos");
+    ip1.setDevice( "picomotors" );
+    ip1.setName( "piaa1x_pos" );
     ip1.add(pcf::IndiElement("target"));
     ip1["target"] = m_piaa1xPos + m_piaaScale*m_piaa1StepSize;
 
@@ -1419,28 +1650,40 @@ void coronAlign::on_button_piaa_r_pressed()
 
 void coronAlign::on_button_piaa_u_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("stagepiaa");
-    ip.setName("position");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaaPos - m_piaaScale*m_piaaStepSize;
+    ip.setDevice( "stagepiaa" );
+    ip.setName( "position" );
+    ip.add( pcf::IndiElement( "target" ) );
+    m_piaaTarget = m_piaaPos - m_piaaScale * m_piaaStepSize;
+    ip["target"] = m_piaaTarget;
 
-    sendNewProperty(ip);
+    startPendingCommand( m_piaaCommandPending, m_piaaPendingTimer, m_piaaPendingRefreshRequested );
+    ui.button_piaa_u->setEnabled( false );
+    ui.button_piaa_d->setEnabled( false );
+    ui.button_piaa_scale->setEnabled( false );
+    ui.labelPIAA->setEnabled( false );
 
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_piaa_d_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("stagepiaa");
-    ip.setName("position");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaaPos + m_piaaScale*m_piaaStepSize;
+    ip.setDevice( "stagepiaa" );
+    ip.setName( "position" );
+    ip.add( pcf::IndiElement( "target" ) );
+    m_piaaTarget = m_piaaPos + m_piaaScale * m_piaaStepSize;
+    ip["target"] = m_piaaTarget;
 
-    sendNewProperty(ip);
+    startPendingCommand( m_piaaCommandPending, m_piaaPendingTimer, m_piaaPendingRefreshRequested );
+    ui.button_piaa_u->setEnabled( false );
+    ui.button_piaa_d->setEnabled( false );
+    ui.button_piaa_scale->setEnabled( false );
+    ui.labelPIAA->setEnabled( false );
 
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_piaa_scale_pressed()
@@ -1548,71 +1791,70 @@ void coronAlign::on_button_piaa1_r_pressed()
 {
     pcf::IndiProperty ip(pcf::IndiProperty::Number);
 
-    ip.setDevice("picomotors");
-    ip.setName("piaa1x_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaa1xPos + m_piaa1Scale*m_piaa1StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "piaa1x_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_piaa1xPos + m_piaa1Scale * m_piaa1StepSize;
 
     disablePicoButtons();
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_piaa1_u_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("picomotors");
-    ip.setName("piaa1y_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaa1yPos - m_piaa1Scale*m_piaa1StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "piaa1y_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_piaa1yPos - m_piaa1Scale * m_piaa1StepSize;
 
     disablePicoButtons();
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_piaa1_d_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("picomotors");
-    ip.setName("piaa1y_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_piaa1yPos + m_piaa1Scale*m_piaa1StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "piaa1y_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_piaa1yPos + m_piaa1Scale * m_piaa1StepSize;
 
     disablePicoButtons();
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_piaa1_scale_pressed()
 {
-    if( m_piaa1Scale == 100)
-   {
-      m_piaa1Scale = 10;
-   }
-   else if(m_piaa1Scale == 10)
-   {
-      m_piaa1Scale = 5;
-   }
-   else if(m_piaa1Scale == 5)
-   {
-      m_piaa1Scale = 1;
-   }
-   else if(m_piaa1Scale == 1)
-   {
-      m_piaa1Scale = 100;
-   }
-   else
-   {
-      m_piaa1Scale = 1;
-   }
+    if( m_piaa1Scale == 100 )
+    {
+        m_piaa1Scale = 10;
+    }
+    else if( m_piaa1Scale == 10 )
+    {
+        m_piaa1Scale = 5;
+    }
+    else if( m_piaa1Scale == 5 )
+    {
+        m_piaa1Scale = 1;
+    }
+    else if( m_piaa1Scale == 1 )
+    {
+        m_piaa1Scale = 100;
+    }
+    else
+    {
+        m_piaa1Scale = 1;
+    }
 
-   char ss[5];
-   snprintf(ss, 5, "%d", m_piaa1Scale);
-   ui.button_piaa1_scale->setText(ss);
-
+    char ss[5];
+    snprintf( ss, 5, "%d", m_piaa1Scale );
+    ui.button_piaa1_scale->setText( ss );
 }
 
 void coronAlign::on_button_ipiaa_l_pressed()
@@ -1622,34 +1864,34 @@ void coronAlign::on_button_ipiaa_l_pressed()
     pcf::IndiProperty ip(pcf::IndiProperty::Number);
 
     ip.setDevice("picomotors");
-    ip.setName("ipiaa0x_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_ipiaa0xPos + m_ipiaaScale*m_ipiaa0StepSize;
+    ip.setName( "ipiaa0x_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_ipiaa0xPos + m_ipiaaScale * m_ipiaa0StepSize;
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 
-    pcf::IndiProperty ip1(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip1( pcf::IndiProperty::Number );
 
-    ip1.setDevice("picomotors");
-    ip1.setName("ipiaa1x_pos");
-    ip1.add(pcf::IndiElement("target"));
-    ip1["target"] = m_ipiaa1xPos + m_ipiaaScale*m_ipiaa1StepSize;
+    ip1.setDevice( "picomotors" );
+    ip1.setName( "ipiaa1x_pos" );
+    ip1.add( pcf::IndiElement( "target" ) );
+    ip1["target"] = m_ipiaa1xPos + m_ipiaaScale * m_ipiaa1StepSize;
 
-    sendNewProperty(ip1);
+    sendNewProperty( ip1 );
 }
 
 void coronAlign::on_button_ipiaa_r_pressed()
 {
     disablePicoButtons();
 
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("picomotors");
-    ip.setName("ipiaa0x_pos");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_ipiaa0xPos - m_ipiaaScale*m_ipiaa0StepSize;
+    ip.setDevice( "picomotors" );
+    ip.setName( "ipiaa0x_pos" );
+    ip.add( pcf::IndiElement( "target" ) );
+    ip["target"] = m_ipiaa0xPos - m_ipiaaScale * m_ipiaa0StepSize;
 
-    sendNewProperty(ip);
+    sendNewProperty( ip );
 
     pcf::IndiProperty ip1(pcf::IndiProperty::Number);
 
@@ -1663,26 +1905,40 @@ void coronAlign::on_button_ipiaa_r_pressed()
 
 void coronAlign::on_button_ipiaa_u_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("stageipiaa");
-    ip.setName("position");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_ipiaaPos - m_ipiaaScale*m_ipiaaStepSize;
-    sendNewProperty(ip);
+    ip.setDevice( "stageipiaa" );
+    ip.setName( "position" );
+    ip.add( pcf::IndiElement( "target" ) );
+    m_ipiaaTarget = m_ipiaaPos - m_ipiaaScale * m_ipiaaStepSize;
+    ip["target"]  = m_ipiaaTarget;
+
+    startPendingCommand( m_ipiaaCommandPending, m_ipiaaPendingTimer, m_ipiaaPendingRefreshRequested );
+    ui.button_ipiaa_u->setEnabled( false );
+    ui.button_ipiaa_d->setEnabled( false );
+    ui.button_ipiaa_scale->setEnabled( false );
+    ui.labeliPIAA->setEnabled( false );
+
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_ipiaa_d_pressed()
 {
-    pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-    ip.setDevice("stageipiaa");
-    ip.setName("position");
-    ip.add(pcf::IndiElement("target"));
-    ip["target"] = m_ipiaaPos + m_ipiaaScale*m_ipiaaStepSize;
+    ip.setDevice( "stageipiaa" );
+    ip.setName( "position" );
+    ip.add( pcf::IndiElement( "target" ) );
+    m_ipiaaTarget = m_ipiaaPos + m_ipiaaScale * m_ipiaaStepSize;
+    ip["target"]  = m_ipiaaTarget;
 
-    sendNewProperty(ip);
+    startPendingCommand( m_ipiaaCommandPending, m_ipiaaPendingTimer, m_ipiaaPendingRefreshRequested );
+    ui.button_ipiaa_u->setEnabled( false );
+    ui.button_ipiaa_d->setEnabled( false );
+    ui.button_ipiaa_scale->setEnabled( false );
+    ui.labeliPIAA->setEnabled( false );
 
+    sendNewProperty( ip );
 }
 
 void coronAlign::on_button_ipiaa_scale_pressed()

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -840,6 +840,8 @@ void dmCtrl::syncComboOptions( QComboBox *combo, const std::vector<std::string> 
     {
         combo->addItem( option.c_str() );
     }
+
+    updateXwComboBoxPopupWidth( combo );
 }
 
 void dmCtrl::on_buttonInit_pressed()

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -6,6 +6,7 @@
 #ifndef dmCtrl_hpp
 #define dmCtrl_hpp
 
+#include <QComboBox>
 #include <QSignalBlocker>
 #include <QTimer>
 
@@ -30,21 +31,25 @@ class dmCtrl : public xWidget
     std::string m_dmName;    ///< INDI device name for the target DM application.
     std::string m_shmimName; ///< Shared-memory stream name reported by the DM app.
 
-    std::string              m_flatShmim;         ///< Shared-memory stream backing the selected flat.
-    bool                     m_flatSet{ false };  ///< True when a flat is currently applied.
-    std::string              m_flatName;          ///< Name of the selected flat option.
-    std::vector<std::string> m_flatOptions;       ///< Available flat options from INDI.
-    std::string              m_flatRequestedName; ///< Flat option requested by the user but not yet confirmed.
-    bool    m_flatSelectionPending{ false };      ///< True while the GUI should hold a requested flat selection.
-    QTimer *m_flatSelectionTimer{ nullptr };      ///< Clears unconfirmed flat selections after a timeout.
+    std::string              m_flatShmim;          ///< Shared-memory stream backing the selected flat.
+    bool                     m_flatSet{ false };   ///< True when a flat is currently applied.
+    std::string              m_flatName;           ///< Name of the selected flat option.
+    std::vector<std::string> m_flatOptions;        ///< Available flat options from INDI.
+    bool        m_flatPropertyRefreshing{ false }; ///< True while the DM app is redefining the flat options.
+    std::string m_flatRequestedName;               ///< Flat option requested by the user but not yet confirmed.
+    bool        m_flatSelectionPending{ false };   ///< True while the GUI should hold a requested flat selection.
+    QTimer     *m_flatSelectionTimer{ nullptr };   ///< Clears unconfirmed flat selections after a timeout.
+    QTimer     *m_flatRefreshTimer{ nullptr };     ///< Clears stale flat options if a redefine never completes.
 
-    std::string              m_testShmim;         ///< Shared-memory stream backing the selected test pattern.
-    bool                     m_testSet{ false };  ///< True when a test pattern is currently applied.
-    std::string              m_testName;          ///< Name of the selected test option.
-    std::vector<std::string> m_testOptions;       ///< Available test options from INDI.
-    std::string              m_testRequestedName; ///< Test option requested by the user but not yet confirmed.
-    bool    m_testSelectionPending{ false };      ///< True while the GUI should hold a requested test selection.
-    QTimer *m_testSelectionTimer{ nullptr };      ///< Clears unconfirmed test selections after a timeout.
+    std::string              m_testShmim;          ///< Shared-memory stream backing the selected test pattern.
+    bool                     m_testSet{ false };   ///< True when a test pattern is currently applied.
+    std::string              m_testName;           ///< Name of the selected test option.
+    std::vector<std::string> m_testOptions;        ///< Available test options from INDI.
+    bool        m_testPropertyRefreshing{ false }; ///< True while the DM app is redefining the test options.
+    std::string m_testRequestedName;               ///< Test option requested by the user but not yet confirmed.
+    bool        m_testSelectionPending{ false };   ///< True while the GUI should hold a requested test selection.
+    QTimer     *m_testSelectionTimer{ nullptr };   ///< Clears unconfirmed test selections after a timeout.
+    QTimer     *m_testRefreshTimer{ nullptr };     ///< Clears stale test options if a redefine never completes.
 
     std::mutex m_stateMutex; ///< Guards cached state copied into the GUI thread.
 
@@ -122,8 +127,14 @@ class dmCtrl : public xWidget
     /// Clears an unconfirmed flat selection after the timeout expires.
     void flatSelectionTimerOut();
 
+    /// Clears cached flat options after an incomplete property recreation.
+    void flatRefreshTimerOut();
+
     /// Clears an unconfirmed test selection after the timeout expires.
     void testSelectionTimerOut();
+
+    /// Clears cached test options after an incomplete property recreation.
+    void testRefreshTimerOut();
 
   signals:
     /// Queues connected-state GUI updates onto the widget thread.
@@ -135,7 +146,29 @@ class dmCtrl : public xWidget
     /// Queues state refresh updates onto the widget thread.
     void doUpdateGUI();
 
+    /// Stops the pending flat-selection timeout on the widget thread.
+    void flatSelectionTimerStop();
+
+    /// Starts the transient flat-refresh timeout on the widget thread.
+    void flatRefreshTimerStart( int timeoutMs /**< [in] Timeout duration in milliseconds. */ );
+
+    /// Stops the transient flat-refresh timeout on the widget thread.
+    void flatRefreshTimerStop();
+
+    /// Stops the pending test-selection timeout on the widget thread.
+    void testSelectionTimerStop();
+
+    /// Starts the transient test-refresh timeout on the widget thread.
+    void testRefreshTimerStart( int timeoutMs /**< [in] Timeout duration in milliseconds. */ );
+
+    /// Stops the transient test-refresh timeout on the widget thread.
+    void testRefreshTimerStop();
+
   private:
+    /// Replace combo-box contents only when the option list has actually changed.
+    void syncComboOptions( QComboBox                      *combo /**< [in] Combo box to synchronize. */,
+                           const std::vector<std::string> &options /**< [in] Options that should be displayed. */ );
+
     Ui::dmCtrl ui; ///< Generated Qt UI object.
 };
 
@@ -175,10 +208,28 @@ dmCtrl::dmCtrl( std::string &dmName, QWidget *Parent, Qt::WindowFlags f ) : xWid
     connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ), Qt::QueuedConnection );
 
     m_flatSelectionTimer = new QTimer( this );
+    m_flatSelectionTimer->setSingleShot( true );
     connect( m_flatSelectionTimer, SIGNAL( timeout() ), this, SLOT( flatSelectionTimerOut() ) );
+    connect( this, SIGNAL( flatSelectionTimerStop() ), m_flatSelectionTimer, SLOT( stop() ), Qt::QueuedConnection );
+
+    m_flatRefreshTimer = new QTimer( this );
+    m_flatRefreshTimer->setSingleShot( true );
+    connect( m_flatRefreshTimer, SIGNAL( timeout() ), this, SLOT( flatRefreshTimerOut() ) );
+    connect(
+        this, SIGNAL( flatRefreshTimerStart( int ) ), m_flatRefreshTimer, SLOT( start( int ) ), Qt::QueuedConnection );
+    connect( this, SIGNAL( flatRefreshTimerStop() ), m_flatRefreshTimer, SLOT( stop() ), Qt::QueuedConnection );
 
     m_testSelectionTimer = new QTimer( this );
+    m_testSelectionTimer->setSingleShot( true );
     connect( m_testSelectionTimer, SIGNAL( timeout() ), this, SLOT( testSelectionTimerOut() ) );
+    connect( this, SIGNAL( testSelectionTimerStop() ), m_testSelectionTimer, SLOT( stop() ), Qt::QueuedConnection );
+
+    m_testRefreshTimer = new QTimer( this );
+    m_testRefreshTimer->setSingleShot( true );
+    connect( m_testRefreshTimer, SIGNAL( timeout() ), this, SLOT( testRefreshTimerOut() ) );
+    connect(
+        this, SIGNAL( testRefreshTimerStart( int ) ), m_testRefreshTimer, SLOT( start( int ) ), Qt::QueuedConnection );
+    connect( this, SIGNAL( testRefreshTimerStop() ), m_testRefreshTimer, SLOT( stop() ), Qt::QueuedConnection );
 
     onDisconnectGUI();
 }
@@ -251,12 +302,14 @@ void dmCtrl::onDisconnectGUI()
         m_flatSet = false;
         m_flatName.clear();
         m_flatOptions.clear();
+        m_flatPropertyRefreshing = false;
         m_flatRequestedName.clear();
         m_flatSelectionPending = false;
         m_testShmim.clear();
         m_testSet = false;
         m_testName.clear();
         m_testOptions.clear();
+        m_testPropertyRefreshing = false;
         m_testRequestedName.clear();
         m_testSelectionPending = false;
     }
@@ -269,6 +322,16 @@ void dmCtrl::onDisconnectGUI()
     if( m_testSelectionTimer )
     {
         m_testSelectionTimer->stop();
+    }
+
+    if( m_flatRefreshTimer )
+    {
+        m_flatRefreshTimer->stop();
+    }
+
+    if( m_testRefreshTimer )
+    {
+        m_testRefreshTimer->stop();
     }
 
     ui.fsmState->setEnabled( false );
@@ -333,42 +396,68 @@ void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
         return;
     }
 
-    if( ipRecv.getName() == "flat" || ipRecv.getName() == "flat_shmim" || ipRecv.getName() == "flat_set" )
+    if( ipRecv.getName() == "flat" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_flatPropertyRefreshing = true;
+        }
+
+        emit flatRefreshTimerStart( 2000 );
+
+        return;
+    }
+
+    if( ipRecv.getName() == "flat_shmim" )
     {
         { // mutex scope
             std::lock_guard<std::mutex> lock( m_stateMutex );
             m_flatShmim.clear();
-            m_flatSet = false;
-            m_flatName.clear();
-            m_flatOptions.clear();
-            m_flatRequestedName.clear();
-            m_flatSelectionPending = false;
-        }
-
-        if( m_flatSelectionTimer )
-        {
-            m_flatSelectionTimer->stop();
         }
 
         emit doUpdateGUI();
         return;
     }
 
-    if( ipRecv.getName() == "test" || ipRecv.getName() == "test_shmim" || ipRecv.getName() == "test_set" )
+    if( ipRecv.getName() == "flat_set" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_flatSet = false;
+        }
+
+        emit doUpdateGUI();
+        return;
+    }
+
+    if( ipRecv.getName() == "test" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_testPropertyRefreshing = true;
+        }
+
+        emit testRefreshTimerStart( 2000 );
+
+        return;
+    }
+
+    if( ipRecv.getName() == "test_shmim" )
     {
         { // mutex scope
             std::lock_guard<std::mutex> lock( m_stateMutex );
             m_testShmim.clear();
-            m_testSet = false;
-            m_testName.clear();
-            m_testOptions.clear();
-            m_testRequestedName.clear();
-            m_testSelectionPending = false;
         }
 
-        if( m_testSelectionTimer )
-        {
-            m_testSelectionTimer->stop();
+        emit doUpdateGUI();
+        return;
+    }
+
+    if( ipRecv.getName() == "test_set" )
+    {
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_testSet = false;
         }
 
         emit doUpdateGUI();
@@ -402,28 +491,50 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
     else if( ipRecv.getName() == "flat" )
     {
-        bool flatConfirmed = false;
+        bool flatStopSelectionTimer = false;
+        bool flatRequestedAvailable = false;
+        bool flatStopRefreshTimer   = false;
 
-        std::lock_guard<std::mutex> lock( m_stateMutex );
-        m_flatOptions.clear();
-        m_flatName = "";
-        for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
-        {
-            m_flatOptions.push_back( it->first );
-            if( ipRecv[it->first] == pcf::IndiElement::On )
-                m_flatName = it->first;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_flatPropertyRefreshing = false;
+            m_flatOptions.clear();
+            m_flatName = "";
+            for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
+            {
+                m_flatOptions.push_back( it->first );
+                if( it->first == m_flatRequestedName )
+                {
+                    flatRequestedAvailable = true;
+                }
+                if( ipRecv[it->first] == pcf::IndiElement::On )
+                    m_flatName = it->first;
+            }
+
+            if( m_flatSelectionPending && m_flatName == m_flatRequestedName )
+            {
+                m_flatRequestedName.clear();
+                m_flatSelectionPending = false;
+                flatStopSelectionTimer = true;
+            }
+            else if( m_flatSelectionPending && !m_flatRequestedName.empty() && !flatRequestedAvailable )
+            {
+                m_flatRequestedName.clear();
+                m_flatSelectionPending = false;
+                flatStopSelectionTimer = true;
+            }
+
+            flatStopRefreshTimer = true;
         }
 
-        if( m_flatSelectionPending && m_flatName == m_flatRequestedName )
+        if( flatStopRefreshTimer )
         {
-            m_flatRequestedName.clear();
-            m_flatSelectionPending = false;
-            flatConfirmed          = true;
+            emit flatRefreshTimerStop();
         }
 
-        if( flatConfirmed && m_flatSelectionTimer )
+        if( flatStopSelectionTimer )
         {
-            m_flatSelectionTimer->stop();
+            emit flatSelectionTimerStop();
         }
     }
     else if( ipRecv.getName() == "flat_shmim" )
@@ -447,28 +558,50 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
     else if( ipRecv.getName() == "test" )
     {
-        bool testConfirmed = false;
+        bool testStopSelectionTimer = false;
+        bool testRequestedAvailable = false;
+        bool testStopRefreshTimer   = false;
 
-        std::lock_guard<std::mutex> lock( m_stateMutex );
-        m_testOptions.clear();
-        m_testName = "";
-        for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
-        {
-            m_testOptions.push_back( it->first );
-            if( ipRecv[it->first] == pcf::IndiElement::On )
-                m_testName = it->first;
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            m_testPropertyRefreshing = false;
+            m_testOptions.clear();
+            m_testName = "";
+            for( auto it = ipRecv.getElements().begin(); it != ipRecv.getElements().end(); ++it )
+            {
+                m_testOptions.push_back( it->first );
+                if( it->first == m_testRequestedName )
+                {
+                    testRequestedAvailable = true;
+                }
+                if( ipRecv[it->first] == pcf::IndiElement::On )
+                    m_testName = it->first;
+            }
+
+            if( m_testSelectionPending && m_testName == m_testRequestedName )
+            {
+                m_testRequestedName.clear();
+                m_testSelectionPending = false;
+                testStopSelectionTimer = true;
+            }
+            else if( m_testSelectionPending && !m_testRequestedName.empty() && !testRequestedAvailable )
+            {
+                m_testRequestedName.clear();
+                m_testSelectionPending = false;
+                testStopSelectionTimer = true;
+            }
+
+            testStopRefreshTimer = true;
         }
 
-        if( m_testSelectionPending && m_testName == m_testRequestedName )
+        if( testStopRefreshTimer )
         {
-            m_testRequestedName.clear();
-            m_testSelectionPending = false;
-            testConfirmed          = true;
+            emit testRefreshTimerStop();
         }
 
-        if( testConfirmed && m_testSelectionTimer )
+        if( testStopSelectionTimer )
         {
-            m_testSelectionTimer->stop();
+            emit testSelectionTimerStop();
         }
     }
     else if( ipRecv.getName() == "test_shmim" )
@@ -515,24 +648,31 @@ void dmCtrl::updateGUI()
     std::vector<std::string> testOptions;
     bool                     flatSelectionPending{ false };
     bool                     testSelectionPending{ false };
+    bool                     flatPropertyRefreshing{ false };
+    bool                     testPropertyRefreshing{ false };
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_stateMutex );
-        appState             = m_appState;
-        shmimName            = m_shmimName;
-        flatShmim            = m_flatShmim;
-        testShmim            = m_testShmim;
-        flatSet              = m_flatSet;
-        testSet              = m_testSet;
-        flatName             = m_flatName;
-        flatRequestedName    = m_flatRequestedName;
-        testName             = m_testName;
-        testRequestedName    = m_testRequestedName;
-        flatOptions          = m_flatOptions;
-        testOptions          = m_testOptions;
-        flatSelectionPending = m_flatSelectionPending;
-        testSelectionPending = m_testSelectionPending;
+        appState               = m_appState;
+        shmimName              = m_shmimName;
+        flatShmim              = m_flatShmim;
+        testShmim              = m_testShmim;
+        flatSet                = m_flatSet;
+        testSet                = m_testSet;
+        flatName               = m_flatName;
+        flatRequestedName      = m_flatRequestedName;
+        testName               = m_testName;
+        testRequestedName      = m_testRequestedName;
+        flatOptions            = m_flatOptions;
+        testOptions            = m_testOptions;
+        flatSelectionPending   = m_flatSelectionPending;
+        testSelectionPending   = m_testSelectionPending;
+        flatPropertyRefreshing = m_flatPropertyRefreshing;
+        testPropertyRefreshing = m_testPropertyRefreshing;
     }
+
+    bool flatControlsAvailable = ( !flatPropertyRefreshing && !flatOptions.empty() );
+    bool testControlsAvailable = ( !testPropertyRefreshing && !testOptions.empty() );
 
     ui.labelShmimName_value->setText( shmimName.c_str() );
     ui.labelFlatShmim_value->setText( flatShmim.c_str() );
@@ -541,9 +681,7 @@ void dmCtrl::updateGUI()
     { // mutex scope
         QSignalBlocker blockFlat( ui.comboSelectFlat );
 
-        ui.comboSelectFlat->clear();
-        for( const auto &opt : flatOptions )
-            ui.comboSelectFlat->addItem( opt.c_str() );
+        syncComboOptions( ui.comboSelectFlat, flatOptions );
 
         std::string flatDisplayName = flatName;
         if( flatSelectionPending && !flatRequestedName.empty() )
@@ -568,9 +706,7 @@ void dmCtrl::updateGUI()
     { // mutex scope
         QSignalBlocker blockTest( ui.comboSelectTest );
 
-        ui.comboSelectTest->clear();
-        for( const auto &opt : testOptions )
-            ui.comboSelectTest->addItem( opt.c_str() );
+        syncComboOptions( ui.comboSelectTest, testOptions );
 
         std::string testDisplayName = testName;
         if( testSelectionPending && !testRequestedName.empty() )
@@ -599,6 +735,8 @@ void dmCtrl::updateGUI()
         ui.buttonInit->setEnabled( false );
         ui.buttonZero->setEnabled( false );
         ui.buttonRelease->setEnabled( false );
+        ui.comboSelectFlat->setEnabled( false );
+        ui.comboSelectTest->setEnabled( false );
 
         ui.buttonSetFlat->setEnabled( false );
         ui.buttonZeroFlat->setEnabled( false );
@@ -616,6 +754,8 @@ void dmCtrl::updateGUI()
         ui.buttonInit->setEnabled( true );
         ui.buttonZero->setEnabled( false );
         ui.buttonRelease->setEnabled( false );
+        ui.comboSelectFlat->setEnabled( false );
+        ui.comboSelectTest->setEnabled( false );
 
         ui.buttonSetFlat->setEnabled( false );
         ui.buttonZeroFlat->setEnabled( false );
@@ -630,32 +770,77 @@ void dmCtrl::updateGUI()
     ui.buttonInit->setEnabled( false );
     ui.buttonZero->setEnabled( true );
     ui.buttonRelease->setEnabled( true );
+    ui.comboSelectFlat->setEnabled( flatControlsAvailable );
+    ui.comboSelectTest->setEnabled( testControlsAvailable );
 
-    if( flatSet == false )
+    if( flatControlsAvailable && flatSet == false )
     {
         ui.buttonSetFlat->setEnabled( true );
         ui.buttonZeroFlat->setEnabled( false );
     }
-    else
+    else if( flatControlsAvailable && flatSet == true )
     {
         ui.buttonSetFlat->setEnabled( false );
         ui.buttonZeroFlat->setEnabled( true );
     }
+    else
+    {
+        ui.buttonSetFlat->setEnabled( false );
+        ui.buttonZeroFlat->setEnabled( false );
+    }
 
-    if( testSet == false )
+    if( testControlsAvailable && testSet == false )
     {
         ui.buttonSetTest->setEnabled( true );
         ui.buttonZeroTest->setEnabled( false );
     }
-    else
+    else if( testControlsAvailable && testSet == true )
     {
         ui.buttonSetTest->setEnabled( false );
         ui.buttonZeroTest->setEnabled( true );
+    }
+    else
+    {
+        ui.buttonSetTest->setEnabled( false );
+        ui.buttonZeroTest->setEnabled( false );
     }
 
     m_inUpdate = false;
 
 } // updateGUI()
+
+void dmCtrl::syncComboOptions( QComboBox *combo, const std::vector<std::string> &options )
+{
+    if( combo == nullptr )
+    {
+        return;
+    }
+
+    bool optionsChanged = ( combo->count() != static_cast<int>( options.size() ) );
+
+    if( !optionsChanged )
+    {
+        for( int n = 0; n < combo->count(); ++n )
+        {
+            if( combo->itemText( n ).toStdString() != options[static_cast<size_t>( n )] )
+            {
+                optionsChanged = true;
+                break;
+            }
+        }
+    }
+
+    if( !optionsChanged )
+    {
+        return;
+    }
+
+    combo->clear();
+    for( const auto &option : options )
+    {
+        combo->addItem( option.c_str() );
+    }
+}
 
 void dmCtrl::on_buttonInit_pressed()
 {
@@ -835,12 +1020,60 @@ void dmCtrl::flatSelectionTimerOut()
     emit doUpdateGUI();
 }
 
+void dmCtrl::flatRefreshTimerOut()
+{
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        if( !m_flatPropertyRefreshing )
+        {
+            return;
+        }
+
+        m_flatName.clear();
+        m_flatOptions.clear();
+        m_flatRequestedName.clear();
+        m_flatSelectionPending   = false;
+        m_flatPropertyRefreshing = false;
+    }
+
+    if( m_flatSelectionTimer )
+    {
+        m_flatSelectionTimer->stop();
+    }
+
+    emit doUpdateGUI();
+}
+
 void dmCtrl::testSelectionTimerOut()
 {
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_stateMutex );
         m_testRequestedName.clear();
         m_testSelectionPending = false;
+    }
+
+    emit doUpdateGUI();
+}
+
+void dmCtrl::testRefreshTimerOut()
+{
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        if( !m_testPropertyRefreshing )
+        {
+            return;
+        }
+
+        m_testName.clear();
+        m_testOptions.clear();
+        m_testRequestedName.clear();
+        m_testSelectionPending   = false;
+        m_testPropertyRefreshing = false;
+    }
+
+    if( m_testSelectionTimer )
+    {
+        m_testSelectionTimer->stop();
     }
 
     emit doUpdateGUI();

--- a/gui/widgets/dmCtrl/dmCtrl.hpp
+++ b/gui/widgets/dmCtrl/dmCtrl.hpp
@@ -7,6 +7,7 @@
 #define dmCtrl_hpp
 
 #include <QSignalBlocker>
+#include <QTimer>
 
 #include <mutex>
 #include <vector>
@@ -29,15 +30,21 @@ class dmCtrl : public xWidget
     std::string m_dmName;    ///< INDI device name for the target DM application.
     std::string m_shmimName; ///< Shared-memory stream name reported by the DM app.
 
-    std::string              m_flatShmim;        ///< Shared-memory stream backing the selected flat.
-    bool                     m_flatSet{ false }; ///< True when a flat is currently applied.
-    std::string              m_flatName;         ///< Name of the selected flat option.
-    std::vector<std::string> m_flatOptions;      ///< Available flat options from INDI.
+    std::string              m_flatShmim;         ///< Shared-memory stream backing the selected flat.
+    bool                     m_flatSet{ false };  ///< True when a flat is currently applied.
+    std::string              m_flatName;          ///< Name of the selected flat option.
+    std::vector<std::string> m_flatOptions;       ///< Available flat options from INDI.
+    std::string              m_flatRequestedName; ///< Flat option requested by the user but not yet confirmed.
+    bool    m_flatSelectionPending{ false };      ///< True while the GUI should hold a requested flat selection.
+    QTimer *m_flatSelectionTimer{ nullptr };      ///< Clears unconfirmed flat selections after a timeout.
 
-    std::string              m_testShmim;        ///< Shared-memory stream backing the selected test pattern.
-    bool                     m_testSet{ false }; ///< True when a test pattern is currently applied.
-    std::string              m_testName;         ///< Name of the selected test option.
-    std::vector<std::string> m_testOptions;      ///< Available test options from INDI.
+    std::string              m_testShmim;         ///< Shared-memory stream backing the selected test pattern.
+    bool                     m_testSet{ false };  ///< True when a test pattern is currently applied.
+    std::string              m_testName;          ///< Name of the selected test option.
+    std::vector<std::string> m_testOptions;       ///< Available test options from INDI.
+    std::string              m_testRequestedName; ///< Test option requested by the user but not yet confirmed.
+    bool    m_testSelectionPending{ false };      ///< True while the GUI should hold a requested test selection.
+    QTimer *m_testSelectionTimer{ nullptr };      ///< Clears unconfirmed test selections after a timeout.
 
     std::mutex m_stateMutex; ///< Guards cached state copied into the GUI thread.
 
@@ -112,6 +119,12 @@ class dmCtrl : public xWidget
     /// Sends request to clear applied test.
     void on_buttonZeroTest_pressed();
 
+    /// Clears an unconfirmed flat selection after the timeout expires.
+    void flatSelectionTimerOut();
+
+    /// Clears an unconfirmed test selection after the timeout expires.
+    void testSelectionTimerOut();
+
   signals:
     /// Queues connected-state GUI updates onto the widget thread.
     void doOnConnect();
@@ -160,6 +173,12 @@ dmCtrl::dmCtrl( std::string &dmName, QWidget *Parent, Qt::WindowFlags f ) : xWid
     connect( this, SIGNAL( doOnConnect() ), this, SLOT( onConnectGUI() ), Qt::QueuedConnection );
     connect( this, SIGNAL( doOnDisconnect() ), this, SLOT( onDisconnectGUI() ), Qt::QueuedConnection );
     connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ), Qt::QueuedConnection );
+
+    m_flatSelectionTimer = new QTimer( this );
+    connect( m_flatSelectionTimer, SIGNAL( timeout() ), this, SLOT( flatSelectionTimerOut() ) );
+
+    m_testSelectionTimer = new QTimer( this );
+    connect( m_testSelectionTimer, SIGNAL( timeout() ), this, SLOT( testSelectionTimerOut() ) );
 
     onDisconnectGUI();
 }
@@ -232,10 +251,24 @@ void dmCtrl::onDisconnectGUI()
         m_flatSet = false;
         m_flatName.clear();
         m_flatOptions.clear();
+        m_flatRequestedName.clear();
+        m_flatSelectionPending = false;
         m_testShmim.clear();
         m_testSet = false;
         m_testName.clear();
         m_testOptions.clear();
+        m_testRequestedName.clear();
+        m_testSelectionPending = false;
+    }
+
+    if( m_flatSelectionTimer )
+    {
+        m_flatSelectionTimer->stop();
+    }
+
+    if( m_testSelectionTimer )
+    {
+        m_testSelectionTimer->stop();
     }
 
     ui.fsmState->setEnabled( false );
@@ -308,6 +341,13 @@ void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
             m_flatSet = false;
             m_flatName.clear();
             m_flatOptions.clear();
+            m_flatRequestedName.clear();
+            m_flatSelectionPending = false;
+        }
+
+        if( m_flatSelectionTimer )
+        {
+            m_flatSelectionTimer->stop();
         }
 
         emit doUpdateGUI();
@@ -322,6 +362,13 @@ void dmCtrl::handleDelProperty( const pcf::IndiProperty &ipRecv )
             m_testSet = false;
             m_testName.clear();
             m_testOptions.clear();
+            m_testRequestedName.clear();
+            m_testSelectionPending = false;
+        }
+
+        if( m_testSelectionTimer )
+        {
+            m_testSelectionTimer->stop();
         }
 
         emit doUpdateGUI();
@@ -355,6 +402,8 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
     else if( ipRecv.getName() == "flat" )
     {
+        bool flatConfirmed = false;
+
         std::lock_guard<std::mutex> lock( m_stateMutex );
         m_flatOptions.clear();
         m_flatName = "";
@@ -363,6 +412,18 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
             m_flatOptions.push_back( it->first );
             if( ipRecv[it->first] == pcf::IndiElement::On )
                 m_flatName = it->first;
+        }
+
+        if( m_flatSelectionPending && m_flatName == m_flatRequestedName )
+        {
+            m_flatRequestedName.clear();
+            m_flatSelectionPending = false;
+            flatConfirmed          = true;
+        }
+
+        if( flatConfirmed && m_flatSelectionTimer )
+        {
+            m_flatSelectionTimer->stop();
         }
     }
     else if( ipRecv.getName() == "flat_shmim" )
@@ -386,6 +447,8 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
     }
     else if( ipRecv.getName() == "test" )
     {
+        bool testConfirmed = false;
+
         std::lock_guard<std::mutex> lock( m_stateMutex );
         m_testOptions.clear();
         m_testName = "";
@@ -394,6 +457,18 @@ void dmCtrl::handleSetProperty( const pcf::IndiProperty &ipRecv )
             m_testOptions.push_back( it->first );
             if( ipRecv[it->first] == pcf::IndiElement::On )
                 m_testName = it->first;
+        }
+
+        if( m_testSelectionPending && m_testName == m_testRequestedName )
+        {
+            m_testRequestedName.clear();
+            m_testSelectionPending = false;
+            testConfirmed          = true;
+        }
+
+        if( testConfirmed && m_testSelectionTimer )
+        {
+            m_testSelectionTimer->stop();
         }
     }
     else if( ipRecv.getName() == "test_shmim" )
@@ -433,22 +508,30 @@ void dmCtrl::updateGUI()
     bool                     flatSet{ false };
     bool                     testSet{ false };
     std::string              flatName;
+    std::string              flatRequestedName;
     std::string              testName;
+    std::string              testRequestedName;
     std::vector<std::string> flatOptions;
     std::vector<std::string> testOptions;
+    bool                     flatSelectionPending{ false };
+    bool                     testSelectionPending{ false };
 
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_stateMutex );
-        appState    = m_appState;
-        shmimName   = m_shmimName;
-        flatShmim   = m_flatShmim;
-        testShmim   = m_testShmim;
-        flatSet     = m_flatSet;
-        testSet     = m_testSet;
-        flatName    = m_flatName;
-        testName    = m_testName;
-        flatOptions = m_flatOptions;
-        testOptions = m_testOptions;
+        appState             = m_appState;
+        shmimName            = m_shmimName;
+        flatShmim            = m_flatShmim;
+        testShmim            = m_testShmim;
+        flatSet              = m_flatSet;
+        testSet              = m_testSet;
+        flatName             = m_flatName;
+        flatRequestedName    = m_flatRequestedName;
+        testName             = m_testName;
+        testRequestedName    = m_testRequestedName;
+        flatOptions          = m_flatOptions;
+        testOptions          = m_testOptions;
+        flatSelectionPending = m_flatSelectionPending;
+        testSelectionPending = m_testSelectionPending;
     }
 
     ui.labelShmimName_value->setText( shmimName.c_str() );
@@ -462,11 +545,23 @@ void dmCtrl::updateGUI()
         for( const auto &opt : flatOptions )
             ui.comboSelectFlat->addItem( opt.c_str() );
 
-        if( !flatName.empty() )
+        std::string flatDisplayName = flatName;
+        if( flatSelectionPending && !flatRequestedName.empty() )
         {
-            int flatIndex = ui.comboSelectFlat->findText( flatName.c_str() );
+            flatDisplayName = flatRequestedName;
+        }
+
+        if( !flatDisplayName.empty() )
+        {
+            int flatIndex = ui.comboSelectFlat->findText( flatDisplayName.c_str() );
             if( flatIndex >= 0 )
                 ui.comboSelectFlat->setCurrentIndex( flatIndex );
+            else
+                ui.comboSelectFlat->setCurrentIndex( -1 );
+        }
+        else
+        {
+            ui.comboSelectFlat->setCurrentIndex( -1 );
         }
     }
 
@@ -477,11 +572,23 @@ void dmCtrl::updateGUI()
         for( const auto &opt : testOptions )
             ui.comboSelectTest->addItem( opt.c_str() );
 
-        if( !testName.empty() )
+        std::string testDisplayName = testName;
+        if( testSelectionPending && !testRequestedName.empty() )
         {
-            int testIndex = ui.comboSelectTest->findText( testName.c_str() );
+            testDisplayName = testRequestedName;
+        }
+
+        if( !testDisplayName.empty() )
+        {
+            int testIndex = ui.comboSelectTest->findText( testDisplayName.c_str() );
             if( testIndex >= 0 )
                 ui.comboSelectTest->setCurrentIndex( testIndex );
+            else
+                ui.comboSelectTest->setCurrentIndex( -1 );
+        }
+        else
+        {
+            ui.comboSelectTest->setCurrentIndex( -1 );
         }
     }
 
@@ -620,6 +727,18 @@ void dmCtrl::on_comboSelectFlat_activated( int index )
         else
             ipFreq[eln] = pcf::IndiElement::Off;
     }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_flatRequestedName    = choice;
+        m_flatSelectionPending = true;
+    }
+
+    if( m_flatSelectionTimer )
+    {
+        m_flatSelectionTimer->start( 10000 );
+    }
+
     sendNewProperty( ipFreq );
 }
 
@@ -666,6 +785,18 @@ void dmCtrl::on_comboSelectTest_activated( int index )
         else
             ipFreq[eln] = pcf::IndiElement::Off;
     }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_testRequestedName    = choice;
+        m_testSelectionPending = true;
+    }
+
+    if( m_testSelectionTimer )
+    {
+        m_testSelectionTimer->start( 10000 );
+    }
+
     sendNewProperty( ipFreq );
 }
 
@@ -691,6 +822,28 @@ void dmCtrl::on_buttonZeroTest_pressed()
     ipFreq["toggle"] = pcf::IndiElement::Off;
 
     sendNewProperty( ipFreq );
+}
+
+void dmCtrl::flatSelectionTimerOut()
+{
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_flatRequestedName.clear();
+        m_flatSelectionPending = false;
+    }
+
+    emit doUpdateGUI();
+}
+
+void dmCtrl::testSelectionTimerOut()
+{
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        m_testRequestedName.clear();
+        m_testSelectionPending = false;
+    }
+
+    emit doUpdateGUI();
 }
 
 } // namespace xqt

--- a/gui/widgets/stage/stage.hpp
+++ b/gui/widgets/stage/stage.hpp
@@ -62,12 +62,18 @@ class stage : public xWidget
 
     /// Tracks edit state for the preset combo box.
     int m_setPointEditing{ STOPPED };
+    /// Whether a requested preset/filter change is still awaiting live confirmation.
+    bool m_setPointCommandPending{ false };
+    /// Last preset/filter name sent from the combo box.
+    std::string m_setPointRequested;
     /// Timer that clears staged preset edits after inactivity.
     QTimer *m_setPointEditTimer{ nullptr };
 
   public:
     /// Construct a stage widget for one INDI stage device.
-    explicit stage( const std::string &stageName, QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
+    explicit stage( const std::string &stageName /**< [in] INDI device name for the controlled stage */,
+                    QWidget           *Parent /**< [in] owning Qt parent widget */   = 0,
+                    Qt::WindowFlags    f /**< [in] Qt window flags for the widget */ = Qt::WindowFlags() );
 
     /// Destroy the widget.
     ~stage();
@@ -97,13 +103,13 @@ class stage : public xWidget
     void updateGUI();
 
     /// Mark the set-point combo box as actively edited.
-    void on_setPoint_activated( int index );
+    void on_setPoint_activated( int index /**< [in] combo-box index selected by the user */ );
 
     /// Send the currently selected preset/filter target.
     void on_setPointGo_pressed();
 
     /// Preview the position corresponding to the slider drag.
-    void on_positionSlider_sliderMoved( double s );
+    void on_positionSlider_sliderMoved( double s /**< [in] slider percentage moved by the user */ );
 
     /// Send a move request from the released slider position.
     void on_positionSlider_sliderReleased();
@@ -133,12 +139,15 @@ class stage : public xWidget
     void setPointEditTimerOut();
 
   signals:
-    void setPointEditTimerStart( int );
+    /// Start or restart the set-point edit timeout.
+    void setPointEditTimerStart( int timeoutMs /**< [in] timeout duration in milliseconds */ );
 
+    /// Queue a GUI refresh onto the widget thread.
     void doUpdateGUI();
 
   protected:
-    virtual void paintEvent( QPaintEvent *e );
+    /// Update combo-box styling for staged edits.
+    virtual void paintEvent( QPaintEvent *e /**< [in] Qt paint event being processed */ );
 
   private:
     Ui::stage ui;
@@ -197,6 +206,8 @@ void stage::onConnect()
     setWindowTitle( QString( m_winTitle.c_str() ) );
 
     ui.stepSize->setText( QString::number( m_step ) );
+    m_setPointCommandPending = false;
+    m_setPointRequested.clear();
 
     clearFocus();
 }
@@ -208,11 +219,19 @@ void stage::onDisconnect()
     m_presetCurrent.clear();
     m_presetTarget.clear();
     m_setPoint.clear();
-    m_parked           = false;
-    m_filterWheel      = false;
-    m_maxPos           = 100;
-    m_position         = -1e30;
-    m_position_changed = false;
+    m_parked                 = false;
+    m_filterWheel            = false;
+    m_maxPos                 = 100;
+    m_position               = -1e30;
+    m_position_changed       = false;
+    m_setPointEditing        = STOPPED;
+    m_setPointCommandPending = false;
+    m_setPointRequested.clear();
+
+    if( m_setPointEditTimer )
+    {
+        m_setPointEditTimer->stop();
+    }
 
     setWindowTitle( QString( m_winTitle.c_str() ) + QString( " (disconnected)" ) );
 
@@ -336,9 +355,23 @@ void stage::handleSetProperty( const pcf::IndiProperty &ipRecv )
 
                 newName    = it->second.getName();
                 m_setPoint = newName;
-                ui.setPoint->setCurrentText( m_setPoint.c_str() );
-                // if(newName != m_value) m_valChanged = true;
-                // m_value = newName;
+
+                if( m_setPointCommandPending && newName == m_setPointRequested )
+                {
+                    if( m_setPointEditTimer )
+                    {
+                        m_setPointEditTimer->stop();
+                    }
+
+                    m_setPointEditing        = STOPPED;
+                    m_setPointCommandPending = false;
+                    m_setPointRequested.clear();
+                }
+
+                if( m_setPointEditing != STARTED && !m_setPointCommandPending )
+                {
+                    ui.setPoint->setCurrentText( m_setPoint.c_str() );
+                }
             }
         }
 
@@ -465,7 +498,9 @@ void stage::on_setPoint_activated( int index )
 {
     static_cast<void>( index );
 
-    m_setPointEditing = STARTED;
+    m_setPointEditing        = STARTED;
+    m_setPointCommandPending = false;
+    m_setPointRequested.clear();
     emit setPointEditTimerStart( 10000 );
     update();
 }
@@ -516,8 +551,10 @@ void stage::on_setPointGo_pressed()
         std::cerr << "exception thrown in stage::on_setPointGo_pressed\n";
     }
 
-    m_setPointEditing = STOPPED;
-    ui.setPoint->setCurrentText( m_setPoint.c_str() );
+    m_setPointEditing        = STARTED;
+    m_setPointCommandPending = true;
+    m_setPointRequested      = selection;
+    emit setPointEditTimerStart( 10000 );
     update();
 }
 
@@ -663,7 +700,9 @@ void stage::on_stop_pressed()
 
 void stage::setPointEditTimerOut()
 {
-    m_setPointEditing = STOPPED;
+    m_setPointEditing        = STOPPED;
+    m_setPointCommandPending = false;
+    m_setPointRequested.clear();
     ui.setPoint->setCurrentText( m_setPoint.c_str() );
     update();
 }

--- a/gui/widgets/xWidgets/stageStatus.hpp
+++ b/gui/widgets/xWidgets/stageStatus.hpp
@@ -1,6 +1,11 @@
+/** \file stageStatus.hpp
+ * \brief Summary status widget for stage and filter-wheel devices.
+ */
+
 #ifndef stageStatus_hpp
 #define stageStatus_hpp
 
+#include <cstdio>
 #include <QWidget>
 
 #include "ui_statusDisplay.h"
@@ -11,40 +16,56 @@
 namespace xqt
 {
 
+/// Stage-status summary widget with preset/filter selection support.
 class stageStatus : public statusCombo
 {
     Q_OBJECT
 
   protected:
-
-    float m_position;
+    /// Most recent numeric position used when no named preset is active.
+    float m_position{ 0 };
 
   public:
-    stageStatus( QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
+    /// Construct an unconfigured stage-status summary widget.
+    stageStatus( QWidget        *Parent /**< [in] owning Qt parent widget */   = 0,
+                 Qt::WindowFlags f /**< [in] Qt window flags for the widget */ = Qt::WindowFlags() );
 
-    stageStatus( const std::string &stgN, QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
+    /// Construct and configure a stage-status summary widget.
+    stageStatus( const std::string &stgN /**< [in] stage device name */,
+                 QWidget           *Parent /**< [in] owning Qt parent widget */   = 0,
+                 Qt::WindowFlags    f /**< [in] Qt window flags for the widget */ = Qt::WindowFlags() );
 
+    /// Destroy the widget.
     ~stageStatus();
 
-    void setup( const std::string &stgN );
+    /// Configure the summary widget for one stage device.
+    void setup( const std::string &stgN /**< [in] stage device name */ );
 
+    /// Format either the active preset name or the live numeric position.
     virtual QString formatValue();
 
+    /// Subscribe to the stage properties needed by the summary widget.
     virtual void subscribe();
 
+    /// Reset the widget for a disconnected stage controller.
+    virtual void onDisconnect();
+
+    /// Handle deletion of a stage property used by this widget.
     void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
 
+    /// Handle updates to the stage position and preset/filter properties.
     void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
-    // void updateGUI();
+  protected:
+    /// Return `true` when the property name is a selectable preset/filter switch.
+    bool isSelectionProperty( const std::string &propertyName /**< [in] property name to test */ ) const;
 };
 
 stageStatus::stageStatus( QWidget *Parent, Qt::WindowFlags f ) : statusCombo( Parent, f )
 {
 }
 
-stageStatus::stageStatus( const std::string &stageName, QWidget *Parent, Qt::WindowFlags f )
-    : statusCombo( Parent, f )
+stageStatus::stageStatus( const std::string &stageName, QWidget *Parent, Qt::WindowFlags f ) : statusCombo( Parent, f )
 {
     setup( stageName );
 }
@@ -55,21 +76,8 @@ stageStatus::~stageStatus()
 
 void stageStatus::setup( const std::string &stageName )
 {
-    if(stageName.find("fw") == 0)
-    {
-        statusCombo::setup( stageName, "filterName", "", stageName, "" );
-    }
-    else
-    {
-        statusCombo::setup( stageName, "presetName", "", stageName, "" );
-    }
-
-    if( m_ctrlWidget )
-    {
-        delete m_ctrlWidget;
-    }
-
-    m_ctrlWidget = (xWidget *)( new stage( stageName, this, Qt::Dialog ) );
+    statusCombo::setup( stageName, "", "", stageName, "" );
+    ctrlWidget( new stage( stageName, this, Qt::Dialog ) );
 }
 
 QString stageStatus::formatValue()
@@ -93,20 +101,32 @@ void stageStatus::subscribe()
         return;
     }
 
-    //m_parent->addSubscriberProperty( this, m_device, "presetName" );
-    //m_parent->addSubscriberProperty( this, m_device, "filterName" );
     m_parent->addSubscriberProperty( this, m_device, "position" );
     m_parent->addSubscriberProperty( this, m_device, "filter" );
+    m_parent->addSubscriberProperty( this, m_device, "presetName" );
+    m_parent->addSubscriberProperty( this, m_device, "filterName" );
 
     statusCombo::subscribe();
 
     return;
 }
 
+void stageStatus::onDisconnect()
+{
+    statusCombo::onDisconnect();
+    m_property.clear();
+    m_position = 0;
+}
+
 void stageStatus::handleSetProperty( const pcf::IndiProperty &ipRecv )
 {
     if( ipRecv.getDevice() != m_device )
         return;
+
+    if( isSelectionProperty( ipRecv.getName() ) && ( m_property == "" || m_property == ipRecv.getName() ) )
+    {
+        m_property = ipRecv.getName();
+    }
 
     if( ipRecv.getName() == "position" || ipRecv.getName() == "filter" )
     {
@@ -116,18 +136,20 @@ void stageStatus::handleSetProperty( const pcf::IndiProperty &ipRecv )
             if( pos != m_position && ( m_value == "none" || m_value == "" ) )
             {
                 m_valChanged = true;
-                m_position = pos;
+                m_position   = pos;
             }
         }
     }
 
-    statusCombo::handleSetProperty( ipRecv ); //always emit updateGUI
+    statusCombo::handleSetProperty( ipRecv ); // always emit updateGUI
 }
 
 void stageStatus::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
     if( ipRecv.getDevice() != m_device )
         return;
+
+    bool clearSelectionProperty = ( ipRecv.getName() == m_property && isSelectionProperty( ipRecv.getName() ) );
 
     if( ipRecv.getName() == "position" || ipRecv.getName() == "filter" )
     {
@@ -139,6 +161,16 @@ void stageStatus::handleDelProperty( const pcf::IndiProperty &ipRecv )
     }
 
     statusCombo::handleDelProperty( ipRecv );
+
+    if( clearSelectionProperty )
+    {
+        m_property.clear();
+    }
+}
+
+bool stageStatus::isSelectionProperty( const std::string &propertyName ) const
+{
+    return ( propertyName == "presetName" || propertyName == "filterName" );
 }
 
 } // namespace xqt

--- a/gui/widgets/xWidgets/statusCombo.hpp
+++ b/gui/widgets/xWidgets/statusCombo.hpp
@@ -58,34 +58,37 @@ class statusCombo : public xWidget
 
     /// Tracks edit state for the combo box.
     int m_statusEditing{ STOPPED };
+    /// Whether a sent selection is still waiting for the live state to confirm it.
+    bool m_statusCommandPending{ false };
     /// Timer that clears staged combo-box edits after inactivity.
     QTimer *m_statusEditTimer{ nullptr };
 
   public:
     /// Construct an unconfigured status combo widget.
-    statusCombo( QWidget *Parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
+    statusCombo( QWidget        *Parent /**< [in] owning Qt parent widget */   = 0,
+                 Qt::WindowFlags f /**< [in] Qt window flags for the widget */ = Qt::WindowFlags() );
 
     /// Construct and configure a status combo widget.
-    statusCombo( const std::string &device,
-                 const std::string &property,
-                 const std::string &element,
-                 const std::string &label,
-                 const std::string &units,
-                 QWidget           *Parent = 0,
-                 Qt::WindowFlags    f      = Qt::WindowFlags() );
+    statusCombo( const std::string &device /**< [in] INDI device name displayed by the widget */,
+                 const std::string &property /**< [in] INDI property name used for combo-box selections */,
+                 const std::string &element /**< [in] optional direct-value element name */,
+                 const std::string &label /**< [in] label text shown beside the combo box */,
+                 const std::string &units /**< [in] optional units suffix appended to the label */,
+                 QWidget           *Parent /**< [in] owning Qt parent widget */   = 0,
+                 Qt::WindowFlags    f /**< [in] Qt window flags for the widget */ = Qt::WindowFlags() );
 
     /// Destroy the widget.
     ~statusCombo();
 
     /// Configure the device, property, and label metadata for the widget.
-    void setup( const std::string &device,
-                const std::string &property,
-                const std::string &element,
-                const std::string &label,
-                const std::string &units );
+    void setup( const std::string &device /**< [in] INDI device name displayed by the widget */,
+                const std::string &property /**< [in] INDI property name used for combo-box selections */,
+                const std::string &element /**< [in] optional direct-value element name */,
+                const std::string &label /**< [in] label text shown beside the combo box */,
+                const std::string &units /**< [in] optional units suffix appended to the label */ );
 
     /// Replace the optional detailed control widget.
-    void ctrlWidget( xWidget *cw );
+    void ctrlWidget( xWidget *cw /**< [in] replacement detailed control widget, or `nullptr` to hide it */ );
 
     /// Return the optional detailed control widget.
     xWidget *ctrlWidget();
@@ -113,7 +116,7 @@ class statusCombo : public xWidget
 
   public:
     /// Hide the control widget when this summary row becomes disabled.
-    virtual void changeEvent( QEvent *e );
+    virtual void changeEvent( QEvent *e /**< [in] Qt change event being processed */ );
 
   public slots:
 
@@ -121,7 +124,7 @@ class statusCombo : public xWidget
     virtual void updateGUI();
 
     /// Mark the combo box as actively edited.
-    void on_status_activated( int index );
+    void on_status_activated( int index /**< [in] combo-box index selected by the user */ );
 
     /// Send the selected value back to INDI.
     void on_buttonGo_pressed();
@@ -133,17 +136,20 @@ class statusCombo : public xWidget
     void statusEditTimerOut();
 
   signals:
+    /// Start or restart the edit timeout.
+    void statusEditTimerStart( int timeoutMs /**< [in] timeout duration in milliseconds */ );
 
-    void statusEditTimerStart( int );
-
+    /// Queue a GUI refresh onto the Qt event loop.
     void doUpdateGUI();
 
   protected:
     /// Decide whether the widget should show the value instead of FSM text.
     bool shouldShowValue() const;
 
-    virtual void paintEvent( QPaintEvent *e );
+    /// Update styling that reflects whether the combo box is in edit mode.
+    virtual void paintEvent( QPaintEvent *e /**< [in] Qt paint event being processed */ );
 
+    /// Generated Qt UI backing this summary widget.
     Ui::statusCombo ui;
 };
 
@@ -271,7 +277,8 @@ void statusCombo::subscribe()
 
 void statusCombo::onConnect()
 {
-    m_valChanged = true;
+    m_valChanged           = true;
+    m_statusCommandPending = false;
     if( m_ctrlWidget )
     {
         m_ctrlWidget->onConnect();
@@ -282,9 +289,16 @@ void statusCombo::onDisconnect()
 {
     m_fsmState.clear();
     m_value.clear();
-    m_parked     = false;
-    m_showVal    = false;
-    m_valChanged = false;
+    m_parked               = false;
+    m_showVal              = false;
+    m_valChanged           = false;
+    m_statusEditing        = STOPPED;
+    m_statusCommandPending = false;
+
+    if( m_statusEditTimer )
+    {
+        m_statusEditTimer->stop();
+    }
 
     ui.status->clear();
     ui.status->setPlaceholderText( "" );
@@ -424,6 +438,13 @@ void statusCombo::handleSetProperty( const pcf::IndiProperty &ipRecv )
                 m_valChanged = true;
             }
             m_value = value;
+
+            if( m_statusCommandPending && value == ui.status->currentText().toStdString() )
+            {
+                m_statusEditing        = STOPPED;
+                m_statusCommandPending = false;
+                m_valChanged           = true;
+            }
         }
     }
 
@@ -445,6 +466,11 @@ void statusCombo::changeEvent( QEvent *e )
 
 void statusCombo::updateGUI()
 {
+    if( m_statusEditing == STARTED || m_statusCommandPending )
+    {
+        return;
+    }
+
     if( isEnabled() )
     {
         if( m_showVal )
@@ -474,7 +500,8 @@ void statusCombo::on_status_activated( int index )
 {
     static_cast<void>( index );
 
-    m_statusEditing = STARTED;
+    m_statusEditing        = STARTED;
+    m_statusCommandPending = false;
     emit statusEditTimerStart( 10000 );
     update();
 }
@@ -484,6 +511,11 @@ void statusCombo::on_buttonGo_pressed()
     std::string selection = ui.status->currentText().toStdString();
 
     if( selection == "" )
+    {
+        return;
+    }
+
+    if( m_property == "" )
     {
         return;
     }
@@ -518,8 +550,9 @@ void statusCombo::on_buttonGo_pressed()
         std::cerr << "INDI exception thrown in statusCombo::on_buttonGo_pressed\n";
     }
 
-    m_statusEditing = STOPPED;
-    ui.status->setCurrentText( formatValue() );
+    m_statusEditing        = STARTED;
+    m_statusCommandPending = true;
+    emit statusEditTimerStart( 10000 );
     ui.status->clearFocus();
     ui.buttonGo->clearFocus();
     update();
@@ -536,9 +569,11 @@ void statusCombo::on_buttonCtrl_pressed()
 
 void statusCombo::statusEditTimerOut()
 {
-    m_statusEditing = STOPPED;
-    ui.status->setCurrentText( formatValue() );
+    m_statusEditing        = STOPPED;
+    m_statusCommandPending = false;
+    ui.status->setCurrentIndex( -1 );
     ui.status->clearFocus();
+    emit doUpdateGUI();
     update();
 }
 

--- a/gui/widgets/xWidgets/xWidget.hpp
+++ b/gui/widgets/xWidgets/xWidget.hpp
@@ -1,49 +1,173 @@
 /** \file xWidget.hpp
-  * \brief Virtual class combining QWidget and multiIndiSubscriber
-  * \author Jared R. Males
-  */
+ * \brief Virtual class combining QWidget and multiIndiSubscriber
+ * \author Jared R. Males
+ */
 
 #ifndef widget_hpp
 #define widget_hpp
 
+#include <algorithm>
+
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+#include <QComboBox>
+#include <QEvent>
+#include <QScrollBar>
+#include <QVariant>
 #include <QWidget>
 
 #include "../../lib/multiIndiSubscriber.hpp"
 
-#define XW_FONT_SIZE (15)
+#define XW_FONT_SIZE ( 15 )
 
 namespace xqt
 {
 
 /// A virtual class combining QWidget and multiIndiSubscriber.
 /** This is the base class of most MagAO-X INDI connected GUIs.
-  * The virtual functions and event handlers of QWidget and be implemented in base classes.
-  * The virtual functions of multiIndiSubscriber should be implemented to enable INDI communications.
-  */
+ * The virtual functions and event handlers of QWidget and be implemented in base classes.
+ * The virtual functions of multiIndiSubscriber should be implemented to enable INDI communications.
+ */
 class xWidget : public QWidget, public multiIndiSubscriber
 {
-   Q_OBJECT
+    Q_OBJECT
 
-public:
-   xWidget( QWidget * Parent = 0,
-            Qt::WindowFlags f = Qt::WindowFlags()
-          ) : QWidget(Parent, f)
-   {
-   }
+  public:
+    /// Construct the shared MagAO-X widget base.
+    xWidget( QWidget        *Parent = 0,                /**< [in] Optional Qt parent widget. */
+             Qt::WindowFlags f      = Qt::WindowFlags() /**< [in] Qt window flags. */
+             )
+        : QWidget( Parent, f )
+    {
+    }
 
-   ~xWidget() noexcept
-   {
-   }
+    /// Destroy the shared MagAO-X widget base.
+    ~xWidget() noexcept
+    {
+    }
+
+  protected:
+    /// Allow the base class to configure shared widget behavior after children are added.
+    bool event( QEvent *event /**< [in] Qt event being processed. */ ) override;
+
+    /// Find descendant combo boxes and enable shared popup sizing for them.
+    void manageComboBoxPopups();
 };
 
-template<class qT>
-void setXwFont( qT * widg, float scale = 1.0)
+/// Update a combo-box popup to fit its widest current entry without widening the widget itself.
+void updateXwComboBoxPopupWidth( QComboBox *combo /**< [in] Combo box whose popup width should be updated. */ );
+
+/// Ensure a combo box uses shared popup sizing and keeps it updated as its model changes.
+void manageXwComboBoxPopupWidth( QComboBox *combo /**< [in] Combo box whose popup width should be managed. */ );
+
+template <class qT>
+/// Apply the standard MagAO-X pixel font size to a widget.
+void setXwFont( qT   *widg,       /**< [in] Widget receiving the standard MagAO-X font. */
+                float scale = 1.0 /**< [in] Optional scale factor applied to the standard pixel size. */
+)
 {
-   QFont qf = widg->font();
-   qf.setPixelSize(XW_FONT_SIZE * scale + 0.5);
-   widg->setFont(qf);
+    QFont qf = widg->font();
+    qf.setPixelSize( XW_FONT_SIZE * scale + 0.5 );
+    widg->setFont( qf );
 }
 
-} //namespace xqt
+inline bool xWidget::event( QEvent *event )
+{
+    bool handled = QWidget::event( event );
+
+    if( event != nullptr &&
+        ( event->type() == QEvent::ChildAdded || event->type() == QEvent::Polish || event->type() == QEvent::Show ) )
+    {
+        manageComboBoxPopups();
+    }
+
+    return handled;
+}
+
+inline void xWidget::manageComboBoxPopups()
+{
+    const auto combos = findChildren<QComboBox *>();
+    for( auto *combo : combos )
+    {
+        manageXwComboBoxPopupWidth( combo );
+    }
+}
+
+inline void updateXwComboBoxPopupWidth( QComboBox *combo )
+{
+    if( combo == nullptr || combo->view() == nullptr )
+    {
+        return;
+    }
+
+    QAbstractItemView *view = combo->view();
+    view->setTextElideMode( Qt::ElideNone );
+
+    int popupWidth   = std::max( combo->width(), combo->minimumSizeHint().width() );
+    int contentWidth = view->sizeHintForColumn( 0 );
+    if( contentWidth < 0 )
+    {
+        contentWidth = combo->minimumSizeHint().width();
+    }
+
+    int scrollBarWidth = 0;
+    if( view->verticalScrollBar() != nullptr )
+    {
+        scrollBarWidth = view->verticalScrollBar()->sizeHint().width();
+    }
+
+    popupWidth = std::max( popupWidth, contentWidth + scrollBarWidth + 2 * view->frameWidth() + 16 );
+
+    view->setMinimumWidth( popupWidth );
+    if( view->window() != nullptr )
+    {
+        view->window()->setMinimumWidth( popupWidth );
+    }
+}
+
+inline void manageXwComboBoxPopupWidth( QComboBox *combo )
+{
+    if( combo == nullptr )
+    {
+        return;
+    }
+
+    updateXwComboBoxPopupWidth( combo );
+
+    QAbstractItemModel *model = combo->model();
+    if( model == nullptr )
+    {
+        return;
+    }
+
+    QObject *managedModel = combo->property( "xwComboPopupModel" ).value<QObject *>();
+    if( managedModel == model )
+    {
+        return;
+    }
+
+    combo->setProperty( "xwComboPopupModel", QVariant::fromValue( static_cast<QObject *>( model ) ) );
+
+    QObject::connect( model,
+                      &QAbstractItemModel::rowsInserted,
+                      combo,
+                      [combo]( const QModelIndex &, int, int ) { updateXwComboBoxPopupWidth( combo ); } );
+
+    QObject::connect( model,
+                      &QAbstractItemModel::rowsRemoved,
+                      combo,
+                      [combo]( const QModelIndex &, int, int ) { updateXwComboBoxPopupWidth( combo ); } );
+
+    QObject::connect(
+        model, &QAbstractItemModel::modelReset, combo, [combo]() { updateXwComboBoxPopupWidth( combo ); } );
+
+    QObject::connect( model,
+                      &QAbstractItemModel::dataChanged,
+                      combo,
+                      [combo]( const QModelIndex &, const QModelIndex &, const QVector<int> & )
+                      { updateXwComboBoxPopupWidth( combo ); } );
+}
+
+} // namespace xqt
 
 #endif


### PR DESCRIPTION
This work was performed by Codex (GPT-5).

## Summary
- stabilize GUI dropdown and combo-box state handling across `dmCtrl`, `stage`, `stageStatus`, and `statusCombo`
- handle DM property-list refreshes more robustly in `dmCtrl` so GUI state survives property redefinition/update cycles
- share combo popup sizing behavior through `xWidget` so widget dropdowns size consistently to their content
- fix GUI build/install dependency wiring in the GUI make and qmake files
- harden `coronAlign` motion-button disable logic by fixing routing for pico vs. non-pico controls, adding pending latches, clearing them from target-reaching updates, and adding timeout-based recovery with a one-shot `getProperties` refresh before local fallback

## Files Changed
- `Make/magAOXGUI.mk`
- `gui/apps/magaoxQtApp.pri`
- `gui/apps/pwr/pwrGUI.pro`
- `gui/widgets/coronAlign/coronAlign.hpp`
- `gui/widgets/dmCtrl/dmCtrl.hpp`
- `gui/widgets/stage/stage.hpp`
- `gui/widgets/xWidgets/stageStatus.hpp`
- `gui/widgets/xWidgets/statusCombo.hpp`
- `gui/widgets/xWidgets/xWidget.hpp`

## Testing
- ran `git diff --check`
- applied `clang-format` to touched regions while developing the branch changes
- did not run a full GUI smoke test in this branch summary

## Notes
- branch is 5 commits ahead of `dev`
- the `coronAlign` changes specifically target small-move controller behavior where expected FSM transitions may not be emitted
- the timeout recovery path now requests fresh `fsm` plus motion-property state before releasing the local pending latch
