### PR TITLE
Jrmales/shift ncpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ scripts_to_install = \
 	inventory_files \
 	list_xfiles_by_semester \
 	loop_instrument_backup_sync \
-	cyverse_replicate
+	cyverse_replicate 
 
 ifeq ($(MAGAOX_ROLE),RTC)
   scripts_to_install += cacao/RTC/cacao-startup
@@ -319,7 +319,7 @@ else ifeq ($(MAGAOX_ROLE),ICC)
   scripts_to_install += cacao/ICC/ncpc-rootdir-scripts/post-calib-apply
   scripts_to_install += cacao/hoblockleaks
   scripts_to_install += cacao/ICC/lowfs_switch
-
+  scripts_to_install += shift_ncpc
 else ifeq ($(MAGAOX_ROLE),TIC)
   scripts_to_install += cacao/TIC/cacao-startup
   scripts_to_install += cacao/TIC/cacao-shutdown

--- a/scripts/shift_ncpc
+++ b/scripts/shift_ncpc
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -x
 #########################################################
 # switch NCPC calibration symlinks between warm and cold
 #
@@ -28,33 +28,49 @@ fi
 
 case "$1" in
     warm)
+
+	setINDI dmncpc.releaseDM.request=On
+        setINDI dmncpc.zeroAll.request=On
+
         xctrl shutdown dmncpc ncpcModes || exit 1
         did_shutdown=1
 
         cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
 
         ln -sf basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
-        ln -sf flats_center flats
+        rm -f flats
+	ln -sf flats_center flats
+	rm -f tests
         ln -sf tests_center tests
 
         cd /opt/MagAOX/calib/fdpr2 || exit 1
 
+	rm -f dmncpc_camsci1_CH4
         ln -sf dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
+	rm -f dmncpc_camsci2_Ha
         ln -sf dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
         ;;
     cold)
+
+	setINDI dmncpc.releaseDM.request=On
+        setINDI dmncpc.zeroAll.request=On
+
         xctrl shutdown dmncpc ncpcModes || exit 1
         did_shutdown=1
 
         cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
 
-        ln -sf basis_shift_down_1/basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+        ln -sf basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+	rm -f flats
         ln -sf flats_shift_down_1 flats
-        ln -sf tests_shift_down_1 tests
+        rm -f tests
+	ln -sf tests_shift_down_1 tests
 
         cd /opt/MagAOX/calib/fdpr2 || exit 1
 
+	rm -f dmncpc_camsci1_CH4
         ln -sf dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
+	rm -f dmncpc_camsci2_Ha
         ln -sf dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha
         ;;
     *)

--- a/scripts/shift_ncpc
+++ b/scripts/shift_ncpc
@@ -1,0 +1,18 @@
+
+cd /opt/MagAOX/calib/dm/bmc_1k
+
+ln -sf basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
+#ln -s basis_shift_down_1/basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+
+ln -sf flats_center flats
+#ln -sf flats_shift_down_1 flats
+
+ln -sf tests_center tests
+#ln -sf tests_shift_down_1 tests
+
+cd /opt/MagAOX/calib/fdpr2
+ln -sf dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
+#ln -sf dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
+
+ln -sf dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
+#ln -sf dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha

--- a/scripts/shift_ncpc
+++ b/scripts/shift_ncpc
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 #########################################################
 # switch NCPC calibration symlinks between warm and cold
 #
@@ -21,6 +20,15 @@ cleanup() {
 
 trap cleanup EXIT
 
+safe_remove_link() {
+    if [[ -L "$1" ]]; then
+        rm "$1" || return 1
+    elif [[ -e "$1" ]]; then
+        echo "error: $1 exists and is not a symlink" >&2
+        return 1
+    fi
+}
+
 if [[ $# -ne 1 ]]; then
     echo "usage: $0 warm|cold" >&2
     exit 1
@@ -28,8 +36,7 @@ fi
 
 case "$1" in
     warm)
-
-	setINDI dmncpc.releaseDM.request=On
+        setINDI dmncpc.releaseDM.request=On
         setINDI dmncpc.zeroAll.request=On
 
         xctrl shutdown dmncpc ncpcModes || exit 1
@@ -37,22 +44,25 @@ case "$1" in
 
         cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
 
-        ln -sf basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
-        rm -f flats
-	ln -sf flats_center flats
-	rm -f tests
-        ln -sf tests_center tests
+        safe_remove_link zbasis.fits || exit 1
+        ln -s basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
+
+        safe_remove_link flats || exit 1
+        ln -s flats_center flats
+
+        safe_remove_link tests || exit 1
+        ln -s tests_center tests
 
         cd /opt/MagAOX/calib/fdpr2 || exit 1
 
-	rm -f dmncpc_camsci1_CH4
-        ln -sf dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
-	rm -f dmncpc_camsci2_Ha
-        ln -sf dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
+        safe_remove_link dmncpc_camsci1_CH4 || exit 1
+        ln -s dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
+
+        safe_remove_link dmncpc_camsci2_Ha || exit 1
+        ln -s dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
         ;;
     cold)
-
-	setINDI dmncpc.releaseDM.request=On
+        setINDI dmncpc.releaseDM.request=On
         setINDI dmncpc.zeroAll.request=On
 
         xctrl shutdown dmncpc ncpcModes || exit 1
@@ -60,18 +70,22 @@ case "$1" in
 
         cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
 
-        ln -sf basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
-	rm -f flats
-        ln -sf flats_shift_down_1 flats
-        rm -f tests
-	ln -sf tests_shift_down_1 tests
+        safe_remove_link zbasis.fits || exit 1
+        ln -s basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+
+        safe_remove_link flats || exit 1
+        ln -s flats_shift_down_1 flats
+
+        safe_remove_link tests || exit 1
+        ln -s tests_shift_down_1 tests
 
         cd /opt/MagAOX/calib/fdpr2 || exit 1
 
-	rm -f dmncpc_camsci1_CH4
-        ln -sf dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
-	rm -f dmncpc_camsci2_Ha
-        ln -sf dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha
+        safe_remove_link dmncpc_camsci1_CH4 || exit 1
+        ln -s dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
+
+        safe_remove_link dmncpc_camsci2_Ha || exit 1
+        ln -s dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha
         ;;
     *)
         echo "usage: $0 warm|cold" >&2

--- a/scripts/shift_ncpc
+++ b/scripts/shift_ncpc
@@ -1,18 +1,64 @@
+#!/usr/bin/env bash
 
-cd /opt/MagAOX/calib/dm/bmc_1k
+#########################################################
+# switch NCPC calibration symlinks between warm and cold
+#
+# usage: shift_ncpc warm|cold
+#
+# This script is under version control in the MagAO-X source
+#########################################################
 
-ln -sf basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
-#ln -s basis_shift_down_1/basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+cpath=$(pwd)
+did_shutdown=0
 
-ln -sf flats_center flats
-#ln -sf flats_shift_down_1 flats
+cleanup() {
+    if [[ $did_shutdown -eq 1 ]]; then
+        xctrl restart dmncpc ncpcModes
+    fi
 
-ln -sf tests_center tests
-#ln -sf tests_shift_down_1 tests
+    cd "$cpath"
+}
 
-cd /opt/MagAOX/calib/fdpr2
-ln -sf dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
-#ln -sf dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
+trap cleanup EXIT
 
-ln -sf dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
-#ln -sf dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 warm|cold" >&2
+    exit 1
+fi
+
+case "$1" in
+    warm)
+        xctrl shutdown dmncpc ncpcModes || exit 1
+        did_shutdown=1
+
+        cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
+
+        ln -sf basis_center/zern_basis_1k_50modes_ellipse_rolled.fits zbasis.fits
+        ln -sf flats_center flats
+        ln -sf tests_center tests
+
+        cd /opt/MagAOX/calib/fdpr2 || exit 1
+
+        ln -sf dmncpc_camsci1_CH4_center dmncpc_camsci1_CH4
+        ln -sf dmncpc_camsci2_Ha_center dmncpc_camsci2_Ha
+        ;;
+    cold)
+        xctrl shutdown dmncpc ncpcModes || exit 1
+        did_shutdown=1
+
+        cd /opt/MagAOX/calib/dm/bmc_1k || exit 1
+
+        ln -sf basis_shift_down_1/basis_shift_down_1/zern_basis_1k_50modes_ellipse_rolled_shift_down_1.fits zbasis.fits
+        ln -sf flats_shift_down_1 flats
+        ln -sf tests_shift_down_1 tests
+
+        cd /opt/MagAOX/calib/fdpr2 || exit 1
+
+        ln -sf dmncpc_camsci1_CH4_shifted_down_1 dmncpc_camsci1_CH4
+        ln -sf dmncpc_camsci2_Ha_shifted_down_1 dmncpc_camsci2_Ha
+        ;;
+    *)
+        echo "usage: $0 warm|cold" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to the prompt: "I would like to finish the shift_ncpc script, which is currently just a skeleton. It should take one argument with choices `warm` and `cold`. When `warm` is should run the ln commands currently not commented. When `cold` it should run the commented commands. It should record pwd at the start and return to that at thend. See other scripts under scripts for our typical conventions."

## Summary
- finish `scripts/shift_ncpc` as a `warm|cold` helper
- add the `setINDI`, `xctrl shutdown`, and `xctrl restart` steps around the relink operation
- safely replace expected symlinks by removing them only when they are symlinks and erroring if a real file or directory is in the way
- restore the caller's original working directory on exit
- clean up script formatting and remove debug tracing

## Validation
- `bash -n scripts/shift_ncpc`
- user-tested on the target system
