### PR TITLE
Add camera focus state and goto-focus controls

### DIFF
--- a/agents/plans/2026-04/cameraGUI-focus-button.md
+++ b/agents/plans/2026-04/cameraGUI-focus-button.md
@@ -9,3 +9,16 @@ Finally, in cameraGUI a focus button should appear if a camera exposes the goto_
 Review AGENTS.md.  Do not make changes to this prompt, but fill in the plan below in this document and commit it along with other work.
 
 Plan:
+- Add optional focus support to `dev::stdCamera` with a new `c_stdCamera_hasFocus` interface flag, runtime `m_hasFocus`
+  enable, read-only `focus.state`, and request switch `goto_focus.request`.
+- Provide `stdCamera` helper configuration and logic for the common focus integrations:
+  `checkFocusSwitchState()` for an external out-of-focus switch and `sendGotoFocusCommand()` for a
+  multi-switch-combo-derived goto-focus command target.
+- Implement focus support in `apps/picamCtrl/picamCtrl.hpp` by enabling `c_stdCamera_hasFocus` and delegating
+  `checkFocus()` / `gotoFocus()` to the new `stdCamera` helpers.
+- Exercise the new stdCamera focus request path in `apps/cameraSim/tests/cameraSim_test.cpp` so the generic
+  callback coverage includes `goto_focus`.
+- Update `gui/widgets/camera/camera.hpp` so cameraGUI adds a `goto focus` button when `goto_focus` is exposed,
+  disables it when `focus.state` is `On`, and shifts left-column controls down when focus support is present.
+- Run `clang-format` on touched files and perform targeted build/test verification before committing the plan
+  and code together.

--- a/agents/plans/2026-04/cameraGUI-focus-button.md
+++ b/agents/plans/2026-04/cameraGUI-focus-button.md
@@ -1,0 +1,11 @@
+We need to add a feature to cameraGUI that sends a command to a focus stage when a button is pressed.  We should add an optional feature to stdCamera called hasFocus.  stdCamera should then call a derived class function called "checkFocus" that returns true if in focus, false if not.  An INDI property switch "focus.state" should be exposed that is On when in focus, Off when not in focus. stdCamera should then also expose a "goto_focus.request" switch that when pressed calls a derived-class provided gotoFocus() function.
+
+stdCamera should also provide some helper functions for the most common way that derived classes will work.
+- Configure and set up to monitor a given INDI property switch, and if the switch is `On` it is interpreted as meaning the camera is out of focus.  The derived class can then return the status of this switch from within its checkFocus by calling checkFocusSwitchState().
+- Configure and set up to use a multiSwitchCombo rule just like in stateRuleEngine, except now instead of comparison, the derived switch state is sent as an INDI command.  A stdCamera helper function is then called by the derived() class when gotoFocus() is called by stdCamera.
+
+Finally, in cameraGUI a focus button should appear if a camera exposes the goto_focus.request switch.  The button should be disabled if focus.state is On (in-focus) and enabled if Off. This may require moving the shutter control down one when so-configured.
+
+Review AGENTS.md.  Do not make changes to this prompt, but fill in the plan below in this document and commit it along with other work.
+
+Plan:

--- a/apps/cameraSim/cameraSim.hpp
+++ b/apps/cameraSim/cameraSim.hpp
@@ -52,9 +52,9 @@ class cameraSim : public MagAOXApp<>,
     friend class dev::telemeter<cameraSim>;
 
   public:
-    typedef dev::stdCamera<cameraSim> stdCameraT;
+    typedef dev::stdCamera<cameraSim>    stdCameraT;
     typedef dev::frameGrabber<cameraSim> frameGrabberT;
-    typedef dev::telemeter<cameraSim> telemeterT;
+    typedef dev::telemeter<cameraSim>    telemeterT;
 
     /** \name app::dev Configurations
      *@{
@@ -97,6 +97,9 @@ class cameraSim : public MagAOXApp<>,
     static constexpr bool c_stdCamera_hasShutter =
         true; ///< app:dev config to tell stdCamera to expose shutter controls
 
+    static constexpr bool c_stdCamera_hasFocus =
+        true; ///< app:dev config to tell stdCamera this camera can expose focus-state and goto-focus controls
+
     static constexpr bool c_stdCamera_usesStateString =
         true; ///< app::dev confg to tell stdCamera to expose the state string property
 
@@ -114,16 +117,20 @@ class cameraSim : public MagAOXApp<>,
     float m_bias{ 500 }; ///< the simulated bias level. default 500.
     float m_ron{ 5 };    ///< the simulated readout noise, in counts/read. default 5.
 
-    std::vector<float> m_xcen{ 0 }; /**< the simulated star x center coordinate, relative to image center.
-                                         one per star. default 0*/
-    std::vector<float> m_ycen{ 0 }; /**< the simulated star y center coordinate, relative to image center.
-                                         one per star. default 0.*/
+    std::vector<float> m_xcen{ 0 };    /**< the simulated star x center coordinate, relative to image center.
+                                            one per star. default 0*/
+    std::vector<float> m_ycen{ 0 };    /**< the simulated star y center coordinate, relative to image center.
+                                            one per star. default 0.*/
     std::vector<float> m_peak{ 2000 }; ///< the simulated star peak, in counts/second. one per star. default 2000.
-    float m_fwhm{ 2 };                 ///< the simulated star FWHM in pixels. the same for all stars. default 2.
+    float              m_fwhm{ 2 };    ///< the simulated star FWHM in pixels. the same for all stars. default 2.
 
     float m_jitter{ 0.1 }; ///< the simulated jitter, in pixels/read. the same for all stars. default 0.1.
 
     mx::math::normDistT<float> m_norm;
+
+    bool m_focusInFocus{ false }; ///< Simulated in-focus state reported through the stdCamera focus interface.
+
+    bool m_gotoFocusRequested{ false }; ///< True after the simulated goto-focus command has been received.
 
   public:
     /// Default c'tor
@@ -215,6 +222,12 @@ class cameraSim : public MagAOXApp<>,
      */
     int setNextROI();
 
+    /// Report whether the simulated camera is currently in focus.
+    bool checkFocus();
+
+    /// Simulate a goto-focus request.
+    int gotoFocus();
+
     int setShutter( int ss );
 
     std::string stateString();
@@ -240,17 +253,17 @@ inline cameraSim::cameraSim() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODI
     m_powerMgtEnabled = true;
 
     m_defaultReadoutSpeed = "1";
-    m_defaultVShiftSpeed = "1";
+    m_defaultVShiftSpeed  = "1";
 
     m_default_x = 511.5;
     m_default_y = 511.5;
     m_default_w = 1024;
     m_default_h = 1024;
 
-    m_nextROI.x = m_default_x;
-    m_nextROI.y = m_default_y;
-    m_nextROI.w = m_default_w;
-    m_nextROI.h = m_default_h;
+    m_nextROI.x     = m_default_x;
+    m_nextROI.y     = m_default_y;
+    m_nextROI.w     = m_default_w;
+    m_nextROI.h     = m_default_h;
     m_nextROI.bin_x = 1;
     m_nextROI.bin_y = 1;
 
@@ -438,19 +451,19 @@ inline int cameraSim::appStartup()
     //=================================
     // Do camera configuration here
 
-    m_ccdTemp = -40;
+    m_ccdTemp      = -40;
     m_ccdTempSetpt = -40;
 
-    m_readoutSpeedNames = { "one", "two", "three" };
+    m_readoutSpeedNames      = { "one", "two", "three" };
     m_readoutSpeedNameLabels = { "One", "Two", "Three" };
-    m_readoutSpeedName = m_readoutSpeedNames[0];
+    m_readoutSpeedName       = m_readoutSpeedNames[0];
 
-    m_vShiftSpeedNames = { "0.1", "0.2", "0.3" };
+    m_vShiftSpeedNames      = { "0.1", "0.2", "0.3" };
     m_vShiftSpeedNameLabels = { "0.1 Hz", "0.2 kHz", "0.4 MhZ" };
-    m_vShiftSpeedName = m_vShiftSpeedNames[0];
+    m_vShiftSpeedName       = m_vShiftSpeedNames[0];
 
     m_shutterStatus = "READY";
-    m_shutterState = 0;
+    m_shutterState  = 0;
 
     if( dev::stdCamera<cameraSim>::appStartup() < 0 )
     {
@@ -461,19 +474,19 @@ inline int cameraSim::appStartup()
 
     TELEMETER_APP_STARTUP;
 
-    m_currentROI.x = m_default_x;
-    m_currentROI.y = m_default_y;
-    m_currentROI.w = m_default_w;
-    m_currentROI.h = m_default_h;
+    m_currentROI.x     = m_default_x;
+    m_currentROI.y     = m_default_y;
+    m_currentROI.w     = m_default_w;
+    m_currentROI.h     = m_default_h;
     m_currentROI.bin_x = 1;
     m_currentROI.bin_y = 1;
-    m_nextROI = m_currentROI;
+    m_nextROI          = m_currentROI;
 
-    m_expTime = 1.0 / m_fps;
+    m_expTime    = 1.0 / m_fps;
     m_expTimeSet = m_expTime;
 
     m_lastTime = mx::sys::get_curr_time();
-    m_offset = 0;
+    m_offset   = 0;
 
     state( stateCodes::OPERATING );
 
@@ -537,15 +550,15 @@ int cameraSim::configureAcquisition()
     {
         recordCamera( true );
 
-        m_currentROI.x = m_nextROI.x;
-        m_currentROI.y = m_nextROI.y;
-        m_currentROI.w = m_nextROI.w;
-        m_currentROI.h = m_nextROI.h;
+        m_currentROI.x     = m_nextROI.x;
+        m_currentROI.y     = m_nextROI.y;
+        m_currentROI.w     = m_nextROI.w;
+        m_currentROI.h     = m_nextROI.h;
         m_currentROI.bin_x = m_nextROI.bin_x;
         m_currentROI.bin_y = m_nextROI.bin_y;
 
-        m_width = m_currentROI.w / m_currentROI.bin_x;
-        m_height = m_currentROI.h / m_currentROI.bin_y;
+        m_width    = m_currentROI.w / m_currentROI.bin_x;
+        m_height   = m_currentROI.h / m_currentROI.bin_y;
         m_xbinning = m_currentROI.bin_x;
         m_ybinning = m_currentROI.bin_y;
 
@@ -569,7 +582,7 @@ int cameraSim::configureAcquisition()
 int cameraSim::startAcquisition()
 {
 
-    m_offset = 0;
+    m_offset   = 0;
     m_lastTime = mx::sys::get_curr_time();
 
     state( stateCodes::OPERATING );
@@ -654,10 +667,10 @@ inline float cameraSim::fps()
 
 inline int cameraSim::powerOnDefaults()
 {
-    m_nextROI.x = m_default_x;
-    m_nextROI.y = m_default_y;
-    m_nextROI.w = m_default_w;
-    m_nextROI.h = m_default_h;
+    m_nextROI.x     = m_default_x;
+    m_nextROI.y     = m_default_y;
+    m_nextROI.w     = m_default_w;
+    m_nextROI.h     = m_default_h;
     m_nextROI.bin_x = m_default_bin_x;
     m_nextROI.bin_y = m_default_bin_y;
 
@@ -692,8 +705,8 @@ inline int cameraSim::setExpTime()
 {
 
     m_expTime = m_expTimeSet;
-    m_fps = 1. / m_fps;
-    m_fpsSet = m_fps;
+    m_fps     = 1. / m_fps;
+    m_fpsSet  = m_fps;
 
     log<text_log>( "Set exposure time: " + std::to_string( m_expTimeSet ) + " sec" );
 
@@ -706,8 +719,8 @@ inline int cameraSim::setFPS()
 {
     recordCamera( true );
 
-    m_fps = m_fpsSet;
-    m_expTime = 1.0 / m_fps;
+    m_fps        = m_fpsSet;
+    m_expTime    = 1.0 / m_fps;
     m_expTimeSet = m_expTime;
 
     log<text_log>( "Set frame rate: " + std::to_string( m_fps ) + " fps" );
@@ -756,6 +769,19 @@ inline int cameraSim::setNextROI()
 inline int cameraSim::setCropMode()
 {
     m_cropMode = m_cropModeSet;
+    return 0;
+}
+
+inline bool cameraSim::checkFocus()
+{
+    return m_focusInFocus;
+}
+
+inline int cameraSim::gotoFocus()
+{
+    m_focusInFocus       = true;
+    m_gotoFocusRequested = true;
+
     return 0;
 }
 

--- a/apps/cameraSim/tests/cameraSim_test.cpp
+++ b/apps/cameraSim/tests/cameraSim_test.cpp
@@ -70,6 +70,7 @@ class cameraSim_test : public cameraSim
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, goto_focus )
     }
 
+    /// Configure the stdCamera focus-state helper for a monitored switch element.
     void configureFocusHelper( const std::string &device,
                                const std::string &property,
                                const std::string &element,
@@ -107,7 +108,13 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
     friend class dev::stdCamera<focusHelper_test>;
 
   public:
-    static constexpr bool c_stdCamera_hasFocus = true;
+    static constexpr bool c_stdCamera_hasFocus     = true;
+    static constexpr bool c_stdCamera_tempControl  = false;
+    static constexpr bool c_stdCamera_readoutSpeed = false;
+    static constexpr bool c_stdCamera_vShiftSpeed  = false;
+    static constexpr bool c_stdCamera_emGain       = false;
+    static constexpr bool c_stdCamera_usesModes    = false;
+    static constexpr bool c_stdCamera_usesROI      = false;
 
   protected:
     pcf::IndiProperty m_lastSentProperty; ///< Captures the last INDI command sent through the goto-focus helper.
@@ -174,27 +181,32 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
         m_indiP_focusMonitoredProperties[0].setName( property );
     }
 
+    /// Cache a monitored INDI property through the stdCamera helper callback.
     int cacheFocusProperty( const pcf::IndiProperty &ipRecv )
     {
         return setCallBack_focusMonitored( ipRecv );
     }
 
+    /// Evaluate the cached focus-state helper result.
     bool checkFocus()
     {
         return checkFocusSwitchState();
     }
 
+    /// Satisfy the stdCamera derived-class interface for unit testing.
     int gotoFocus()
     {
         return 0;
     }
 
+    /// Capture the last helper-issued INDI command instead of sending it.
     int sendNewProperty( const pcf::IndiProperty &ipSend )
     {
         m_lastSentProperty = ipSend;
         return m_sendNewPropertyResult;
     }
 
+    /// Set the return code that the sendNewProperty test hook should report.
     void setSendNewPropertyResult( int result )
     {
         m_sendNewPropertyResult = result;
@@ -220,9 +232,28 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
         return m_indiP_focus["state"].getSwitchState();
     }
 
+    /// Retrieve the last INDI property captured from sendGotoFocusCommand.
     const pcf::IndiProperty &lastSentProperty() const
     {
         return m_lastSentProperty;
+    }
+
+    /// Retrieve the configured goto-focus format string after config parsing.
+    const std::string &gotoFocusFormat() const
+    {
+        return m_focusGotoFormat;
+    }
+
+    /// Expose stdCamera configuration setup for the config-file unit test.
+    int setupConfig( mx::app::appConfigurator &config )
+    {
+        return dev::stdCamera<focusHelper_test>::setupConfig( config );
+    }
+
+    /// Expose stdCamera configuration loading for the config-file unit test.
+    int loadConfig( mx::app::appConfigurator &config )
+    {
+        return dev::stdCamera<focusHelper_test>::loadConfig( config );
     }
 };
 /// \endcond
@@ -357,6 +388,37 @@ TEST_CASE( "cameraSim stdCamera goto-focus helper dispatches preset commands", "
         app.setSendNewPropertyResult( -1 );
         REQUIRE( app.sendGotoFocusCommand() == -1 );
     }
+}
+
+/// Verify the stdCamera goto-focus helper strips wrapping quotes from configured format strings.
+/**
+ * \ingroup cameraSim_unit_test
+ */
+TEST_CASE( "cameraSim stdCamera goto-focus helper strips quoted format strings", "[cameraSim]" )
+{
+    mx::app::writeConfigFile( "/tmp/cameraSim_focusHelper.conf",
+                              { "focus.gotoFocus",
+                                "focus.gotoFocus",
+                                "focus.gotoFocus",
+                                "focus.gotoFocus",
+                                "focus.gotoFocus",
+                                "focus.gotoFocus" },
+                              { "numSwitches", "property1", "property2", "property3", "format", "targetProperty" },
+                              { "3",
+                                "stagebs.presetName",
+                                "fwfpm.filterName",
+                                "stagescibs.presetName",
+                                "\"{}-{}-{}\"",
+                                "stagesci1.presetName" } );
+
+    mx::app::appConfigurator config;
+    focusHelper_test         app;
+
+    REQUIRE( app.setupConfig( config ) == 0 );
+    config.readConfig( "/tmp/cameraSim_focusHelper.conf" );
+    REQUIRE( app.loadConfig( config ) == 0 );
+    REQUIRE( app.gotoFocusFormat() == "{}-{}-{}" );
+    REQUIRE_FALSE( app.gotoFocusFormat().find( '\"' ) != std::string::npos );
 }
 
 } // namespace cameraSimTest

--- a/apps/cameraSim/tests/cameraSim_test.cpp
+++ b/apps/cameraSim/tests/cameraSim_test.cpp
@@ -109,6 +109,12 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
   public:
     static constexpr bool c_stdCamera_hasFocus = true;
 
+  protected:
+    pcf::IndiProperty m_lastSentProperty; ///< Captures the last INDI command sent through the goto-focus helper.
+
+    int m_sendNewPropertyResult{ 0 }; ///< Return value used by the test sendNewProperty override.
+
+  public:
     focusHelper_test() : MagAOXApp<>( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
     {
         m_configName = "camtest";
@@ -119,6 +125,37 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
         m_indiP_focus.setName( "focus" );
         m_indiP_focus.setState( INDI_IDLE );
         m_indiP_focus.add( pcf::IndiElement( "state", pcf::IndiElement::Off ) );
+    }
+
+    ~focusHelper_test() noexcept override = default;
+
+    void configureGotoFocusHelper( const std::vector<std::string> &properties,
+                                   const std::string              &format,
+                                   const std::string              &targetProperty )
+    {
+        m_focusGotoHelperConfigured = true;
+        m_focusGotoSourceProperties = properties;
+        m_focusGotoFormat           = format;
+        m_focusGotoTargetProperty   = targetProperty;
+        m_focusGotoSourceIndices.clear();
+        m_focusMonitoredPropertyKeys.clear();
+        m_indiP_focusMonitoredProperties.clear();
+
+        REQUIRE( indi::parseIndiKey( m_focusGotoTargetDevice, m_focusGotoTargetName, m_focusGotoTargetProperty ) == 0 );
+
+        for( size_t n = 0; n < properties.size(); ++n )
+        {
+            std::string devName;
+            std::string propName;
+
+            REQUIRE( indi::parseIndiKey( devName, propName, properties[n] ) == 0 );
+
+            m_focusGotoSourceIndices.push_back( static_cast<int>( n ) );
+            m_focusMonitoredPropertyKeys.push_back( properties[n] );
+            m_indiP_focusMonitoredProperties.emplace_back();
+            m_indiP_focusMonitoredProperties[n].setDevice( devName );
+            m_indiP_focusMonitoredProperties[n].setName( propName );
+        }
     }
 
     void configureFocusHelper( const std::string &device,
@@ -152,6 +189,17 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
         return 0;
     }
 
+    int sendNewProperty( const pcf::IndiProperty &ipSend )
+    {
+        m_lastSentProperty = ipSend;
+        return m_sendNewPropertyResult;
+    }
+
+    void setSendNewPropertyResult( int result )
+    {
+        m_sendNewPropertyResult = result;
+    }
+
     int appStartup() override
     {
         return 0;
@@ -170,6 +218,11 @@ class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_t
     pcf::IndiElement::SwitchStateType publishedFocusState()
     {
         return m_indiP_focus["state"].getSwitchState();
+    }
+
+    const pcf::IndiProperty &lastSentProperty() const
+    {
+        return m_lastSentProperty;
     }
 };
 /// \endcond
@@ -255,6 +308,54 @@ TEST_CASE( "cameraSim stdCamera focus helper tracks monitored switch properties"
 
         REQUIRE( app.cacheFocusProperty( focusProp ) == 0 );
         REQUIRE( app.publishedFocusState() == pcf::IndiElement::Off );
+    }
+}
+
+/// Verify the stdCamera goto-focus helper formats and dispatches the expected preset command.
+/**
+ * \ingroup cameraSim_unit_test
+ */
+TEST_CASE( "cameraSim stdCamera goto-focus helper dispatches preset commands", "[cameraSim]" )
+{
+    focusHelper_test app;
+    app.configureGotoFocusHelper(
+        { "stagebs.presetName", "fwfpm.filterName", "stagescibs.presetName" }, "{}-{}-{}", "stagesci1.presetName" );
+
+    pcf::IndiProperty prop1( pcf::IndiProperty::Switch );
+    prop1.setDevice( "stagebs" );
+    prop1.setName( "presetName" );
+    prop1.add( pcf::IndiElement( "65-35", pcf::IndiElement::On ) );
+    prop1.add( pcf::IndiElement( "ha-ir", pcf::IndiElement::Off ) );
+
+    pcf::IndiProperty prop2( pcf::IndiProperty::Switch );
+    prop2.setDevice( "fwfpm" );
+    prop2.setName( "filterName" );
+    prop2.add( pcf::IndiElement( "open", pcf::IndiElement::On ) );
+    prop2.add( pcf::IndiElement( "lyotsm", pcf::IndiElement::Off ) );
+
+    pcf::IndiProperty prop3( pcf::IndiProperty::Switch );
+    prop3.setDevice( "stagescibs" );
+    prop3.setName( "presetName" );
+    prop3.add( pcf::IndiElement( "ri", pcf::IndiElement::On ) );
+    prop3.add( pcf::IndiElement( "out", pcf::IndiElement::Off ) );
+
+    REQUIRE( app.cacheFocusProperty( prop1 ) == 0 );
+    REQUIRE( app.cacheFocusProperty( prop2 ) == 0 );
+    REQUIRE( app.cacheFocusProperty( prop3 ) == 0 );
+
+    SECTION( "successful dispatch sends the formatted preset selection" )
+    {
+        REQUIRE( app.sendGotoFocusCommand() == 0 );
+        REQUIRE( app.lastSentProperty().getDevice() == "stagesci1" );
+        REQUIRE( app.lastSentProperty().getName() == "presetName" );
+        REQUIRE( app.lastSentProperty().find( "65-35-open-ri" ) );
+        REQUIRE( app.lastSentProperty()["65-35-open-ri"].getSwitchState() == pcf::IndiElement::On );
+    }
+
+    SECTION( "dispatch failures are propagated to the caller" )
+    {
+        app.setSendNewPropertyResult( -1 );
+        REQUIRE( app.sendGotoFocusCommand() == -1 );
     }
 }
 

--- a/apps/cameraSim/tests/cameraSim_test.cpp
+++ b/apps/cameraSim/tests/cameraSim_test.cpp
@@ -34,6 +34,7 @@ class cameraSim_test : public cameraSim
     cameraSim_test( const std::string device )
     {
         m_configName = device;
+        m_hasFocus   = true;
 
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, reconfigure )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, temp_ccd )
@@ -60,6 +61,7 @@ class cameraSim_test : public cameraSim
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, roi_set_last )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, roi_set_default )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, shutter )
+        XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, goto_focus )
     }
 };
 /// \endcond
@@ -100,6 +102,7 @@ TEST_CASE( "cameraSim INDI callbacks validate device and property names", "[came
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, roi_set_last );
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, roi_set_default );
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, shutter );
+    XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, goto_focus );
 }
 
 } // namespace cameraSimTest

--- a/apps/cameraSim/tests/cameraSim_test.cpp
+++ b/apps/cameraSim/tests/cameraSim_test.cpp
@@ -36,6 +36,12 @@ class cameraSim_test : public cameraSim
         m_configName = device;
         m_hasFocus   = true;
 
+        m_indiP_focus = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        m_indiP_focus.setDevice( m_configName );
+        m_indiP_focus.setName( "focus" );
+        m_indiP_focus.setState( INDI_IDLE );
+        m_indiP_focus.add( pcf::IndiElement( "state", pcf::IndiElement::Off ) );
+
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, reconfigure )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, temp_ccd )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, temp_controller )
@@ -62,6 +68,108 @@ class cameraSim_test : public cameraSim
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, roi_set_default )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, shutter )
         XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_temp, goto_focus )
+    }
+
+    void configureFocusHelper( const std::string &device,
+                               const std::string &property,
+                               const std::string &element,
+                               bool               onMeansInFocus )
+    {
+        m_focusStateHelperConfigured = true;
+        m_focusStateSource           = device + "." + property;
+        m_focusStateElement          = element;
+        m_focusStateOnMeansInFocus   = onMeansInFocus;
+        m_focusStateSourceIndex      = 0;
+        m_focusMonitoredPropertyKeys = { m_focusStateSource };
+        m_indiP_focusMonitoredProperties.resize( 1 );
+        m_indiP_focusMonitoredProperties[0].setDevice( device );
+        m_indiP_focusMonitoredProperties[0].setName( property );
+    }
+
+    int cacheFocusProperty( const pcf::IndiProperty &ipRecv )
+    {
+        return setCallBack_focusMonitored( ipRecv );
+    }
+
+    bool helperFocusState()
+    {
+        return checkFocusSwitchState();
+    }
+
+    pcf::IndiElement::SwitchStateType publishedFocusState()
+    {
+        return m_indiP_focus["state"].getSwitchState();
+    }
+};
+
+class focusHelper_test : public MagAOXApp<>, public dev::stdCamera<focusHelper_test>
+{
+    friend class dev::stdCamera<focusHelper_test>;
+
+  public:
+    static constexpr bool c_stdCamera_hasFocus = true;
+
+    focusHelper_test() : MagAOXApp<>( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
+    {
+        m_configName = "camtest";
+        m_hasFocus   = true;
+
+        m_indiP_focus = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        m_indiP_focus.setDevice( m_configName );
+        m_indiP_focus.setName( "focus" );
+        m_indiP_focus.setState( INDI_IDLE );
+        m_indiP_focus.add( pcf::IndiElement( "state", pcf::IndiElement::Off ) );
+    }
+
+    void configureFocusHelper( const std::string &device,
+                               const std::string &property,
+                               const std::string &element,
+                               bool               onMeansInFocus )
+    {
+        m_focusStateHelperConfigured = true;
+        m_focusStateSource           = device + "." + property;
+        m_focusStateElement          = element;
+        m_focusStateOnMeansInFocus   = onMeansInFocus;
+        m_focusStateSourceIndex      = 0;
+        m_focusMonitoredPropertyKeys = { m_focusStateSource };
+        m_indiP_focusMonitoredProperties.resize( 1 );
+        m_indiP_focusMonitoredProperties[0].setDevice( device );
+        m_indiP_focusMonitoredProperties[0].setName( property );
+    }
+
+    int cacheFocusProperty( const pcf::IndiProperty &ipRecv )
+    {
+        return setCallBack_focusMonitored( ipRecv );
+    }
+
+    bool checkFocus()
+    {
+        return checkFocusSwitchState();
+    }
+
+    int gotoFocus()
+    {
+        return 0;
+    }
+
+    int appStartup() override
+    {
+        return 0;
+    }
+
+    int appLogic() override
+    {
+        return 0;
+    }
+
+    int appShutdown() override
+    {
+        return 0;
+    }
+
+    pcf::IndiElement::SwitchStateType publishedFocusState()
+    {
+        return m_indiP_focus["state"].getSwitchState();
     }
 };
 /// \endcond
@@ -103,6 +211,51 @@ TEST_CASE( "cameraSim INDI callbacks validate device and property names", "[came
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, roi_set_default );
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, shutter );
     XWCTEST_INDI_ARBNEW_CALLBACK( cameraSim, newCallBack_stdCamera, goto_focus );
+}
+
+/// Verify the stdCamera focus helper supports configurable polarity and tracks monitored property updates.
+/**
+ * \ingroup cameraSim_unit_test
+ */
+TEST_CASE( "cameraSim stdCamera focus helper tracks monitored switch properties", "[cameraSim]" )
+{
+    SECTION( "configured element On means out of focus" )
+    {
+        focusHelper_test app;
+        app.configureFocusHelper( "sre", "caution", "focus-mismatch", false );
+
+        pcf::IndiProperty focusProp( pcf::IndiProperty::Switch );
+        focusProp.setDevice( "sre" );
+        focusProp.setName( "caution" );
+        focusProp.add( pcf::IndiElement( "focus-mismatch", pcf::IndiElement::On ) );
+
+        REQUIRE( app.cacheFocusProperty( focusProp ) == 0 );
+        REQUIRE( app.publishedFocusState() == pcf::IndiElement::Off );
+
+        focusProp["focus-mismatch"].setSwitchState( pcf::IndiElement::Off );
+
+        REQUIRE( app.cacheFocusProperty( focusProp ) == 0 );
+        REQUIRE( app.publishedFocusState() == pcf::IndiElement::On );
+    }
+
+    SECTION( "configured element On means in focus" )
+    {
+        focusHelper_test app;
+        app.configureFocusHelper( "sre", "caution", "focus-ok", true );
+
+        pcf::IndiProperty focusProp( pcf::IndiProperty::Switch );
+        focusProp.setDevice( "sre" );
+        focusProp.setName( "caution" );
+        focusProp.add( pcf::IndiElement( "focus-ok", pcf::IndiElement::On ) );
+
+        REQUIRE( app.cacheFocusProperty( focusProp ) == 0 );
+        REQUIRE( app.publishedFocusState() == pcf::IndiElement::On );
+
+        focusProp["focus-ok"].setSwitchState( pcf::IndiElement::Off );
+
+        REQUIRE( app.cacheFocusProperty( focusProp ) == 0 );
+        REQUIRE( app.publishedFocusState() == pcf::IndiElement::Off );
+    }
 }
 
 } // namespace cameraSimTest

--- a/apps/picamCtrl/picamCtrl.hpp
+++ b/apps/picamCtrl/picamCtrl.hpp
@@ -180,6 +180,9 @@ class picamCtrl : public MagAOXApp<>,
     static constexpr bool c_stdCamera_hasShutter =
         true; ///< app:dev config to tell stdCamera to expose shutter controls
 
+    static constexpr bool c_stdCamera_hasFocus =
+        true; ///< app:dev config to tell stdCamera to expose focus-state reporting and goto-focus control
+
     static constexpr bool c_stdCamera_usesStateString =
         false; ///< app::dev confg to tell stdCamera to expose the state string property
 
@@ -315,7 +318,21 @@ class picamCtrl : public MagAOXApp<>,
      */
     int checkNextROI();
 
+    /// Reports whether the camera is currently in focus. [stdCamera interface]
+    /**
+     * \returns `true` when the configured external focus switch indicates the camera is in focus.
+     * \returns `false` otherwise
+     */
+    bool checkFocus();
+
     int setNextROI();
+
+    /// Requests the configured focus preset. [stdCamera interface]
+    /**
+     * \returns 0 on success
+     * \returns -1 if the goto-focus helper is not fully configured
+     */
+    int gotoFocus();
 
     /// Sets the shutter state, via call to dssShutter::setShutterState(int) [stdCamera interface]
     /**
@@ -1556,6 +1573,16 @@ inline int picamCtrl::setNextROI()
     m_reconfig = true;
 
     return 0;
+}
+
+inline bool picamCtrl::checkFocus()
+{
+    return checkFocusSwitchState();
+}
+
+inline int picamCtrl::gotoFocus()
+{
+    return sendGotoFocusCommand();
 }
 
 inline int picamCtrl::setShutter( int sh )

--- a/gui/widgets/camera/camera.hpp
+++ b/gui/widgets/camera/camera.hpp
@@ -339,8 +339,12 @@ void camera::subscribe()
     if( !m_parent )
         return;
 
+    // The empty-name subscription requests the current device property list,
+    // but live updates still require exact property subscriptions.
     m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "" );
     m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "fsm" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "focus" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "goto_focus" );
     m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_darkName, "" );
     m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_darkName, "start" );
     m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_avgName, "" );

--- a/gui/widgets/camera/camera.hpp
+++ b/gui/widgets/camera/camera.hpp
@@ -1,3 +1,9 @@
+/** \file camera.hpp
+ * \brief Widget providing the standard camera control panel for cameraGUI.
+ *
+ * \author Jared R. Males (jaredmales@gmail.com)
+ */
+
 #ifndef camera_hpp
 #define camera_hpp
 
@@ -29,217 +35,297 @@ class camera : public xWidget
 {
     Q_OBJECT
 
-protected:
+  protected:
+    std::string m_appState; ///< Current FSM state string reported by the camera app.
 
-    std::string m_appState;
+    std::string m_camName;  ///< INDI device name of the camera.
+    std::string m_darkName; ///< INDI device name of the dark-frame helper app.
+    std::string m_avgName;  ///< INDI device name of the averaging helper app.
 
-    std::string m_camName;
-    std::string m_darkName;
-    std::string m_avgName;
+    fsmDisplay *ui_fsmState{ nullptr }; ///< Camera FSM status display.
 
-    fsmDisplay * ui_fsmState {nullptr};
+    statusEntry *ui_tempCCD{ nullptr }; ///< Detector temperature display and optional control.
 
-    statusEntry * ui_tempCCD {nullptr};
+    statusDisplay *ui_tempStatus{ nullptr }; ///< Detector temperature-control status display.
 
-    statusDisplay * ui_tempStatus {nullptr};
+    QPushButton *ui_reconfigure{ nullptr }; ///< Button requesting a camera reconfiguration.
 
-    QPushButton * ui_reconfigure {nullptr};
+    std::vector<std::string> m_stageNames; ///< Configured stage widgets associated with this camera.
 
-    std::vector<std::string> m_stageNames;
+    std::vector<stageStatus *> ui_stage; ///< Stage status widgets shown in the left column.
 
-    std::vector<stageStatus *> ui_stage;
+    QPushButton *ui_focus{ nullptr }; ///< Optional button requesting the configured goto-focus preset.
 
-    shutterStatus * ui_shutterStatus {nullptr};
+    bool m_gotoFocusPresent{ false }; ///< True once the camera exposes the `goto_focus` request property.
 
-    roiStatus * ui_roiStatus {nullptr};
+    bool m_focusStateKnown{ false }; ///< True once the camera exposes a current `focus.state` value.
 
-    statusCombo * ui_modes {nullptr};
+    bool m_focusInFocus{ false }; ///< Cached `focus.state` value, true when the camera reports in focus.
 
-    statusCombo * ui_readoutSpd {nullptr};
+    shutterStatus *ui_shutterStatus{ nullptr }; ///< Optional shutter-status widget.
 
-    statusCombo * ui_vshiftSpd {nullptr};
+    roiStatus *ui_roiStatus{ nullptr }; ///< Region-of-interest status widget.
 
-    toggleSlider * ui_cropMode {nullptr};
+    statusCombo *ui_modes{ nullptr }; ///< Camera mode selector/status widget.
 
-    statusEntry * ui_expTime {nullptr};
+    statusCombo *ui_readoutSpd{ nullptr }; ///< Readout-speed selector/status widget.
 
-    statusEntry * ui_fps {nullptr};
+    statusCombo *ui_vshiftSpd{ nullptr }; ///< Vertical-shift-speed selector/status widget.
 
-    statusEntry * ui_emGain {nullptr};
+    toggleSlider *ui_cropMode{ nullptr }; ///< ROI crop-mode toggle widget.
 
-    statusEntry * ui_avgTime {nullptr};
+    statusEntry *ui_expTime{ nullptr }; ///< Exposure-time display and optional control.
 
-    toggleSlider * ui_synchro {nullptr};
+    statusEntry *ui_fps{ nullptr }; ///< Frame-rate display and optional control.
 
-    QPushButton * ui_takeDarks {nullptr};
+    statusEntry *ui_emGain{ nullptr }; ///< EM-gain display and optional control.
 
-    float m_temp {-99};
+    statusEntry *ui_avgTime{ nullptr }; ///< Averaging time control from the averaging helper app.
 
-    bool m_takingDark {false};
+    toggleSlider *ui_synchro{ nullptr }; ///< Synchronization toggle control.
 
-    bool m_inUpdate {false};
+    QPushButton *ui_takeDarks{ nullptr }; ///< Button requesting a new dark acquisition.
 
-    QTimer * m_updateTimer {nullptr}; ///< Timer for periodic updates
+    float m_temp{ -99 }; ///< Cached detector temperature placeholder used during initialization.
 
-    bool m_connected {false};
+    bool m_takingDark{ false }; ///< True while the dark helper reports an active dark acquisition.
 
-public:
-    explicit camera( std::string & camName,
-                     QWidget * Parent = 0,
-                     Qt::WindowFlags f = Qt::WindowFlags()
-                   );
+    bool m_inUpdate{ false }; ///< Guards against overlapping periodic GUI updates.
 
+    QTimer *m_updateTimer{ nullptr }; ///< Timer for periodic updates
+
+    bool m_connected{ false }; ///< True while the widget is connected to the INDI stream.
+
+  public:
+    /// Constructs the standard camera widget.
+    explicit camera( std::string    &camName,
+                     QWidget        *Parent = 0 /**< [in] parent widget */,
+                     Qt::WindowFlags f      = Qt::WindowFlags() /**< [in] Qt window flags */
+    );
+
+    /// Destroys the widget.
     ~camera();
 
-    void subscribe( );
+    /// Subscribes the widget and any created child widgets to their INDI properties.
+    void subscribe();
 
+    /// Handles the initial connection of the widget to its INDI sources.
     virtual void onConnect();
+
+    /// Handles loss of connection to the widget's INDI sources.
     virtual void onDisconnect();
 
-    void handleDefProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handles a newly defined INDI property by reusing the set-property path.
+    void handleDefProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
-    void handleDelProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has been deleted*/);
+    /// Handles removal of an INDI property used by this widget.
+    void handleDelProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has been deleted*/ );
 
-    void handleSetProperty( const pcf::IndiProperty & ipRecv /**< [in] the property which has changed*/);
+    /// Handles updates to any subscribed INDI property used by this widget.
+    void handleSetProperty( const pcf::IndiProperty &ipRecv /**< [in] the property which has changed*/ );
 
+    /// Hides optional child widgets that should not be shown in every configuration.
     void hideAll();
 
-    void setEnableDisable(bool tf, bool all=true);
+    /// Enables or disables the widget's controls.
+    void setEnableDisable( bool tf /**< [in] true to enable the controls, false to disable them */,
+                           bool all = true /**< [in] true to include the title and FSM widgets */
+    );
 
-    //static b/c it gets called before the device is instantiated.
-    static void setupConfig( mx::app::appConfigurator & config );
+    /// Adds the widget's configuration options before the widget is instantiated.
+    static void setupConfig( mx::app::appConfigurator &config );
 
-    void loadConfig( mx::app::appConfigurator & config );
+    /// Loads widget configuration from the application configurator.
+    void loadConfig( mx::app::appConfigurator &config );
 
-public slots:
+  public slots:
 
+    /// Refreshes the enabled state and child widgets from cached INDI state.
     void updateGUI();
 
-    void setup_temp_ccd(bool ro);
+    /// Creates the detector-temperature widget.
+    void setup_temp_ccd( bool ro );
 
+    /// Creates the detector temperature-control status widget.
     void setup_tempStatus();
 
+    /// Creates the reconfigure button.
     void setup_reconfigure();
 
+    /// Sends the camera reconfigure request.
     void reconfigure();
 
+    /// Creates one configured stage widget.
     void setup_stage();
 
+    /// Creates the optional goto-focus button.
+    void setup_focus();
+
+    /// Creates the shutter-status widget.
     void setup_shutter();
 
+    /// Creates the ROI status widget.
     void setup_roiStatus();
 
+    /// Creates the mode selector/status widget.
     void setup_modes();
 
+    /// Creates the readout-speed selector/status widget.
     void setup_readoutSpd();
 
+    /// Creates the vertical-shift-speed selector/status widget.
     void setup_vshiftSpd();
 
+    /// Creates the ROI crop-mode toggle widget.
     void setup_cropMode();
 
-    void setup_expTime(bool ro);
+    /// Creates the exposure-time widget.
+    void setup_expTime( bool ro );
 
-    void setup_fps(bool ro);
+    /// Creates the frame-rate widget.
+    void setup_fps( bool ro );
 
-    void setup_emGain(bool ro);
+    /// Creates the EM-gain widget.
+    void setup_emGain( bool ro );
 
-   void setup_avgTime(bool ro);
+    /// Creates the averaging-time widget.
+    void setup_avgTime( bool ro );
 
+    /// Creates the synchronization toggle widget.
     void setup_synchro();
 
+    /// Creates the take-darks button.
     void setup_takeDarks();
 
+    /// Sends the goto-focus request.
+    void gotoFocus();
+
+    /// Sends the take-dark request.
     void takeDark();
 
-signals:
+  signals:
 
+    /// Requests a GUI refresh on the widget thread.
     void doUpdateGUI();
 
+    /// Stops the periodic update timer.
     void updateTimerStop();
-    void updateTimerStart(int);
 
-    void add_temp_ccd(bool ro);
+    /// Starts the periodic update timer.
+    void updateTimerStart( int );
+
+    /// Queues creation of the detector-temperature widget.
+    void add_temp_ccd( bool ro );
+
+    /// Queues creation of the temperature-status widget.
     void add_tempStatus();
 
+    /// Queues creation of the reconfigure button.
     void add_reconfigure();
 
+    /// Queues creation of the goto-focus button.
+    void add_focus();
+
+    /// Queues creation of the shutter-status widget.
     void add_shutter();
 
+    /// Queues creation of the ROI status widget.
     void add_roiStatus();
+
+    /// Queues creation of the mode selector/status widget.
     void add_modes();
 
+    /// Queues creation of the readout-speed selector/status widget.
     void add_readoutSpd();
+
+    /// Queues creation of the vertical-shift-speed selector/status widget.
     void add_vshiftSpd();
 
+    /// Queues creation of the crop-mode widget.
     void add_cropMode();
 
-    void add_expTime(bool ro);
-    void add_fps(bool ro);
-    void add_emGain(bool ro);
+    /// Queues creation of the exposure-time widget.
+    void add_expTime( bool ro );
 
-    void add_avgTime(bool ro);
+    /// Queues creation of the frame-rate widget.
+    void add_fps( bool ro );
 
+    /// Queues creation of the EM-gain widget.
+    void add_emGain( bool ro );
+
+    /// Queues creation of the averaging-time widget.
+    void add_avgTime( bool ro );
+
+    /// Queues creation of the synchronization widget.
     void add_synchro();
 
+    /// Queues creation of the take-darks button.
     void add_takeDarks();
 
-private:
+  private:
+    /// Resets cached focus-property state when the camera disconnects or removes focus support.
+    void clearFocusState();
+
+    /// Returns the base row used for left-column controls beneath the stage widgets.
+    int leftColumnBaseRow() const;
+
+    /// Repositions optional left-column controls after stage or focus changes.
+    void layoutLeftColumnControls();
 
     Ui::camera ui;
 };
 
-camera::camera( std::string & camName,
-                QWidget * Parent,
-                Qt::WindowFlags f) : xWidget(Parent, f), m_camName{camName}
+camera::camera( std::string &camName, QWidget *Parent, Qt::WindowFlags f ) : xWidget( Parent, f ), m_camName{ camName }
 {
     m_darkName = m_camName + "-dark";
-    m_avgName = m_camName + "-avg";
+    m_avgName  = m_camName + "-avg";
 
-    ui.setupUi(this);
+    ui.setupUi( this );
 
-    m_updateTimer = new QTimer(this);
+    m_updateTimer = new QTimer( this );
 
-    connect(this, SIGNAL(doUpdateGUI()), this, SLOT(updateGUI()));
+    connect( this, SIGNAL( doUpdateGUI() ), this, SLOT( updateGUI() ) );
 
-    connect(m_updateTimer, SIGNAL(timeout()), this, SLOT(updateGUI()));
-    connect(this, SIGNAL(updateTimerStop()), m_updateTimer, SLOT(stop()));
-    connect(this, SIGNAL(updateTimerStart(int)), m_updateTimer, SLOT(start(int)));
+    connect( m_updateTimer, SIGNAL( timeout() ), this, SLOT( updateGUI() ) );
+    connect( this, SIGNAL( updateTimerStop() ), m_updateTimer, SLOT( stop() ) );
+    connect( this, SIGNAL( updateTimerStart( int ) ), m_updateTimer, SLOT( start( int ) ) );
 
-    connect(this, SIGNAL(add_temp_ccd(bool)), this, SLOT(setup_temp_ccd(bool)));
-    connect(this, SIGNAL(add_tempStatus()), this, SLOT(setup_tempStatus()));
+    connect( this, SIGNAL( add_temp_ccd( bool ) ), this, SLOT( setup_temp_ccd( bool ) ) );
+    connect( this, SIGNAL( add_tempStatus() ), this, SLOT( setup_tempStatus() ) );
 
-    connect(this, SIGNAL(add_reconfigure()), this, SLOT(setup_reconfigure()));
+    connect( this, SIGNAL( add_reconfigure() ), this, SLOT( setup_reconfigure() ) );
 
-    connect(this, SIGNAL(add_shutter()), this, SLOT(setup_shutter()));
+    connect( this, SIGNAL( add_focus() ), this, SLOT( setup_focus() ) );
+    connect( this, SIGNAL( add_shutter() ), this, SLOT( setup_shutter() ) );
 
-    connect(this, SIGNAL(add_roiStatus()), this, SLOT(setup_roiStatus()));
-    connect(this, SIGNAL(add_modes()), this, SLOT(setup_modes()));
+    connect( this, SIGNAL( add_roiStatus() ), this, SLOT( setup_roiStatus() ) );
+    connect( this, SIGNAL( add_modes() ), this, SLOT( setup_modes() ) );
 
-    connect(this, SIGNAL(add_readoutSpd()), this, SLOT(setup_readoutSpd()));
-    connect(this, SIGNAL(add_vshiftSpd()), this, SLOT(setup_vshiftSpd()));
-    connect(this, SIGNAL(add_cropMode()), this, SLOT(setup_cropMode()));
+    connect( this, SIGNAL( add_readoutSpd() ), this, SLOT( setup_readoutSpd() ) );
+    connect( this, SIGNAL( add_vshiftSpd() ), this, SLOT( setup_vshiftSpd() ) );
+    connect( this, SIGNAL( add_cropMode() ), this, SLOT( setup_cropMode() ) );
 
-    connect(this, SIGNAL(add_expTime(bool)), this, SLOT(setup_expTime(bool)));
-    connect(this, SIGNAL(add_fps(bool)), this, SLOT(setup_fps(bool)));
-    connect(this, SIGNAL(add_emGain(bool)), this, SLOT(setup_emGain(bool)));
-    connect(this, SIGNAL(add_avgTime(bool)), this, SLOT(setup_avgTime(bool)));
-    connect(this, SIGNAL(add_synchro()), this, SLOT(setup_synchro()));
+    connect( this, SIGNAL( add_expTime( bool ) ), this, SLOT( setup_expTime( bool ) ) );
+    connect( this, SIGNAL( add_fps( bool ) ), this, SLOT( setup_fps( bool ) ) );
+    connect( this, SIGNAL( add_emGain( bool ) ), this, SLOT( setup_emGain( bool ) ) );
+    connect( this, SIGNAL( add_avgTime( bool ) ), this, SLOT( setup_avgTime( bool ) ) );
+    connect( this, SIGNAL( add_synchro() ), this, SLOT( setup_synchro() ) );
 
-    connect(this, SIGNAL(add_takeDarks()), this, SLOT(setup_takeDarks()));
+    connect( this, SIGNAL( add_takeDarks() ), this, SLOT( setup_takeDarks() ) );
 
-    QSpacerItem *holder = new QSpacerItem(10,0, QSizePolicy::Expanding, QSizePolicy::Expanding);
-    ui.grid->addItem(holder, 2,1,1,1);
+    QSpacerItem *holder = new QSpacerItem( 10, 0, QSizePolicy::Expanding, QSizePolicy::Expanding );
+    ui.grid->addItem( holder, 2, 1, 1, 1 );
 
-    ui_fsmState = new xqt::fsmDisplay(this);
-    ui_fsmState->setObjectName(QString::fromUtf8("fsmState"));
-    ui.grid->addWidget(ui_fsmState, 1, 0, 1, 1);
-    ui_fsmState->device(m_camName);
+    ui_fsmState = new xqt::fsmDisplay( this );
+    ui_fsmState->setObjectName( QString::fromUtf8( "fsmState" ) );
+    ui.grid->addWidget( ui_fsmState, 1, 0, 1, 1 );
+    ui_fsmState->device( m_camName );
 
     QFont qf = ui.lab_camName->font();
-    qf.setPixelSize(XW_FONT_SIZE+3);
-    ui.lab_camName->setFont(qf);
+    qf.setPixelSize( XW_FONT_SIZE + 3 );
+    ui.lab_camName->setFont( qf );
 
-    ui.lab_camName->setText(m_camName.c_str());
+    ui.lab_camName->setText( m_camName.c_str() );
 
     onDisconnect();
 }
@@ -250,78 +336,106 @@ camera::~camera()
 
 void camera::subscribe()
 {
-    if(!m_parent) return;
+    if( !m_parent )
+        return;
 
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_camName, "");
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_camName, "fsm");
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_darkName, "");
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_darkName, "start");
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_avgName, "");
-    m_parent->addSubscriberProperty((multiIndiSubscriber *) this, m_avgName, "avgTime");
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_camName, "fsm" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_darkName, "" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_darkName, "start" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_avgName, "" );
+    m_parent->addSubscriberProperty( (multiIndiSubscriber *)this, m_avgName, "avgTime" );
 
-    m_parent->addSubscriber(ui_fsmState);
+    m_parent->addSubscriber( ui_fsmState );
 
-    if(ui_tempCCD) m_parent->addSubscriber(ui_tempCCD);
-    if(ui_tempStatus) m_parent->addSubscriber(ui_tempStatus);
+    if( ui_tempCCD )
+        m_parent->addSubscriber( ui_tempCCD );
+    if( ui_tempStatus )
+        m_parent->addSubscriber( ui_tempStatus );
 
-    if(ui_stage.size() > 0)
+    if( ui_stage.size() > 0 )
     {
-        for(size_t n = 0; n < ui_stage.size(); ++n)
+        for( size_t n = 0; n < ui_stage.size(); ++n )
         {
-            m_parent->addSubscriber(ui_stage[n]);
+            m_parent->addSubscriber( ui_stage[n] );
         }
     }
 
-    if(ui_shutterStatus) m_parent->addSubscriber(ui_shutterStatus);
-    if(ui_roiStatus) m_parent->addSubscriber(ui_roiStatus);
-    if(ui_modes) m_parent->addSubscriber(ui_modes);
-    if(ui_readoutSpd) m_parent->addSubscriber(ui_readoutSpd);
-    if(ui_vshiftSpd) m_parent->addSubscriber(ui_vshiftSpd);
-    if(ui_cropMode) m_parent->addSubscriber(ui_cropMode);
-    if(ui_expTime) m_parent->addSubscriber(ui_expTime);
-    if(ui_fps) m_parent->addSubscriber(ui_fps);
-    if(ui_emGain) m_parent->addSubscriber(ui_emGain);
-    if(ui_avgTime) m_parent->addSubscriber(ui_avgTime);
-    if(ui_synchro) m_parent->addSubscriber(ui_synchro);
+    if( ui_shutterStatus )
+        m_parent->addSubscriber( ui_shutterStatus );
+    if( ui_roiStatus )
+        m_parent->addSubscriber( ui_roiStatus );
+    if( ui_modes )
+        m_parent->addSubscriber( ui_modes );
+    if( ui_readoutSpd )
+        m_parent->addSubscriber( ui_readoutSpd );
+    if( ui_vshiftSpd )
+        m_parent->addSubscriber( ui_vshiftSpd );
+    if( ui_cropMode )
+        m_parent->addSubscriber( ui_cropMode );
+    if( ui_expTime )
+        m_parent->addSubscriber( ui_expTime );
+    if( ui_fps )
+        m_parent->addSubscriber( ui_fps );
+    if( ui_emGain )
+        m_parent->addSubscriber( ui_emGain );
+    if( ui_avgTime )
+        m_parent->addSubscriber( ui_avgTime );
+    if( ui_synchro )
+        m_parent->addSubscriber( ui_synchro );
 
     return;
 }
 
 void camera::onConnect()
 {
-    ui.lab_camName->setEnabled(true);
+    ui.lab_camName->setEnabled( true );
 
-    setWindowTitle(QString((m_camName+"Ctrl").c_str()));
+    setWindowTitle( QString( ( m_camName + "Ctrl" ).c_str() ) );
 
     ui_fsmState->onConnect();
 
-    if(ui_tempCCD) ui_tempCCD->onConnect();
-    if(ui_tempStatus) ui_tempStatus->onConnect();
+    if( ui_tempCCD )
+        ui_tempCCD->onConnect();
+    if( ui_tempStatus )
+        ui_tempStatus->onConnect();
 
-    if(ui_stage.size() > 0)
+    if( ui_stage.size() > 0 )
     {
-        for(size_t n = 0; n < ui_stage.size(); ++n)
+        for( size_t n = 0; n < ui_stage.size(); ++n )
         {
             ui_stage[n]->onConnect();
         }
     }
 
-    if(ui_shutterStatus) ui_shutterStatus->onConnect();
+    if( ui_shutterStatus )
+        ui_shutterStatus->onConnect();
 
-    if(ui_roiStatus) ui_roiStatus->onConnect();
-    if(ui_modes) ui_modes->onConnect();
-    if(ui_readoutSpd) ui_readoutSpd->onConnect();
-    if(ui_vshiftSpd) ui_vshiftSpd->onConnect();
-    if(ui_cropMode) ui_cropMode->onConnect();
+    if( ui_roiStatus )
+        ui_roiStatus->onConnect();
+    if( ui_modes )
+        ui_modes->onConnect();
+    if( ui_readoutSpd )
+        ui_readoutSpd->onConnect();
+    if( ui_vshiftSpd )
+        ui_vshiftSpd->onConnect();
+    if( ui_cropMode )
+        ui_cropMode->onConnect();
 
-    if(ui_expTime) ui_expTime->onConnect();
-    if(ui_fps) ui_fps->onConnect();
-    if(ui_emGain) ui_emGain->onConnect();
-    if(ui_avgTime) ui_avgTime->onConnect();
+    if( ui_expTime )
+        ui_expTime->onConnect();
+    if( ui_fps )
+        ui_fps->onConnect();
+    if( ui_emGain )
+        ui_emGain->onConnect();
+    if( ui_avgTime )
+        ui_avgTime->onConnect();
 
-    if(ui_synchro) ui_synchro->onConnect();
+    if( ui_synchro )
+        ui_synchro->onConnect();
 
     clearFocus();
+    clearFocusState();
 
     m_connected = true;
 
@@ -331,282 +445,358 @@ void camera::onConnect()
 void camera::onDisconnect()
 {
 
-    setWindowTitle(QString((m_camName+"Ctrl").c_str()) + QString(" (disconnected)"));
+    setWindowTitle( QString( ( m_camName + "Ctrl" ).c_str() ) + QString( " (disconnected)" ) );
 
     ui_fsmState->onDisconnect();
 
-    if(ui_tempCCD) ui_tempCCD->onDisconnect();
-    if(ui_tempStatus) ui_tempStatus->onDisconnect();
+    if( ui_tempCCD )
+        ui_tempCCD->onDisconnect();
+    if( ui_tempStatus )
+        ui_tempStatus->onDisconnect();
 
-    if(ui_stage.size() > 0)
+    if( ui_stage.size() > 0 )
     {
-        for(size_t n =0; n < ui_stage.size(); ++n)
+        for( size_t n = 0; n < ui_stage.size(); ++n )
         {
             ui_stage[n]->onDisconnect();
         }
     }
 
-    if(ui_shutterStatus) ui_shutterStatus->onDisconnect();
+    if( ui_shutterStatus )
+        ui_shutterStatus->onDisconnect();
 
-    if(ui_roiStatus) ui_roiStatus->onDisconnect();
-    if(ui_modes) ui_modes->onDisconnect();
-    if(ui_readoutSpd) ui_readoutSpd->onDisconnect();
-    if(ui_vshiftSpd) ui_vshiftSpd->onDisconnect();
-    if(ui_cropMode) ui_cropMode->onDisconnect();
+    if( ui_roiStatus )
+        ui_roiStatus->onDisconnect();
+    if( ui_modes )
+        ui_modes->onDisconnect();
+    if( ui_readoutSpd )
+        ui_readoutSpd->onDisconnect();
+    if( ui_vshiftSpd )
+        ui_vshiftSpd->onDisconnect();
+    if( ui_cropMode )
+        ui_cropMode->onDisconnect();
 
-    if(ui_expTime) ui_expTime->onDisconnect();
-    if(ui_fps) ui_fps->onDisconnect();
-    if(ui_emGain) ui_emGain->onDisconnect();
-    if(ui_avgTime) ui_avgTime->onDisconnect();
+    if( ui_expTime )
+        ui_expTime->onDisconnect();
+    if( ui_fps )
+        ui_fps->onDisconnect();
+    if( ui_emGain )
+        ui_emGain->onDisconnect();
+    if( ui_avgTime )
+        ui_avgTime->onDisconnect();
 
-    if(ui_synchro) ui_synchro->onDisconnect();
+    if( ui_synchro )
+        ui_synchro->onDisconnect();
 
     clearFocus();
+    clearFocusState();
 
     m_connected = false;
-    while(m_inUpdate)
+    while( m_inUpdate )
     {
-       QThread::msleep(10); //Wait to get out of update
+        QThread::msleep( 10 ); // Wait to get out of update
     }
     emit updateTimerStop();
 
-    setEnableDisable(false);
+    setEnableDisable( false );
 }
 
-void camera::handleDefProperty( const pcf::IndiProperty & ipRecv)
+void camera::handleDefProperty( const pcf::IndiProperty &ipRecv )
 {
-   return handleSetProperty(ipRecv);
+    return handleSetProperty( ipRecv );
 }
 
-void camera::handleDelProperty( const pcf::IndiProperty & ipRecv)
+void camera::handleDelProperty( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getDevice() != m_camName && ipRecv.getDevice() != m_darkName && ipRecv.getDevice() != m_avgName) return;
+    if( ipRecv.getDevice() != m_camName && ipRecv.getDevice() != m_darkName && ipRecv.getDevice() != m_avgName )
+        return;
 
-   if(ipRecv.getDevice() == m_camName)
-   {
-      if(ipRecv.getName() == "fsm")
-      {
-         m_appState.clear();
-      }
-   }
-   else if(ipRecv.getDevice() == m_darkName)
-   {
-      if(ipRecv.getName() == "start")
-      {
-         m_takingDark = false;
-      }
-   }
-
-   emit doUpdateGUI();
-}
-
-void camera::handleSetProperty( const pcf::IndiProperty & ipRecv)
-{
-   if(ipRecv.getDevice() != m_camName && ipRecv.getDevice() != m_darkName && ipRecv.getDevice() != m_avgName) return;
-
-   if(ipRecv.getDevice() == m_camName)
-   {
-      if(ipRecv.getName() == "fsm")
-      {
-         if(ipRecv.find("state"))
-         {
-            m_appState = ipRecv["state"].get<std::string>();
-         }
-      }
-
-      if(ipRecv.getName() == "temp_ccd")
-      {
-         if(!ui_tempCCD)
-         {
-            bool ro = true;
-            if(ipRecv.find("target")) ro = false;
-
-            emit add_temp_ccd(ro);
-         }
-      }
-
-      if(ipRecv.getName() == "temp_control")
-      {
-         if(!ui_tempStatus)
-         {
-            emit add_tempStatus();
-         }
-      }
-
-      if(ipRecv.getName() == "reconfigure")
-      {
-         if(!ui_reconfigure)
-         {
-            emit add_reconfigure();
-         }
-      }
-
-      if(ipRecv.getName() == "shutter")
-      {
-         if(!ui_shutterStatus)
-         {
-            emit add_shutter();
-         }
-      }
-
-      if(ipRecv.getName() == "roi_set")
-      {
-         if(!ui_roiStatus)
-         {
-            emit add_roiStatus();
-         }
-      }
-
-      if(ipRecv.getName() == "mode")
-      {
-         if(!ui_modes)
-         {
-            emit add_modes();
-         }
-      }
-
-      if(ipRecv.getName() == "readout_speed")
-      {
-         if(!ui_readoutSpd)
-         {
-            emit add_readoutSpd();
-         }
-      }
-
-      if(ipRecv.getName() == "vshift_speed")
-      {
-         if(!ui_vshiftSpd)
-         {
-            emit add_vshiftSpd();
-         }
-      }
-
-      if(ipRecv.getName() == "roi_crop_mode")
-      {
-         if(!ui_cropMode)
-         {
-            emit add_cropMode();
-         }
-      }
-
-      if(ipRecv.getName() == "exptime")
-      {
-         if(!ui_expTime)
-         {
-            bool ro = true;
-            if(ipRecv.find("target")) ro = false;
-
-            emit add_expTime(ro);
-         }
-      }
-
-      if(ipRecv.getName() == "fps")
-      {
-         if(!ui_fps)
-         {
-            bool ro = true;
-            if(ipRecv.find("target")) ro = false;
-
-            emit add_fps(ro);
-         }
-      }
-
-      if(ipRecv.getName() == "emgain")
-      {
-         if(!ui_emGain)
-         {
-            bool ro = true;
-            if(ipRecv.find("target")) ro = false;
-
-            emit add_emGain(ro);
-         }
-      }
-
-      if(ipRecv.getName() == "synchro")
-      {
-         if(!ui_synchro)
-         {
-            emit add_synchro();
-         }
-      }
-
-   }
-   else if(ipRecv.getDevice() == m_darkName)
-   {
-      if(!ui_takeDarks) emit add_takeDarks();
-
-      if(ipRecv.getName() == "start" && ipRecv.find("toggle"))
-      {
-         if(ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On)
-         {
-            m_takingDark = true;
-         }
-         else
-         {
+    if( ipRecv.getDevice() == m_camName )
+    {
+        if( ipRecv.getName() == "fsm" )
+        {
+            m_appState.clear();
+        }
+        else if( ipRecv.getName() == "focus" )
+        {
+            m_focusStateKnown = false;
+            m_focusInFocus    = false;
+        }
+        else if( ipRecv.getName() == "goto_focus" )
+        {
+            m_gotoFocusPresent = false;
+            layoutLeftColumnControls();
+        }
+    }
+    else if( ipRecv.getDevice() == m_darkName )
+    {
+        if( ipRecv.getName() == "start" )
+        {
             m_takingDark = false;
-         }
-      }
-   }
-   else if(ipRecv.getDevice() == m_avgName)
-   {
-      if(!ui_avgTime)
-      {
-         emit add_avgTime(false);
-      }
-   }
+        }
+    }
 
-   emit doUpdateGUI();
+    emit doUpdateGUI();
+}
+
+void camera::handleSetProperty( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.getDevice() != m_camName && ipRecv.getDevice() != m_darkName && ipRecv.getDevice() != m_avgName )
+        return;
+
+    if( ipRecv.getDevice() == m_camName )
+    {
+        if( ipRecv.getName() == "fsm" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_appState = ipRecv["state"].get<std::string>();
+            }
+        }
+
+        if( ipRecv.getName() == "temp_ccd" )
+        {
+            if( !ui_tempCCD )
+            {
+                bool ro = true;
+                if( ipRecv.find( "target" ) )
+                    ro = false;
+
+                emit add_temp_ccd( ro );
+            }
+        }
+
+        if( ipRecv.getName() == "temp_control" )
+        {
+            if( !ui_tempStatus )
+            {
+                emit add_tempStatus();
+            }
+        }
+
+        if( ipRecv.getName() == "reconfigure" )
+        {
+            if( !ui_reconfigure )
+            {
+                emit add_reconfigure();
+            }
+        }
+
+        if( ipRecv.getName() == "focus" )
+        {
+            if( ipRecv.find( "state" ) )
+            {
+                m_focusStateKnown = true;
+                m_focusInFocus    = ( ipRecv["state"].getSwitchState() == pcf::IndiElement::On );
+            }
+        }
+
+        if( ipRecv.getName() == "goto_focus" )
+        {
+            m_gotoFocusPresent = true;
+
+            if( !ui_focus )
+            {
+                emit add_focus();
+            }
+            else
+            {
+                layoutLeftColumnControls();
+            }
+        }
+
+        if( ipRecv.getName() == "shutter" )
+        {
+            if( !ui_shutterStatus )
+            {
+                emit add_shutter();
+            }
+        }
+
+        if( ipRecv.getName() == "roi_set" )
+        {
+            if( !ui_roiStatus )
+            {
+                emit add_roiStatus();
+            }
+        }
+
+        if( ipRecv.getName() == "mode" )
+        {
+            if( !ui_modes )
+            {
+                emit add_modes();
+            }
+        }
+
+        if( ipRecv.getName() == "readout_speed" )
+        {
+            if( !ui_readoutSpd )
+            {
+                emit add_readoutSpd();
+            }
+        }
+
+        if( ipRecv.getName() == "vshift_speed" )
+        {
+            if( !ui_vshiftSpd )
+            {
+                emit add_vshiftSpd();
+            }
+        }
+
+        if( ipRecv.getName() == "roi_crop_mode" )
+        {
+            if( !ui_cropMode )
+            {
+                emit add_cropMode();
+            }
+        }
+
+        if( ipRecv.getName() == "exptime" )
+        {
+            if( !ui_expTime )
+            {
+                bool ro = true;
+                if( ipRecv.find( "target" ) )
+                    ro = false;
+
+                emit add_expTime( ro );
+            }
+        }
+
+        if( ipRecv.getName() == "fps" )
+        {
+            if( !ui_fps )
+            {
+                bool ro = true;
+                if( ipRecv.find( "target" ) )
+                    ro = false;
+
+                emit add_fps( ro );
+            }
+        }
+
+        if( ipRecv.getName() == "emgain" )
+        {
+            if( !ui_emGain )
+            {
+                bool ro = true;
+                if( ipRecv.find( "target" ) )
+                    ro = false;
+
+                emit add_emGain( ro );
+            }
+        }
+
+        if( ipRecv.getName() == "synchro" )
+        {
+            if( !ui_synchro )
+            {
+                emit add_synchro();
+            }
+        }
+    }
+    else if( ipRecv.getDevice() == m_darkName )
+    {
+        if( !ui_takeDarks )
+            emit add_takeDarks();
+
+        if( ipRecv.getName() == "start" && ipRecv.find( "toggle" ) )
+        {
+            if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
+            {
+                m_takingDark = true;
+            }
+            else
+            {
+                m_takingDark = false;
+            }
+        }
+    }
+    else if( ipRecv.getDevice() == m_avgName )
+    {
+        if( !ui_avgTime )
+        {
+            emit add_avgTime( false );
+        }
+    }
+
+    emit doUpdateGUI();
 }
 
 void camera::hideAll()
 {
-   if(ui_roiStatus) ui_roiStatus->hide();
+    if( ui_roiStatus )
+        ui_roiStatus->hide();
 }
 
-void camera::setEnableDisable(bool tf, bool all)
+void camera::setEnableDisable( bool tf, bool all )
 {
-    if(all)
+    if( all )
     {
-       ui.lab_camName->setEnabled(tf);
-       ui_fsmState->setEnabled(tf);
+        ui.lab_camName->setEnabled( tf );
+        ui_fsmState->setEnabled( tf );
     }
 
-    if(ui_reconfigure) ui_reconfigure->setEnabled(tf);
-    if(ui_tempCCD) ui_tempCCD->setEnabled(tf);
-    if(ui_tempStatus) ui_tempStatus->setEnabled(tf);
+    if( ui_reconfigure )
+        ui_reconfigure->setEnabled( tf );
+    if( ui_tempCCD )
+        ui_tempCCD->setEnabled( tf );
+    if( ui_tempStatus )
+        ui_tempStatus->setEnabled( tf );
+    if( ui_focus )
+        ui_focus->setEnabled( tf );
 
-    if(ui_roiStatus) ui_roiStatus->setEnabled(tf);
-    if(ui_modes) ui_modes->setEnabled(tf);
-    if(ui_readoutSpd) ui_readoutSpd->setEnabled(tf);
-    if(ui_vshiftSpd) ui_vshiftSpd->setEnabled(tf);
-    if(ui_expTime) ui_expTime->setEnabled(tf);
-    if(ui_fps) ui_fps->setEnabled(tf);
-    if(ui_emGain) ui_emGain->setEnabled(tf);
-    if(ui_avgTime) ui_avgTime->setEnabled(tf);
+    if( ui_roiStatus )
+        ui_roiStatus->setEnabled( tf );
+    if( ui_modes )
+        ui_modes->setEnabled( tf );
+    if( ui_readoutSpd )
+        ui_readoutSpd->setEnabled( tf );
+    if( ui_vshiftSpd )
+        ui_vshiftSpd->setEnabled( tf );
+    if( ui_expTime )
+        ui_expTime->setEnabled( tf );
+    if( ui_fps )
+        ui_fps->setEnabled( tf );
+    if( ui_emGain )
+        ui_emGain->setEnabled( tf );
+    if( ui_avgTime )
+        ui_avgTime->setEnabled( tf );
 
-    if(ui_stage.size() > 0)
+    if( ui_stage.size() > 0 )
     {
-        for(size_t n = 0; n < ui_stage.size(); ++n)
+        for( size_t n = 0; n < ui_stage.size(); ++n )
         {
-            ui_stage[n]->setEnabled(tf);
+            ui_stage[n]->setEnabled( tf );
         }
     }
 
-    if(ui_shutterStatus) ui_shutterStatus->setEnabled(tf);
+    if( ui_shutterStatus )
+        ui_shutterStatus->setEnabled( tf );
 
-    if(ui_takeDarks) ui_takeDarks->setEnabled(tf);
-
+    if( ui_takeDarks )
+        ui_takeDarks->setEnabled( tf );
 }
 
-void camera::setupConfig( mx::app::appConfigurator & config )
+void camera::setupConfig( mx::app::appConfigurator &config )
 {
-   config.add("camera.stages", "", "camera.stages", mx::app::argType::Required, "camera", "stages", false, "vector<string>", "List of stages associated with this camera");
+    config.add( "camera.stages",
+                "",
+                "camera.stages",
+                mx::app::argType::Required,
+                "camera",
+                "stages",
+                false,
+                "vector<string>",
+                "List of stages associated with this camera" );
 }
 
-void camera::loadConfig( mx::app::appConfigurator & config )
+void camera::loadConfig( mx::app::appConfigurator &config )
 {
-    config(m_stageNames, "camera.stages");
-    for(size_t n = 0; n < m_stageNames.size(); ++n)
+    config( m_stageNames, "camera.stages" );
+    for( size_t n = 0; n < m_stageNames.size(); ++n )
     {
         setup_stage();
     }
@@ -615,356 +805,466 @@ void camera::loadConfig( mx::app::appConfigurator & config )
 
 void camera::updateGUI()
 {
-    if(m_inUpdate || !m_connected) return;
+    if( m_inUpdate || !m_connected )
+        return;
     emit updateTimerStop();
     m_inUpdate = true;
 
-    if( m_appState == "NODEVICE" || m_appState == "NOTCONNECTED" || m_appState == "CONNECTED")
+    if( m_appState == "NODEVICE" || m_appState == "NOTCONNECTED" || m_appState == "CONNECTED" )
     {
-       setEnableDisable(false, false);
-       ui.lab_camName->setEnabled(true);
-       ui_fsmState->setEnabled(true);
+        setEnableDisable( false, false );
+        ui.lab_camName->setEnabled( true );
+        ui_fsmState->setEnabled( true );
     }
-    else if( m_appState != "READY" && m_appState != "OPERATING" && m_appState != "CONFIGURING")
+    else if( m_appState != "READY" && m_appState != "OPERATING" && m_appState != "CONFIGURING" )
     {
-       setEnableDisable(false);
-       m_inUpdate = false;
+        setEnableDisable( false );
+        m_inUpdate = false;
 
-       emit updateTimerStart(1000);
-       return;
+        emit updateTimerStart( 1000 );
+        return;
     }
-    else //if( m_appState == "READY" || m_appState == "OPERATING" || m_appState == "CONFIGURING")
+    else // if( m_appState == "READY" || m_appState == "OPERATING" || m_appState == "CONFIGURING")
     {
-       setEnableDisable(true);
+        setEnableDisable( true );
     }
 
-    //Update the component GUIs to ensure they update for connection state, etc.
-    if(ui_tempCCD) ui_tempCCD->updateGUI();
-    if(ui_roiStatus) ui_roiStatus->updateGUI();
+    // Update the component GUIs to ensure they update for connection state, etc.
+    if( ui_tempCCD )
+        ui_tempCCD->updateGUI();
+    if( ui_roiStatus )
+        ui_roiStatus->updateGUI();
 
-    if(ui_stage.size() > 0)
+    if( ui_stage.size() > 0 )
     {
-        for(size_t n = 0; n < ui_stage.size(); ++n)
+        for( size_t n = 0; n < ui_stage.size(); ++n )
         {
             ui_stage[n]->updateGUI();
         }
     }
 
-    if(ui_shutterStatus) ui_shutterStatus->updateGUI();
-    if(ui_modes) ui_modes->updateGUI();
-    if(ui_readoutSpd) ui_readoutSpd->updateGUI();
-    if(ui_vshiftSpd) ui_vshiftSpd->updateGUI();
-    if(ui_cropMode) ui_cropMode->updateGUI();
-    if(ui_expTime) ui_expTime->updateGUI();
-    if(ui_fps) ui_fps->updateGUI();
-    if(ui_emGain) ui_emGain->updateGUI();
-    if(ui_avgTime) ui_avgTime->updateGUI();
-    if(ui_synchro) ui_synchro->updateGUI();
+    if( ui_shutterStatus )
+        ui_shutterStatus->updateGUI();
+    if( ui_modes )
+        ui_modes->updateGUI();
+    if( ui_readoutSpd )
+        ui_readoutSpd->updateGUI();
+    if( ui_vshiftSpd )
+        ui_vshiftSpd->updateGUI();
+    if( ui_cropMode )
+        ui_cropMode->updateGUI();
+    if( ui_expTime )
+        ui_expTime->updateGUI();
+    if( ui_fps )
+        ui_fps->updateGUI();
+    if( ui_emGain )
+        ui_emGain->updateGUI();
+    if( ui_avgTime )
+        ui_avgTime->updateGUI();
+    if( ui_synchro )
+        ui_synchro->updateGUI();
 
-    if( (m_appState == "READY" || m_appState == "OPERATING") && ui_takeDarks )
+    if( ui_focus )
     {
-       if(m_takingDark)
-       {
-          ui_takeDarks->setEnabled(false);
-       }
-       else
-       {
-          ui_takeDarks->setEnabled(true);
-       }
+        ui_focus->setVisible( m_gotoFocusPresent );
+
+        if( ( m_appState == "READY" || m_appState == "OPERATING" || m_appState == "CONFIGURING" ) &&
+            m_gotoFocusPresent && m_focusStateKnown && !m_focusInFocus )
+        {
+            ui_focus->setEnabled( true );
+        }
+        else
+        {
+            ui_focus->setEnabled( false );
+        }
     }
 
-    emit updateTimerStart(1000);
+    if( ( m_appState == "READY" || m_appState == "OPERATING" ) && ui_takeDarks )
+    {
+        if( m_takingDark )
+        {
+            ui_takeDarks->setEnabled( false );
+        }
+        else
+        {
+            ui_takeDarks->setEnabled( true );
+        }
+    }
+
+    emit updateTimerStart( 1000 );
     m_inUpdate = false;
 
-} //updateGUI()
+} // updateGUI()
 
-void camera::setup_temp_ccd(bool ro)
+void camera::setup_temp_ccd( bool ro )
 {
-   if(ui_tempCCD) return;
+    if( ui_tempCCD )
+        return;
 
-   ui_tempCCD = new statusEntry(this);
-   ui_tempCCD->setObjectName(QString::fromUtf8("tempCCD"));
-   ui_tempCCD->setup(m_camName, "temp_ccd", statusEntry::FLOAT, "Detector Temp.", "C");
-   ui_tempCCD->highlightChanges(false);
-   ui_tempCCD->readOnly(ro);
+    ui_tempCCD = new statusEntry( this );
+    ui_tempCCD->setObjectName( QString::fromUtf8( "tempCCD" ) );
+    ui_tempCCD->setup( m_camName, "temp_ccd", statusEntry::FLOAT, "Detector Temp.", "C" );
+    ui_tempCCD->highlightChanges( false );
+    ui_tempCCD->readOnly( ro );
 
-   ui.grid->addWidget(ui_tempCCD, 0, 1, 1, 1);
+    ui.grid->addWidget( ui_tempCCD, 0, 1, 1, 1 );
 
-   ui_tempCCD->onDisconnect();
+    ui_tempCCD->onDisconnect();
 
-   m_parent->addSubscriber(ui_tempCCD);
-
+    m_parent->addSubscriber( ui_tempCCD );
 }
 
 void camera::setup_tempStatus()
 {
-   if(ui_tempStatus) return;
+    if( ui_tempStatus )
+        return;
 
-   ui_tempStatus = new statusDisplay(m_camName,"temp_control", "status", "Temp. Ctrl.", "", this, Qt::WindowFlags());
-   ui_tempStatus->setObjectName(QString::fromUtf8("tempStatus"));
+    ui_tempStatus =
+        new statusDisplay( m_camName, "temp_control", "status", "Temp. Ctrl.", "", this, Qt::WindowFlags() );
+    ui_tempStatus->setObjectName( QString::fromUtf8( "tempStatus" ) );
 
-   ui.grid->addWidget(ui_tempStatus, 1, 1, 1, 1);
+    ui.grid->addWidget( ui_tempStatus, 1, 1, 1, 1 );
 
-   ui_tempStatus->onDisconnect();
+    ui_tempStatus->onDisconnect();
 
-   m_parent->addSubscriber(ui_tempStatus);
+    m_parent->addSubscriber( ui_tempStatus );
 }
 
 void camera::setup_reconfigure()
 {
-   if(ui_reconfigure) return;
+    if( ui_reconfigure )
+        return;
 
-   ui_reconfigure = new QPushButton(this);
-   ui_reconfigure->setObjectName(QString::fromUtf8("reconfigure"));
-   ui_reconfigure->setText("reconfigure");
-   ui_reconfigure->setMaximumWidth(200);
-   connect(ui_reconfigure, SIGNAL(pressed()), this, SLOT(reconfigure()));
-   ui.grid->addWidget(ui_reconfigure, 3, 0, 1, 1, Qt::AlignHCenter);
-
+    ui_reconfigure = new QPushButton( this );
+    ui_reconfigure->setObjectName( QString::fromUtf8( "reconfigure" ) );
+    ui_reconfigure->setText( "reconfigure" );
+    ui_reconfigure->setMaximumWidth( 200 );
+    connect( ui_reconfigure, SIGNAL( pressed() ), this, SLOT( reconfigure() ) );
+    ui.grid->addWidget( ui_reconfigure, 3, 0, 1, 1, Qt::AlignHCenter );
 }
 
 void camera::reconfigure()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_camName);
-   ipFreq.setName("reconfigure");
-   ipFreq.add(pcf::IndiElement("request"));
-   ipFreq["request"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_camName );
+    ipFreq.setName( "reconfigure" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
 void camera::setup_stage()
 {
-    if(ui_stage.size() >= m_stageNames.size()) return;
+    if( ui_stage.size() >= m_stageNames.size() )
+        return;
 
     size_t n = ui_stage.size();
 
-    ui_stage.push_back(new stageStatus(m_stageNames[n], this));
+    ui_stage.push_back( new stageStatus( m_stageNames[n], this ) );
 
-    ui_stage[n]->setObjectName(QString::fromUtf8(m_stageNames[n].c_str()));
+    ui_stage[n]->setObjectName( QString::fromUtf8( m_stageNames[n].c_str() ) );
 
-    ui.grid->addWidget(ui_stage[n], 4+n, 0, 1, 1);
+    ui.grid->addWidget( ui_stage[n], 4 + n, 0, 1, 1 );
 
     ui_stage[n]->onDisconnect();
 
+    layoutLeftColumnControls();
+}
+
+void camera::setup_focus()
+{
+    if( ui_focus )
+        return;
+
+    ui_focus = new QPushButton( this );
+    ui_focus->setObjectName( QString::fromUtf8( "focus" ) );
+    ui_focus->setText( "goto focus" );
+    ui_focus->setMaximumWidth( 200 );
+    ui_focus->setFocusPolicy( Qt::NoFocus );
+    ui_focus->setVisible( m_gotoFocusPresent );
+    connect( ui_focus, SIGNAL( pressed() ), this, SLOT( gotoFocus() ) );
+
+    layoutLeftColumnControls();
 }
 
 void camera::setup_shutter()
 {
-    if(ui_shutterStatus) return;
+    if( ui_shutterStatus )
+        return;
 
-    ui_shutterStatus = new shutterStatus(m_camName, this);
+    ui_shutterStatus = new shutterStatus( m_camName, this );
 
-    ui_shutterStatus->setObjectName(QString::fromUtf8("shutter"));
-
-    int doff = 0;
-    if(ui_stage.size() > 4)
-    {
-        doff = ui_stage.size() - 4;
-    }
-
-    ui.grid->addWidget(ui_shutterStatus, 8 + doff, 0, 1, 1);
+    ui_shutterStatus->setObjectName( QString::fromUtf8( "shutter" ) );
+    layoutLeftColumnControls();
 
     ui_shutterStatus->onDisconnect();
 
-    m_parent->addSubscriber(ui_shutterStatus);
+    m_parent->addSubscriber( ui_shutterStatus );
 }
 
 void camera::setup_roiStatus()
 {
-   if(ui_roiStatus) return; //can get called from several threads
+    if( ui_roiStatus )
+        return; // can get called from several threads
 
-   ui_roiStatus = new roiStatus(m_camName, this);
-   ui_roiStatus->setObjectName(QString::fromUtf8("roiStatus"));
+    ui_roiStatus = new roiStatus( m_camName, this );
+    ui_roiStatus->setObjectName( QString::fromUtf8( "roiStatus" ) );
 
-   ui.grid->addWidget(ui_roiStatus, 3, 1, 1, 1);
+    ui.grid->addWidget( ui_roiStatus, 3, 1, 1, 1 );
 
-   ui_roiStatus->onDisconnect();
+    ui_roiStatus->onDisconnect();
 
-   m_parent->addSubscriber(ui_roiStatus);
+    m_parent->addSubscriber( ui_roiStatus );
 }
 
 void camera::setup_modes()
 {
-   if(ui_modes) return;
+    if( ui_modes )
+        return;
 
-   ui_modes = new statusCombo(m_camName, "mode", "", "Mode", "", this);
+    ui_modes = new statusCombo( m_camName, "mode", "", "Mode", "", this );
 
-   ui_modes->setObjectName(QString::fromUtf8("modes"));
+    ui_modes->setObjectName( QString::fromUtf8( "modes" ) );
 
-   ui.grid->addWidget(ui_modes, 3, 1, 1, 1);
+    ui.grid->addWidget( ui_modes, 3, 1, 1, 1 );
 
-   ui_modes->onDisconnect();
+    ui_modes->onDisconnect();
 
-   m_parent->addSubscriber(ui_modes);
-
+    m_parent->addSubscriber( ui_modes );
 }
 
 void camera::setup_readoutSpd()
 {
-   if(ui_readoutSpd) return;
+    if( ui_readoutSpd )
+        return;
 
-   ui_readoutSpd = new statusCombo(m_camName,"readout_speed", "", "Readout Spd", "", this);
-   ui_readoutSpd->ctrlWidget(nullptr);
+    ui_readoutSpd = new statusCombo( m_camName, "readout_speed", "", "Readout Spd", "", this );
+    ui_readoutSpd->ctrlWidget( nullptr );
 
-   ui_readoutSpd->setObjectName(QString::fromUtf8("readoutSpd"));
+    ui_readoutSpd->setObjectName( QString::fromUtf8( "readoutSpd" ) );
 
-   ui.grid->addWidget(ui_readoutSpd, 4, 1, 1, 1);
+    ui.grid->addWidget( ui_readoutSpd, 4, 1, 1, 1 );
 
-   ui_readoutSpd->onDisconnect();
+    ui_readoutSpd->onDisconnect();
 
-   m_parent->addSubscriber(ui_readoutSpd);
+    m_parent->addSubscriber( ui_readoutSpd );
 }
 
 void camera::setup_vshiftSpd()
 {
-   if(ui_vshiftSpd) return;
+    if( ui_vshiftSpd )
+        return;
 
-   ui_vshiftSpd = new statusCombo(m_camName,"vshift_speed", "", "Vert. Shift Spd", "", this);
-   ui_vshiftSpd->ctrlWidget(nullptr);
+    ui_vshiftSpd = new statusCombo( m_camName, "vshift_speed", "", "Vert. Shift Spd", "", this );
+    ui_vshiftSpd->ctrlWidget( nullptr );
 
-   ui_vshiftSpd->setObjectName(QString::fromUtf8("vshiftSpd"));
+    ui_vshiftSpd->setObjectName( QString::fromUtf8( "vshiftSpd" ) );
 
-   ui.grid->addWidget(ui_vshiftSpd, 5, 1, 1, 1);
+    ui.grid->addWidget( ui_vshiftSpd, 5, 1, 1, 1 );
 
-   ui_vshiftSpd->onDisconnect();
+    ui_vshiftSpd->onDisconnect();
 
-   m_parent->addSubscriber(ui_vshiftSpd);
+    m_parent->addSubscriber( ui_vshiftSpd );
 }
 
 void camera::setup_cropMode()
 {
-   if(ui_cropMode) return;
+    if( ui_cropMode )
+        return;
 
-   ui_cropMode = new toggleSlider(m_camName, "roi_crop_mode", "Crop Mode", this);
-   ui_cropMode->setObjectName(QString::fromUtf8("cropMode"));
+    ui_cropMode = new toggleSlider( m_camName, "roi_crop_mode", "Crop Mode", this );
+    ui_cropMode->setObjectName( QString::fromUtf8( "cropMode" ) );
 
-   ui.grid->addWidget(ui_cropMode, 6, 1, 1, 1);
+    ui.grid->addWidget( ui_cropMode, 6, 1, 1, 1 );
 
-   ui_cropMode->onDisconnect();
+    ui_cropMode->onDisconnect();
 
-   m_parent->addSubscriber(ui_cropMode);
+    m_parent->addSubscriber( ui_cropMode );
 }
 
-void camera::setup_expTime(bool ro)
+void camera::setup_expTime( bool ro )
 {
-   if(ui_expTime) return;
+    if( ui_expTime )
+        return;
 
-   ui_expTime = new statusEntry(this);
-   ui_expTime->setObjectName(QString::fromUtf8("expTime"));
-   ui_expTime->setup(m_camName, "exptime", statusEntry::FLOAT, "Exp. Time", "sec");
-   ui_expTime->highlightChanges(true);
-   ui_expTime->readOnly(ro);
+    ui_expTime = new statusEntry( this );
+    ui_expTime->setObjectName( QString::fromUtf8( "expTime" ) );
+    ui_expTime->setup( m_camName, "exptime", statusEntry::FLOAT, "Exp. Time", "sec" );
+    ui_expTime->highlightChanges( true );
+    ui_expTime->readOnly( ro );
 
-   ui.grid->addWidget(ui_expTime, 7, 1, 1, 1);
+    ui.grid->addWidget( ui_expTime, 7, 1, 1, 1 );
 
-   ui_expTime->onDisconnect();
+    ui_expTime->onDisconnect();
 
-   m_parent->addSubscriber(ui_expTime);
+    m_parent->addSubscriber( ui_expTime );
 }
 
-void camera::setup_fps(bool ro)
+void camera::setup_fps( bool ro )
 {
-   if(ui_fps) return;
+    if( ui_fps )
+        return;
 
-   ui_fps = new statusEntry(this);
-   ui_fps->setObjectName(QString::fromUtf8("fps"));
-   ui_fps->setup(m_camName, "fps", statusEntry::FLOAT, "Frame Rate", "F.P.S.");
-   ui_fps->highlightChanges(true);
-   ui_fps->readOnly(ro);
+    ui_fps = new statusEntry( this );
+    ui_fps->setObjectName( QString::fromUtf8( "fps" ) );
+    ui_fps->setup( m_camName, "fps", statusEntry::FLOAT, "Frame Rate", "F.P.S." );
+    ui_fps->highlightChanges( true );
+    ui_fps->readOnly( ro );
 
-   ui.grid->addWidget(ui_fps, 8, 1, 1, 1);
+    ui.grid->addWidget( ui_fps, 8, 1, 1, 1 );
 
-   ui_fps->onDisconnect();
+    ui_fps->onDisconnect();
 
-   m_parent->addSubscriber(ui_fps);
+    m_parent->addSubscriber( ui_fps );
 }
 
-void camera::setup_emGain(bool ro)
+void camera::setup_emGain( bool ro )
 {
-   if(ui_emGain) return;
+    if( ui_emGain )
+        return;
 
-   ui_emGain = new statusEntry(this);
-   ui_emGain->setObjectName(QString::fromUtf8("emgain"));
-   ui_emGain->setup(m_camName, "emgain", statusEntry::FLOAT, "E.M. Gain", "");
-   ui_emGain->highlightChanges(true);
-   ui_emGain->readOnly(ro);
+    ui_emGain = new statusEntry( this );
+    ui_emGain->setObjectName( QString::fromUtf8( "emgain" ) );
+    ui_emGain->setup( m_camName, "emgain", statusEntry::FLOAT, "E.M. Gain", "" );
+    ui_emGain->highlightChanges( true );
+    ui_emGain->readOnly( ro );
 
-   ui.grid->addWidget(ui_emGain, 9, 1, 1, 1);
+    ui.grid->addWidget( ui_emGain, 9, 1, 1, 1 );
 
-   ui_emGain->onDisconnect();
+    ui_emGain->onDisconnect();
 
-   m_parent->addSubscriber(ui_emGain);
+    m_parent->addSubscriber( ui_emGain );
 }
 
-void camera::setup_avgTime(bool ro)
+void camera::setup_avgTime( bool ro )
 {
-   if(ui_avgTime) return;
+    if( ui_avgTime )
+        return;
 
-   ui_avgTime = new statusEntry(this);
-   ui_avgTime->setObjectName(QString::fromUtf8("avgTime"));
-   ui_avgTime->setup(m_avgName, "avgTime", statusEntry::FLOAT, "Avg. Time", "");
-   ui_avgTime->highlightChanges(true);
-   ui_avgTime->readOnly(ro);
+    ui_avgTime = new statusEntry( this );
+    ui_avgTime->setObjectName( QString::fromUtf8( "avgTime" ) );
+    ui_avgTime->setup( m_avgName, "avgTime", statusEntry::FLOAT, "Avg. Time", "" );
+    ui_avgTime->highlightChanges( true );
+    ui_avgTime->readOnly( ro );
 
-   ui.grid->addWidget(ui_avgTime, 11, 1, 1, 1);
+    ui.grid->addWidget( ui_avgTime, 11, 1, 1, 1 );
 
-   ui_avgTime->onDisconnect();
+    ui_avgTime->onDisconnect();
 
-   m_parent->addSubscriber(ui_avgTime);
+    m_parent->addSubscriber( ui_avgTime );
 }
 
 void camera::setup_synchro()
 {
-   if(ui_synchro) return;
+    if( ui_synchro )
+        return;
 
-   ui_synchro = new toggleSlider(m_camName, "synchro", "Synchro", this);
-   ui_synchro->setObjectName(QString::fromUtf8("synchro"));
+    ui_synchro = new toggleSlider( m_camName, "synchro", "Synchro", this );
+    ui_synchro->setObjectName( QString::fromUtf8( "synchro" ) );
 
-   ui.grid->addWidget(ui_synchro, 10, 1, 1, 1);
+    ui.grid->addWidget( ui_synchro, 10, 1, 1, 1 );
 
-   ui_synchro->onDisconnect();
+    ui_synchro->onDisconnect();
 
-   m_parent->addSubscriber(ui_synchro);
+    m_parent->addSubscriber( ui_synchro );
 }
 
 void camera::setup_takeDarks()
 {
-    if(ui_takeDarks) return;
+    if( ui_takeDarks )
+        return;
 
-    ui_takeDarks = new QPushButton(this);
-    ui_takeDarks->setObjectName(QString::fromUtf8("takeDarks"));
-    ui_takeDarks->setText("take darks");
-    ui_takeDarks->setMaximumWidth(200);
-    ui_takeDarks->setFocusPolicy(Qt::NoFocus);
-    connect(ui_takeDarks, SIGNAL(pressed()), this, SLOT(takeDark()));
+    ui_takeDarks = new QPushButton( this );
+    ui_takeDarks->setObjectName( QString::fromUtf8( "takeDarks" ) );
+    ui_takeDarks->setText( "take darks" );
+    ui_takeDarks->setMaximumWidth( 200 );
+    ui_takeDarks->setFocusPolicy( Qt::NoFocus );
+    connect( ui_takeDarks, SIGNAL( pressed() ), this, SLOT( takeDark() ) );
 
-    int doff = 0;
-    if(ui_stage.size() > 4)
-    {
-        doff = ui_stage.size() - 4;
-    }
+    layoutLeftColumnControls();
+}
 
-    ui.grid->addWidget(ui_takeDarks, 9 + doff, 0, 1, 1,Qt::AlignHCenter);
+void camera::gotoFocus()
+{
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
+    ipFreq.setDevice( m_camName );
+    ipFreq.setName( "goto_focus" );
+    ipFreq.add( pcf::IndiElement( "request" ) );
+    ipFreq["request"].setSwitchState( pcf::IndiElement::On );
+
+    sendNewProperty( ipFreq );
 }
 
 void camera::takeDark()
 {
-   pcf::IndiProperty ipFreq(pcf::IndiProperty::Switch);
+    pcf::IndiProperty ipFreq( pcf::IndiProperty::Switch );
 
-   ipFreq.setDevice(m_darkName);
-   ipFreq.setName("start");
-   ipFreq.add(pcf::IndiElement("toggle"));
-   ipFreq["toggle"].setSwitchState(pcf::IndiElement::On);
+    ipFreq.setDevice( m_darkName );
+    ipFreq.setName( "start" );
+    ipFreq.add( pcf::IndiElement( "toggle" ) );
+    ipFreq["toggle"].setSwitchState( pcf::IndiElement::On );
 
-   sendNewProperty(ipFreq);
+    sendNewProperty( ipFreq );
 }
 
+void camera::clearFocusState()
+{
+    m_gotoFocusPresent = false;
+    m_focusStateKnown  = false;
+    m_focusInFocus     = false;
 
-} //namespace xqt
+    if( ui_focus )
+    {
+        ui_focus->hide();
+        ui_focus->setEnabled( false );
+    }
+
+    layoutLeftColumnControls();
+}
+
+int camera::leftColumnBaseRow() const
+{
+    int doff = 0;
+    if( ui_stage.size() > 4 )
+    {
+        doff = ui_stage.size() - 4;
+    }
+
+    return 8 + doff;
+}
+
+void camera::layoutLeftColumnControls()
+{
+    int row = leftColumnBaseRow();
+
+    if( ui_focus )
+    {
+        ui.grid->removeWidget( ui_focus );
+        if( m_gotoFocusPresent )
+        {
+            ui.grid->addWidget( ui_focus, row, 0, 1, 1, Qt::AlignHCenter );
+            ++row;
+        }
+    }
+
+    if( ui_shutterStatus )
+    {
+        ui.grid->removeWidget( ui_shutterStatus );
+        ui.grid->addWidget( ui_shutterStatus, row, 0, 1, 1 );
+        ++row;
+    }
+
+    if( ui_takeDarks )
+    {
+        ui.grid->removeWidget( ui_takeDarks );
+        ui.grid->addWidget( ui_takeDarks, row, 0, 1, 1, Qt::AlignHCenter );
+    }
+}
+
+} // namespace xqt
 
 #include "moc_camera.cpp"
 

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -93,6 +93,19 @@ struct stdCameraHasAnalogGain<derivedT, std::void_t<decltype( derivedT::c_stdCam
 {
 };
 
+/// Detect whether a derived camera exposes stdCamera focus-state and goto-focus support.
+template <class derivedT, class = void>
+struct stdCameraHasFocus : std::false_type
+{
+};
+
+/// Specialization for cameras that define `c_stdCamera_hasFocus`.
+template <class derivedT>
+struct stdCameraHasFocus<derivedT, std::void_t<decltype( derivedT::c_stdCamera_hasFocus )>>
+    : std::bool_constant<derivedT::c_stdCamera_hasFocus>
+{
+};
+
 /// MagAO-X standard camera interface
 /** Implements the standard interface to a MagAO-X camera.  The derived class `derivedT` must
  * meet the following requirements:
@@ -358,6 +371,36 @@ struct stdCameraHasAnalogGain<derivedT, std::void_t<decltype( derivedT::c_stdCam
  *         \endcode
  *         which shuts the shutter if the argument is 0, opens it otherwise.
  *
+ *     - Focus State and Control:
+ *
+ *       - A static configuration variable may be defined in derivedT as
+ *         \code
+ *             static constexpr bool c_stdCamera_hasFocus = true; //or: false
+ *         \endcode
+ *         which determines whether or not focus-state reporting and goto-focus control are available. If omitted,
+ *         focus support defaults to off.
+ *
+ *       - If true then the derived class must implement
+ *         \code
+ *             bool checkFocus(); // return true when the current instrument state is in focus
+ *             int gotoFocus(); // command the focus stage to the current in-focus position
+ *         \endcode
+ *
+ *       - The focus controls are only published when \ref m_hasFocus is true at runtime. Derived classes may set
+ *         \ref m_hasFocus directly when they provide custom focus logic. When both stdCamera focus helpers are fully
+ *         configured, stdCamera enables \ref m_hasFocus automatically.
+ *
+ *       - When focus control is enabled, stdCamera publishes the read-only switch `focus.state`, which is `On` when
+ *         \ref checkFocus returns `true`, and the request switch `goto_focus.request`, which dispatches to
+ *         \ref gotoFocus when pressed.
+ *
+ *       - Derived classes can use \ref checkFocusSwitchState when an external switch property indicates an
+ *         out-of-focus condition by being `On`.
+ *
+ *       - Derived classes can use \ref sendGotoFocusCommand to derive and send a target preset name from the
+ *         configuration keys `focus.gotoFocus.numSwitches`, `focus.gotoFocus.property1...propertyN`,
+ *         `focus.gotoFocus.format`, and `focus.gotoFocus.targetProperty`.
+ *
  *     - State:
  *
  *       - A static configuration variable must be defined in derivedT as
@@ -393,6 +436,8 @@ class stdCamera
         stdCameraHasLED<derivedT>::value; ///< True when the derived camera exposes LED control.
     static constexpr bool c_hasAnalogGain =
         stdCameraHasAnalogGain<derivedT>::value; ///< True when the derived camera exposes analog-gain control.
+    static constexpr bool c_hasFocus = stdCameraHasFocus<derivedT>::value; ///< True when the derived camera exposes
+                                                                           ///< focus-state and goto-focus support.
 
     /** \name Configurable Parameters
      * @{
@@ -657,6 +702,54 @@ class stdCamera
 
     ///@}
 
+    /** \name Focus Control - Data
+     * Focus controls are exposed if the derived camera supports focus and m_hasFocus is true.
+     * @{
+     */
+    bool m_hasFocus{ false }; ///< Runtime flag enabling focus-state reporting and goto-focus control publication.
+
+    bool m_focusStateHelperConfigured{
+        false }; ///< True when stdCamera should evaluate focus state from an external out-of-focus switch.
+
+    std::string
+        m_focusStateSource; ///< INDI key (`device.property`) of the switch property used by checkFocusSwitchState.
+
+    std::string m_focusStateElement{
+        "toggle" }; ///< Element within m_focusStateSource interpreted as out of focus when it is `On`.
+
+    int m_focusStateSourceIndex{
+        -1 }; ///< Index of m_focusStateSource within m_indiP_focusMonitoredProperties, or `-1` when unused.
+
+    bool m_focusGotoHelperConfigured{
+        false }; ///< True when stdCamera should derive goto-focus commands from external switch properties.
+
+    std::vector<std::string> m_focusGotoSourceProperties; ///< INDI keys (`device.property`) of the switch properties
+                                                          ///< combined for gotoFocus().
+
+    std::vector<int>
+        m_focusGotoSourceIndices; ///< Indices of m_focusGotoSourceProperties within m_indiP_focusMonitoredProperties.
+
+    std::string m_focusGotoFormat; ///< Literal `{}` placeholder format used to build the goto-focus preset name.
+
+    std::string
+        m_focusGotoTargetProperty; ///< INDI key (`device.property`) of the switch property commanded by gotoFocus().
+
+    std::string m_focusGotoTargetDevice; ///< Device portion parsed from m_focusGotoTargetProperty.
+
+    std::string m_focusGotoTargetName; ///< Property-name portion parsed from m_focusGotoTargetProperty.
+
+    std::vector<std::string>
+        m_focusMonitoredPropertyKeys; ///< Unique INDI keys monitored for the focus-state and goto-focus helpers.
+
+    std::vector<pcf::IndiProperty>
+        m_indiP_focusMonitoredProperties; ///< Cached external switch properties monitored for the focus helpers.
+
+    pcf::IndiProperty m_indiP_focus; ///< Read-only switch property reporting whether the current state is in focus.
+
+    pcf::IndiProperty m_indiP_gotoFocus; ///< Request switch property used to command the current focus target.
+
+    ///@}
+
     /** \name State String
      * The State string is exposed if derivedT::c_stdCamera_usesStateString is true.
      * @{
@@ -687,6 +780,18 @@ class stdCamera
       * with appropriate error checking.
       */
     int loadConfig( mx::app::appConfigurator &config /**< [in] the derived classes configurator*/ );
+
+    /** \name Focus Control
+     * @{
+     */
+
+    /// Evaluate the configured out-of-focus switch helper as an in-focus boolean.
+    bool checkFocusSwitchState();
+
+    /// Format and send the configured goto-focus switch command.
+    int sendGotoFocusCommand();
+
+    ///@}
 
   protected:
     // workers to create indi variables if needed
@@ -1205,6 +1310,32 @@ class stdCamera
     int newCallBack_shutter(
         const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the the new property request.*/ );
 
+    /// Interface to checkFocus when the derivedT exposes focus support.
+    bool checkFocus( const mx::meta::trueFalseT<true> &t );
+
+    /// Interface to checkFocus when the derivedT does not expose focus support.
+    bool checkFocus( const mx::meta::trueFalseT<false> &f );
+
+    /// Interface to gotoFocus when the derivedT exposes focus support.
+    int gotoFocus( const mx::meta::trueFalseT<true> &t );
+
+    /// Interface to gotoFocus when the derivedT does not expose focus support.
+    int gotoFocus( const mx::meta::trueFalseT<false> &f );
+
+    /// Callback to process a NEW goto-focus request.
+    int newCallBack_gotoFocus(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the new property request.*/ );
+
+    /// The static callback function registered for external focus-helper switch properties.
+    static int st_setCallBack_focusMonitored(
+        void                    *app,   ///< [in] a pointer to this, which will be static_cast-ed to derivedT
+        const pcf::IndiProperty &ipRecv ///< [in] the INDI property sent with the set-property update
+    );
+
+    /// The callback which caches external focus-helper switch-property updates.
+    int setCallBack_focusMonitored(
+        const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the set-property update.*/ );
+
     /// Interface to stateString when the derivedT provides it
     /** Tag-dispatch resolution of c_stdCamera_usesStateString==true will call this function.
      * Calls derivedT::stateString.
@@ -1450,6 +1581,63 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     "The default ROI y binning." );
     }
 
+    if( c_hasFocus )
+    {
+        config.add( "focus.stateProperty",
+                    "",
+                    "focus.stateProperty",
+                    argType::Optional,
+                    "focus",
+                    "stateProperty",
+                    false,
+                    "string",
+                    "The INDI key (device.property) of a switch property whose configured element is On when the "
+                    "camera is out of focus." );
+
+        config.add( "focus.stateElement",
+                    "",
+                    "focus.stateElement",
+                    argType::Optional,
+                    "focus",
+                    "stateElement",
+                    false,
+                    "string",
+                    "The element of focus.stateProperty interpreted as out of focus when it is On. Default is "
+                    "\"toggle\"." );
+
+        config.add( "focus.gotoFocus.numSwitches",
+                    "",
+                    "focus.gotoFocus.numSwitches",
+                    argType::Optional,
+                    "focus.gotoFocus",
+                    "numSwitches",
+                    false,
+                    "int",
+                    "The number of source switch properties combined to derive the goto-focus preset name. Also "
+                    "configure focus.gotoFocus.property1..propertyN, focus.gotoFocus.format, and "
+                    "focus.gotoFocus.targetProperty." );
+
+        config.add( "focus.gotoFocus.format",
+                    "",
+                    "focus.gotoFocus.format",
+                    argType::Optional,
+                    "focus.gotoFocus",
+                    "format",
+                    false,
+                    "string",
+                    "Literal {} placeholder format used to combine the configured goto-focus source switch names." );
+
+        config.add( "focus.gotoFocus.targetProperty",
+                    "",
+                    "focus.gotoFocus.targetProperty",
+                    argType::Optional,
+                    "focus.gotoFocus",
+                    "targetProperty",
+                    false,
+                    "string",
+                    "The INDI key (device.property) of the switch property commanded by gotoFocus()." );
+    }
+
     return 0;
 }
 
@@ -1622,6 +1810,275 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
         m_nextROI.bin_x = m_default_bin_x;
         m_nextROI.bin_y = m_default_bin_y;
     }
+
+    if( c_hasFocus )
+    {
+        config( m_focusStateSource, "focus.stateProperty" );
+        config( m_focusStateElement, "focus.stateElement" );
+        if( m_focusStateElement == "" )
+        {
+            m_focusStateElement = "toggle";
+        }
+
+        m_focusStateHelperConfigured = false;
+        m_focusStateSourceIndex      = -1;
+        m_focusGotoHelperConfigured  = false;
+        m_focusGotoSourceProperties.clear();
+        m_focusGotoSourceIndices.clear();
+        m_focusGotoFormat.clear();
+        m_focusGotoTargetProperty.clear();
+        m_focusGotoTargetDevice.clear();
+        m_focusGotoTargetName.clear();
+        m_focusMonitoredPropertyKeys.clear();
+        m_indiP_focusMonitoredProperties.clear();
+
+        auto addFocusMonitoredProperty = [&]( const std::string &propertyKey ) -> int
+        {
+            for( size_t n = 0; n < m_focusMonitoredPropertyKeys.size(); ++n )
+            {
+                if( m_focusMonitoredPropertyKeys[n] == propertyKey )
+                {
+                    return static_cast<int>( n );
+                }
+            }
+
+            std::string devName;
+            std::string propName;
+            if( indi::parseIndiKey( devName, propName, propertyKey ) < 0 )
+            {
+                return -1;
+            }
+
+            m_focusMonitoredPropertyKeys.push_back( propertyKey );
+            m_indiP_focusMonitoredProperties.emplace_back();
+            return static_cast<int>( m_focusMonitoredPropertyKeys.size() - 1 );
+        };
+
+        if( m_focusStateSource != "" )
+        {
+            m_focusStateSourceIndex = addFocusMonitoredProperty( m_focusStateSource );
+            if( m_focusStateSourceIndex < 0 )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__, __LINE__, "invalid focus.stateProperty: " + m_focusStateSource } );
+            }
+
+            m_focusStateHelperConfigured = true;
+        }
+
+        int numFocusGotoSwitches = 0;
+        config( numFocusGotoSwitches, "focus.gotoFocus.numSwitches" );
+        config( m_focusGotoFormat, "focus.gotoFocus.format" );
+        config( m_focusGotoTargetProperty, "focus.gotoFocus.targetProperty" );
+
+        bool focusGotoConfigPresent =
+            numFocusGotoSwitches > 0 || m_focusGotoFormat != "" || m_focusGotoTargetProperty != "";
+
+        if( focusGotoConfigPresent )
+        {
+            if( numFocusGotoSwitches < 1 )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__, __LINE__, "focus.gotoFocus.numSwitches must be greater than zero" } );
+            }
+
+            if( m_focusGotoFormat == "" )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__, __LINE__, "focus.gotoFocus.format must be set when goto-focus helper is used" } );
+            }
+
+            if( m_focusGotoTargetProperty == "" )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__,
+                      __LINE__,
+                      "focus.gotoFocus.targetProperty must be set when goto-focus helper is used" } );
+            }
+
+            bool   invalidBraces = false;
+            size_t placeholders  = 0;
+            for( size_t n = 0; n < m_focusGotoFormat.size(); ++n )
+            {
+                if( m_focusGotoFormat[n] == '{' )
+                {
+                    if( n + 1 < m_focusGotoFormat.size() && m_focusGotoFormat[n + 1] == '}' )
+                    {
+                        ++placeholders;
+                        ++n;
+                    }
+                    else
+                    {
+                        invalidBraces = true;
+                        break;
+                    }
+                }
+                else if( m_focusGotoFormat[n] == '}' )
+                {
+                    invalidBraces = true;
+                    break;
+                }
+            }
+
+            if( invalidBraces )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__, __LINE__, "focus.gotoFocus.format only supports literal {} placeholders" } );
+            }
+
+            if( placeholders != static_cast<size_t>( numFocusGotoSwitches ) )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__,
+                      __LINE__,
+                      "focus.gotoFocus.format placeholder count does not match focus.gotoFocus.numSwitches" } );
+            }
+
+            if( indi::parseIndiKey( m_focusGotoTargetDevice, m_focusGotoTargetName, m_focusGotoTargetProperty ) < 0 )
+            {
+                return derivedT::template log<software_critical, -1>(
+                    { __FILE__, __LINE__, "invalid focus.gotoFocus.targetProperty: " + m_focusGotoTargetProperty } );
+            }
+
+            for( int n = 0; n < numFocusGotoSwitches; ++n )
+            {
+                std::string propKey = std::string( "property" ) + std::to_string( n + 1 );
+                std::string property;
+                config.configUnused( property, mx::app::iniFile::makeKey( "focus.gotoFocus", propKey ) );
+
+                if( property == "" )
+                {
+                    return derivedT::template log<software_critical, -1>(
+                        { __FILE__, __LINE__, "focus.gotoFocus." + propKey + " must be set" } );
+                }
+
+                int propertyIndex = addFocusMonitoredProperty( property );
+                if( propertyIndex < 0 )
+                {
+                    return derivedT::template log<software_critical, -1>(
+                        { __FILE__, __LINE__, "invalid focus.gotoFocus." + propKey + ": " + property } );
+                }
+
+                m_focusGotoSourceProperties.push_back( property );
+                m_focusGotoSourceIndices.push_back( propertyIndex );
+            }
+
+            m_focusGotoHelperConfigured = true;
+        }
+
+        if( !m_hasFocus && m_focusStateHelperConfigured && m_focusGotoHelperConfigured )
+        {
+            m_hasFocus = true;
+        }
+    }
+
+    return 0;
+}
+
+template <class derivedT>
+bool stdCamera<derivedT>::checkFocusSwitchState()
+{
+    if( !m_focusStateHelperConfigured || m_focusStateSourceIndex < 0 ||
+        m_focusStateSourceIndex >= static_cast<int>( m_indiP_focusMonitoredProperties.size() ) )
+    {
+        return false;
+    }
+
+    const pcf::IndiProperty &focusProperty = m_indiP_focusMonitoredProperties[m_focusStateSourceIndex];
+    if( !focusProperty.find( m_focusStateElement ) )
+    {
+        return false;
+    }
+
+    return focusProperty[m_focusStateElement].getSwitchState() != pcf::IndiElement::On;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::sendGotoFocusCommand()
+{
+    if( !m_focusGotoHelperConfigured )
+    {
+        return derivedT::template log<software_error, -1>(
+            { __FILE__, __LINE__, "goto-focus helper is not configured" } );
+    }
+
+    std::vector<std::string> activeNames;
+    activeNames.reserve( m_focusGotoSourceIndices.size() );
+
+    for( size_t n = 0; n < m_focusGotoSourceIndices.size(); ++n )
+    {
+        int propertyIndex = m_focusGotoSourceIndices[n];
+        if( propertyIndex < 0 || propertyIndex >= static_cast<int>( m_indiP_focusMonitoredProperties.size() ) )
+        {
+            return derivedT::template log<software_error, -1>(
+                { __FILE__, __LINE__, "goto-focus helper property index is out of range" } );
+        }
+
+        const pcf::IndiProperty &sourceProperty = m_indiP_focusMonitoredProperties[propertyIndex];
+
+        size_t      onCount = 0;
+        std::string activeName;
+        for( auto &&el : sourceProperty.getElements() )
+        {
+            if( el.second.getSwitchState() == pcf::IndiElement::On )
+            {
+                if( onCount == 0 )
+                {
+                    activeName = el.first;
+                }
+
+                ++onCount;
+            }
+        }
+
+        if( onCount == 0 )
+        {
+            return derivedT::template log<software_error, -1>(
+                { __FILE__,
+                  __LINE__,
+                  "goto-focus helper found no active switch element in " + m_focusGotoSourceProperties[n] } );
+        }
+
+        if( onCount > 1 )
+        {
+            return derivedT::template log<software_error, -1>(
+                { __FILE__,
+                  __LINE__,
+                  "goto-focus helper found multiple active switch elements in " + m_focusGotoSourceProperties[n] } );
+        }
+
+        activeNames.push_back( activeName );
+    }
+
+    std::string targetElement;
+    size_t      valueIndex = 0;
+    for( size_t n = 0; n < m_focusGotoFormat.size(); ++n )
+    {
+        if( m_focusGotoFormat[n] == '{' && n + 1 < m_focusGotoFormat.size() && m_focusGotoFormat[n + 1] == '}' )
+        {
+            targetElement += activeNames[valueIndex];
+            ++valueIndex;
+            ++n;
+        }
+        else
+        {
+            targetElement += m_focusGotoFormat[n];
+        }
+    }
+
+    if( targetElement == "" )
+    {
+        return derivedT::template log<software_error, -1>(
+            { __FILE__, __LINE__, "goto-focus helper produced an empty target element name" } );
+    }
+
+    pcf::IndiProperty ipSend( pcf::IndiProperty::Switch );
+    ipSend.setDevice( m_focusGotoTargetDevice );
+    ipSend.setName( m_focusGotoTargetName );
+    ipSend.setRule( pcf::IndiProperty::AtMostOne );
+    ipSend.add( pcf::IndiElement( targetElement, pcf::IndiElement::On ) );
+
+    derived().sendNewProperty( ipSend );
 
     return 0;
 }
@@ -2134,6 +2591,61 @@ int stdCamera<derivedT>::appStartup()
         }
     }
 
+    if( c_hasFocus && m_hasFocus )
+    {
+        m_indiP_focus = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        m_indiP_focus.setDevice( derived().configName() );
+        m_indiP_focus.setName( "focus" );
+        m_indiP_focus.setPerm( pcf::IndiProperty::ReadOnly );
+        m_indiP_focus.setState( pcf::IndiProperty::Idle );
+        m_indiP_focus.setRule( pcf::IndiProperty::AtMostOne );
+        m_indiP_focus.setLabel( "Focus" );
+        m_indiP_focus.setGroup( "Focus" );
+        m_indiP_focus.add( pcf::IndiElement( "state", pcf::IndiElement::Off ) );
+        if( derived().registerIndiPropertyReadOnly( m_indiP_focus ) < 0 )
+        {
+#ifndef STDCAMERA_TEST_NOLOG
+            derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+            return -1;
+        }
+
+        derived().createStandardIndiRequestSw( m_indiP_gotoFocus, "goto_focus", "Goto Focus", "Focus" );
+        if( derived().registerIndiPropertyNew( m_indiP_gotoFocus, st_newCallBack_stdCamera ) < 0 )
+        {
+#ifndef STDCAMERA_TEST_NOLOG
+            derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+            return -1;
+        }
+    }
+
+    if( c_hasFocus && !m_focusMonitoredPropertyKeys.empty() )
+    {
+        for( size_t n = 0; n < m_focusMonitoredPropertyKeys.size(); ++n )
+        {
+            std::string devName;
+            std::string propName;
+            if( indi::parseIndiKey( devName, propName, m_focusMonitoredPropertyKeys[n] ) < 0 )
+            {
+#ifndef STDCAMERA_TEST_NOLOG
+                derivedT::template log<software_error>(
+                    { __FILE__, __LINE__, "invalid monitored focus property: " + m_focusMonitoredPropertyKeys[n] } );
+#endif
+                return -1;
+            }
+
+            if( derived().registerIndiPropertySet(
+                    m_indiP_focusMonitoredProperties[n], devName, propName, st_setCallBack_focusMonitored ) < 0 )
+            {
+#ifndef STDCAMERA_TEST_NOLOG
+                derivedT::template log<software_error>( { __FILE__, __LINE__ } );
+#endif
+                return -1;
+            }
+        }
+    }
+
     if( derivedT::c_stdCamera_usesStateString )
     {
         derived().createROIndiText( m_indiP_stateString, "state_string", "current", "State String", "State", "String" );
@@ -2240,6 +2752,21 @@ int stdCamera<derivedT>::appLogic()
                     {
                         derived().updateSwitchIfChanged( m_indiP_shutter, "toggle", pcf::IndiElement::Off, INDI_IDLE );
                     }
+                }
+
+                if( c_hasFocus && m_hasFocus )
+                {
+                    mx::meta::trueFalseT<c_hasFocus> tf;
+                    if( checkFocus( tf ) )
+                    {
+                        derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
+                    }
+                    else
+                    {
+                        derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
+                    }
+
+                    derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
                 }
 
                 return 0;
@@ -2385,6 +2912,21 @@ int stdCamera<derivedT>::onPowerOff()
         }
     }
 
+    if( c_hasFocus && m_hasFocus )
+    {
+        mx::meta::trueFalseT<c_hasFocus> tf;
+        if( checkFocus( tf ) )
+        {
+            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
+        }
+        else
+        {
+            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
+        }
+
+        derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
+    }
+
     if( c_hasFanSpeed && m_fanSpeedControlEnabled && m_fanSpeedValid )
     {
         indi::updateSelectionSwitchIfChanged( m_indiP_fanSpeed, m_fanSpeedName, derived().m_indiDriver, INDI_IDLE );
@@ -2437,6 +2979,21 @@ int stdCamera<derivedT>::whilePowerOff()
         {
             derived().updateSwitchIfChanged( m_indiP_shutter, "toggle", pcf::IndiElement::Off, INDI_IDLE );
         }
+    }
+
+    if( c_hasFocus && m_hasFocus )
+    {
+        mx::meta::trueFalseT<c_hasFocus> tf;
+        if( checkFocus( tf ) )
+        {
+            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
+        }
+        else
+        {
+            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
+        }
+
+        derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
     }
 
     if( c_hasFanSpeed && m_fanSpeedControlEnabled && m_fanSpeedValid )
@@ -2550,6 +3107,8 @@ int stdCamera<derivedT>::newCallBack_stdCamera( const pcf::IndiProperty &ipRecv 
         return newCallBack_roi_default( ipRecv );
     else if( derivedT::c_stdCamera_hasShutter && name == "shutter" )
         return newCallBack_shutter( ipRecv );
+    else if( c_hasFocus && m_hasFocus && name == "goto_focus" )
+        return newCallBack_gotoFocus( ipRecv );
 
 #ifndef XWCTEST_INDI_CALLBACK_VALIDATION
     derivedT::template log<software_error>( { __FILE__, __LINE__, "unknown INDI property" } );
@@ -3707,6 +4266,85 @@ int stdCamera<derivedT>::newCallBack_shutter( const pcf::IndiProperty &ipRecv )
 }
 
 template <class derivedT>
+bool stdCamera<derivedT>::checkFocus( const mx::meta::trueFalseT<true> &t )
+{
+    static_cast<void>( t );
+    return derived().checkFocus();
+}
+
+template <class derivedT>
+bool stdCamera<derivedT>::checkFocus( const mx::meta::trueFalseT<false> &f )
+{
+    static_cast<void>( f );
+    return false;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::gotoFocus( const mx::meta::trueFalseT<true> &t )
+{
+    static_cast<void>( t );
+    return derived().gotoFocus();
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::gotoFocus( const mx::meta::trueFalseT<false> &f )
+{
+    static_cast<void>( f );
+    return 0;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::newCallBack_gotoFocus( const pcf::IndiProperty &ipRecv )
+{
+    if( c_hasFocus && m_hasFocus )
+    {
+#ifdef XWCTEST_INDI_CALLBACK_VALIDATION
+        return 0;
+#endif
+
+        if( !ipRecv.find( "request" ) )
+        {
+            return 0;
+        }
+
+        if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+        {
+            std::unique_lock<std::mutex> lock( derived().m_indiMutex );
+
+            indi::updateSwitchIfChanged(
+                m_indiP_gotoFocus, "request", pcf::IndiElement::Off, derived().m_indiDriver, INDI_IDLE );
+
+            mx::meta::trueFalseT<c_hasFocus> tf;
+            return gotoFocus( tf );
+        }
+    }
+
+    return 0;
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::st_setCallBack_focusMonitored( void *app, const pcf::IndiProperty &ipRecv )
+{
+    return static_cast<derivedT *>( app )->setCallBack_focusMonitored( ipRecv );
+}
+
+template <class derivedT>
+int stdCamera<derivedT>::setCallBack_focusMonitored( const pcf::IndiProperty &ipRecv )
+{
+    for( size_t n = 0; n < m_indiP_focusMonitoredProperties.size(); ++n )
+    {
+        if( ipRecv.getDevice() == m_indiP_focusMonitoredProperties[n].getDevice() &&
+            ipRecv.getName() == m_indiP_focusMonitoredProperties[n].getName() )
+        {
+            m_indiP_focusMonitoredProperties[n] = ipRecv;
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
+template <class derivedT>
 std::string stdCamera<derivedT>::stateString( const mx::meta::trueFalseT<true> &t )
 {
     static_cast<void>( t );
@@ -3897,6 +4535,21 @@ int stdCamera<derivedT>::updateINDI()
             {
                 derived().updateSwitchIfChanged( m_indiP_shutter, "toggle", pcf::IndiElement::Off, INDI_IDLE );
             }
+        }
+
+        if( c_hasFocus && m_hasFocus )
+        {
+            mx::meta::trueFalseT<c_hasFocus> tf;
+            if( checkFocus( tf ) )
+            {
+                derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
+            }
+            else
+            {
+                derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
+            }
+
+            derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
         }
 
         if( derivedT::c_stdCamera_usesStateString )

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -793,6 +793,9 @@ class stdCamera
     bool checkFocusSwitchState();
 
     /// Format and send the configured goto-focus switch command.
+    /** \returns 0 on success.
+     *  \returns -1 if formatting fails or the command cannot be dispatched.
+     */
     int sendGotoFocusCommand();
 
     ///@}
@@ -2132,9 +2135,10 @@ int stdCamera<derivedT>::sendGotoFocusCommand()
     ipSend.setRule( pcf::IndiProperty::AtMostOne );
     ipSend.add( pcf::IndiElement( targetElement, pcf::IndiElement::On ) );
 
-    derived().sendNewProperty( ipSend );
+    derivedT::template log<text_log>( "goto-focus helper commanding " + m_focusGotoTargetProperty + "." +
+                                      targetElement );
 
-    return 0;
+    return derived().sendNewProperty( ipSend );
 }
 
 template <class derivedT>

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -49,6 +49,30 @@ struct cameraConfig
 
 typedef std::unordered_map<std::string, cameraConfig> cameraConfigMap;
 
+/// Strip leading and trailing whitespace and one matching pair of wrapping double quotes.
+inline void stripQuotedWhitespace( std::string &value )
+{
+    if( value.size() == 0 )
+    {
+        return;
+    }
+
+    size_t first = value.find_first_not_of( " \t\r\n" );
+    if( first == std::string::npos )
+    {
+        value.clear();
+        return;
+    }
+
+    size_t last = value.find_last_not_of( " \t\r\n" );
+    value       = value.substr( first, last - first + 1 );
+
+    if( value.size() >= 2 && value.front() == '\"' && value.back() == '\"' )
+    {
+        value = value.substr( 1, value.size() - 2 );
+    }
+}
+
 /// Load the camera configurations contained in the app configuration into a map
 int loadCameraConfig( cameraConfigMap &ccmap, ///< [out] the map in which to place the configurations found in config
                       mx::app::appConfigurator &config ///< [in] the application configuration structure
@@ -1891,6 +1915,7 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
         int numFocusGotoSwitches = 0;
         config( numFocusGotoSwitches, "focus.gotoFocus.numSwitches" );
         config( m_focusGotoFormat, "focus.gotoFocus.format" );
+        stripQuotedWhitespace( m_focusGotoFormat );
         config( m_focusGotoTargetProperty, "focus.gotoFocus.targetProperty" );
 
         bool focusGotoConfigPresent =

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -394,8 +394,9 @@ struct stdCameraHasFocus<derivedT, std::void_t<decltype( derivedT::c_stdCamera_h
  *         \ref checkFocus returns `true`, and the request switch `goto_focus.request`, which dispatches to
  *         \ref gotoFocus when pressed.
  *
- *       - Derived classes can use \ref checkFocusSwitchState when an external switch property indicates an
- *         out-of-focus condition by being `On`.
+ *       - Derived classes can use \ref checkFocusSwitchState when an external switch property indicates focus state
+ *         via a configured switch element. By default that element being `On` means "out of focus", and
+ *         `focus.stateElementOnMeansInFocus=true` flips the interpretation so `On` means "in focus".
  *
  *       - Derived classes can use \ref sendGotoFocusCommand to derive and send a target preset name from the
  *         configuration keys `focus.gotoFocus.numSwitches`, `focus.gotoFocus.property1...propertyN`,
@@ -709,13 +710,16 @@ class stdCamera
     bool m_hasFocus{ false }; ///< Runtime flag enabling focus-state reporting and goto-focus control publication.
 
     bool m_focusStateHelperConfigured{
-        false }; ///< True when stdCamera should evaluate focus state from an external out-of-focus switch.
+        false }; ///< True when stdCamera should evaluate focus state from an external switch property.
 
     std::string
         m_focusStateSource; ///< INDI key (`device.property`) of the switch property used by checkFocusSwitchState.
 
-    std::string m_focusStateElement{
-        "toggle" }; ///< Element within m_focusStateSource interpreted as out of focus when it is `On`.
+    std::string m_focusStateElement{ "toggle" }; ///< Element within m_focusStateSource whose `On` state is interpreted
+                                                 ///< according to m_focusStateOnMeansInFocus.
+
+    bool m_focusStateOnMeansInFocus{ false }; ///< True when m_focusStateElement being `On` means "in focus". Default
+                                              ///< false means `On` is interpreted as "out of focus".
 
     int m_focusStateSourceIndex{
         -1 }; ///< Index of m_focusStateSource within m_indiP_focusMonitoredProperties, or `-1` when unused.
@@ -785,7 +789,7 @@ class stdCamera
      * @{
      */
 
-    /// Evaluate the configured out-of-focus switch helper as an in-focus boolean.
+    /// Evaluate the configured focus-state switch helper as an in-focus boolean.
     bool checkFocusSwitchState();
 
     /// Format and send the configured goto-focus switch command.
@@ -806,6 +810,9 @@ class stdCamera
     int createFanSpeed( const mx::meta::trueFalseT<true> &t );
 
     int createFanSpeed( const mx::meta::trueFalseT<false> &f );
+
+    /// Refresh the published focus.state property from the current helper or derived focus implementation.
+    void updateFocusStateProperty();
 
   public:
     /// Startup function
@@ -1591,8 +1598,8 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     "stateProperty",
                     false,
                     "string",
-                    "The INDI key (device.property) of a switch property whose configured element is On when the "
-                    "camera is out of focus." );
+                    "The INDI key (device.property) of a switch property whose configured element is used to infer "
+                    "whether the camera is in focus." );
 
         config.add( "focus.stateElement",
                     "",
@@ -1602,8 +1609,19 @@ int stdCamera<derivedT>::setupConfig( mx::app::appConfigurator &config )
                     "stateElement",
                     false,
                     "string",
-                    "The element of focus.stateProperty interpreted as out of focus when it is On. Default is "
+                    "The element of focus.stateProperty whose state is interpreted as focus state. Default is "
                     "\"toggle\"." );
+
+        config.add( "focus.stateElementOnMeansInFocus",
+                    "",
+                    "focus.stateElementOnMeansInFocus",
+                    argType::Optional,
+                    "focus",
+                    "stateElementOnMeansInFocus",
+                    false,
+                    "bool",
+                    "Set true when the configured focus.stateElement being On means the camera is in focus. The "
+                    "default false keeps the original behavior where On means out of focus." );
 
         config.add( "focus.gotoFocus.numSwitches",
                     "",
@@ -1815,6 +1833,7 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
     {
         config( m_focusStateSource, "focus.stateProperty" );
         config( m_focusStateElement, "focus.stateElement" );
+        config( m_focusStateOnMeansInFocus, "focus.stateElementOnMeansInFocus" );
         if( m_focusStateElement == "" )
         {
             m_focusStateElement = "toggle";
@@ -1990,7 +2009,42 @@ bool stdCamera<derivedT>::checkFocusSwitchState()
         return false;
     }
 
+    if( m_focusStateOnMeansInFocus )
+    {
+        return focusProperty[m_focusStateElement].getSwitchState() == pcf::IndiElement::On;
+    }
+
     return focusProperty[m_focusStateElement].getSwitchState() != pcf::IndiElement::On;
+}
+
+template <class derivedT>
+void stdCamera<derivedT>::updateFocusStateProperty()
+{
+    if( !( c_hasFocus && m_hasFocus ) || !m_indiP_focus.find( "state" ) )
+    {
+        return;
+    }
+
+    mx::meta::trueFalseT<c_hasFocus> tf;
+    bool                             inFocus = checkFocus( tf );
+
+    pcf::IndiElement::SwitchStateType    focusState = pcf::IndiElement::Off;
+    pcf::IndiProperty::PropertyStateType indiState  = INDI_IDLE;
+
+    if( inFocus )
+    {
+        focusState = pcf::IndiElement::On;
+        indiState  = INDI_OK;
+    }
+
+    if( derived().m_indiDriver )
+    {
+        derived().updateSwitchIfChanged( m_indiP_focus, "state", focusState, indiState );
+        return;
+    }
+
+    m_indiP_focus["state"].setSwitchState( focusState );
+    m_indiP_focus.setState( indiState );
 }
 
 template <class derivedT>
@@ -2756,16 +2810,7 @@ int stdCamera<derivedT>::appLogic()
 
                 if( c_hasFocus && m_hasFocus )
                 {
-                    mx::meta::trueFalseT<c_hasFocus> tf;
-                    if( checkFocus( tf ) )
-                    {
-                        derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
-                    }
-                    else
-                    {
-                        derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
-                    }
-
+                    updateFocusStateProperty();
                     derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
                 }
 
@@ -2914,16 +2959,7 @@ int stdCamera<derivedT>::onPowerOff()
 
     if( c_hasFocus && m_hasFocus )
     {
-        mx::meta::trueFalseT<c_hasFocus> tf;
-        if( checkFocus( tf ) )
-        {
-            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
-        }
-        else
-        {
-            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
-        }
-
+        updateFocusStateProperty();
         derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
     }
 
@@ -2983,16 +3019,7 @@ int stdCamera<derivedT>::whilePowerOff()
 
     if( c_hasFocus && m_hasFocus )
     {
-        mx::meta::trueFalseT<c_hasFocus> tf;
-        if( checkFocus( tf ) )
-        {
-            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
-        }
-        else
-        {
-            derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
-        }
-
+        updateFocusStateProperty();
         derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
     }
 
@@ -4337,6 +4364,13 @@ int stdCamera<derivedT>::setCallBack_focusMonitored( const pcf::IndiProperty &ip
             ipRecv.getName() == m_indiP_focusMonitoredProperties[n].getName() )
         {
             m_indiP_focusMonitoredProperties[n] = ipRecv;
+
+            if( c_hasFocus && m_hasFocus && static_cast<int>( n ) == m_focusStateSourceIndex )
+            {
+                std::unique_lock<std::mutex> lock( derived().m_indiMutex );
+                updateFocusStateProperty();
+            }
+
             return 0;
         }
     }
@@ -4539,16 +4573,7 @@ int stdCamera<derivedT>::updateINDI()
 
         if( c_hasFocus && m_hasFocus )
         {
-            mx::meta::trueFalseT<c_hasFocus> tf;
-            if( checkFocus( tf ) )
-            {
-                derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::On, INDI_OK );
-            }
-            else
-            {
-                derived().updateSwitchIfChanged( m_indiP_focus, "state", pcf::IndiElement::Off, INDI_IDLE );
-            }
-
+            updateFocusStateProperty();
             derived().updateSwitchIfChanged( m_indiP_gotoFocus, "request", pcf::IndiElement::Off, INDI_IDLE );
         }
 

--- a/libMagAOX/app/dev/stdMotionStage.hpp
+++ b/libMagAOX/app/dev/stdMotionStage.hpp
@@ -498,6 +498,48 @@ int stdMotionStage<derivedT>::newCallBack_m_indiP_presetName( const pcf::IndiPro
 {
     INDI_VALIDATE_CALLBACK_PROPS_DERIVED( m_indiP_presetName, ipRecv );
 
+    std::vector<std::string> invalidSelections;
+    for( auto &&el : ipRecv.getElements() )
+    {
+        if( el.second.getSwitchState() != pcf::IndiElement::On )
+        {
+            continue;
+        }
+
+        bool knownPreset = false;
+        for( size_t i = 0; i < m_presetNames.size(); ++i )
+        {
+            if( el.first == m_presetNames[i] )
+            {
+                knownPreset = true;
+                break;
+            }
+        }
+
+        if( !knownPreset )
+        {
+            invalidSelections.push_back( el.first );
+        }
+    }
+
+    if( invalidSelections.size() > 0 )
+    {
+        std::string invalidNames;
+        for( size_t n = 0; n < invalidSelections.size(); ++n )
+        {
+            if( n > 0 )
+            {
+                invalidNames += ", ";
+            }
+
+            invalidNames += invalidSelections[n];
+        }
+
+        derivedT::template log<text_log>( "Unknown " + m_presetNotation + "Name selected: " + invalidNames,
+                                          logPrio::LOG_ERROR );
+        return -1;
+    }
+
     std::string newName = "";
     int         newn    = -1;
 

--- a/libMagAOX/app/dev/tests/stdMotionStage_test.cpp
+++ b/libMagAOX/app/dev/tests/stdMotionStage_test.cpp
@@ -1,0 +1,280 @@
+/** \file stdMotionStage_test.cpp
+ * \brief Catch2 tests for the stdMotionStage helper.
+ * \author Jared R. Males (jaredmales@gmail.com)
+ *
+ * \ingroup testing
+ */
+
+#include "../../../../tests/testXWC.hpp"
+
+#include "../../MagAOXApp.hpp"
+#include "../stdMotionStage.hpp"
+
+using namespace MagAOX::app;
+
+namespace libXWCTest
+{
+namespace appTest
+{
+namespace devTest
+{
+
+/** \defgroup stdMotionStage_tests libXWC::app::dev::stdMotionStage Unit Tests
+ * \ingroup app_dev_unit_tests
+ */
+
+/// Test harness for exercising stdMotionStage preset-name callbacks without the INDI validation short-circuit.
+/** \ingroup stdMotionStage_tests
+ */
+class stdMotionStageHarness : public MagAOXApp<false>, public dev::stdMotionStage<stdMotionStageHarness>
+{
+    friend class dev::stdMotionStage<stdMotionStageHarness>;
+
+  protected:
+    float m_lastMoveTarget{ -1.0f }; ///< Last target passed to moveTo by the helper.
+
+    int m_moveCalls{ 0 }; ///< Number of motion requests issued by the helper.
+
+    static std::string s_lastLogMessage; ///< Most recent text log message captured from stdMotionStage.
+
+    static logPrioT s_lastLogLevel; ///< Most recent log priority captured from stdMotionStage.
+
+    static int s_logCount; ///< Number of captured stdMotionStage log messages.
+
+  public:
+    /// Construct a stdMotionStage test harness with a presetName callback property.
+    stdMotionStageHarness();
+
+    /// Destroy the stdMotionStage test harness.
+    ~stdMotionStageHarness() noexcept override;
+
+    /// Reset the captured stdMotionStage logging state shared across harness instances.
+    static void resetLogState();
+
+    /// Configure the preset-name list and notation used by stdMotionStage.
+    void
+    configurePresets( const std::vector<std::string> &presetNames /**< [in] configured preset names */,
+                      const std::string &presetNotation /**< [in] singular preset notation such as preset or filter */
+    );
+
+    /// Apply a presetName request property to the stdMotionStage callback under test.
+    int applyPresetNameRequest(
+        const std::vector<std::pair<std::string, pcf::IndiElement::SwitchStateType>> &elements /**< [in] requested
+                                                                                                        switch
+                                                                                                        elements and
+                                                                                                        states */
+    );
+
+    /// Get the number of move requests accepted by stdMotionStage.
+    int moveCalls() const;
+
+    /// Get the last move target accepted by stdMotionStage.
+    float lastMoveTarget() const;
+
+    /// Get the most recent stdMotionStage text log message captured by the harness.
+    static const std::string &lastLogMessage();
+
+    /// Get the most recent stdMotionStage log priority captured by the harness.
+    static logPrioT lastLogLevel();
+
+    /// Get the number of stdMotionStage log messages captured by the harness.
+    static int logCount();
+
+    /// Capture stdMotionStage log messages instead of sending them to the normal logger.
+    template <typename logT, int retval = 0>
+    static int log( const typename logT::messageT &msg /**< [in] the logged message */,
+                    logPrioT                       level = logPrio::LOG_DEFAULT /**< [in] the logged priority */
+    );
+
+    /// No-op startup implementation required by MagAOXApp for testing.
+    int appStartup() override;
+
+    /// No-op logic implementation required by MagAOXApp for testing.
+    int appLogic() override;
+
+    /// No-op shutdown implementation required by MagAOXApp for testing.
+    int appShutdown() override;
+
+    /// No-op stop implementation required by stdMotionStage for testing.
+    int stop();
+
+    /// No-op homing implementation required by stdMotionStage for testing.
+    int startHoming();
+
+    /// Return a fixed preset number for testing paths that query the current preset.
+    float presetNumber();
+
+    /// Record a requested move target when stdMotionStage accepts a motion request.
+    int moveTo( float target /**< [in] the accepted move target */ );
+};
+
+std::string stdMotionStageHarness::s_lastLogMessage;
+
+logPrioT stdMotionStageHarness::s_lastLogLevel = logPrio::LOG_DEFAULT;
+
+int stdMotionStageHarness::s_logCount = 0;
+
+stdMotionStageHarness::stdMotionStageHarness() : MagAOXApp<false>( "", false )
+{
+    m_configName = "stest";
+
+    m_indiP_presetName = pcf::IndiProperty( pcf::IndiProperty::Switch );
+    m_indiP_presetName.setDevice( m_configName );
+    m_indiP_presetName.setName( "presetName" );
+
+    resetLogState();
+}
+
+stdMotionStageHarness::~stdMotionStageHarness() noexcept = default;
+
+void stdMotionStageHarness::resetLogState()
+{
+    s_lastLogMessage.clear();
+    s_lastLogLevel = logPrio::LOG_DEFAULT;
+    s_logCount     = 0;
+}
+
+void stdMotionStageHarness::configurePresets( const std::vector<std::string> &presetNames,
+                                              const std::string              &presetNotation )
+{
+    m_presetNames    = presetNames;
+    m_presetNotation = presetNotation;
+}
+
+int stdMotionStageHarness::applyPresetNameRequest(
+    const std::vector<std::pair<std::string, pcf::IndiElement::SwitchStateType>> &elements )
+{
+    pcf::IndiProperty ip( pcf::IndiProperty::Switch );
+    ip.setDevice( m_configName );
+    ip.setName( "presetName" );
+
+    for( const auto &element : elements )
+    {
+        ip.add( pcf::IndiElement( element.first ) );
+        ip[element.first].setSwitchState( element.second );
+    }
+
+    return newCallBack_m_indiP_presetName( ip );
+}
+
+int stdMotionStageHarness::moveCalls() const
+{
+    return m_moveCalls;
+}
+
+float stdMotionStageHarness::lastMoveTarget() const
+{
+    return m_lastMoveTarget;
+}
+
+const std::string &stdMotionStageHarness::lastLogMessage()
+{
+    return s_lastLogMessage;
+}
+
+logPrioT stdMotionStageHarness::lastLogLevel()
+{
+    return s_lastLogLevel;
+}
+
+int stdMotionStageHarness::logCount()
+{
+    return s_logCount;
+}
+
+template <typename logT, int retval>
+int stdMotionStageHarness::log( const typename logT::messageT &msg, logPrioT level )
+{
+    s_lastLogMessage =
+        logT::msgString( const_cast<uint8_t *>( msg.builder.GetBufferPointer() ), msg.builder.GetSize() );
+    s_lastLogLevel = level;
+    ++s_logCount;
+
+    return retval;
+}
+
+int stdMotionStageHarness::appStartup()
+{
+    return 0;
+}
+
+int stdMotionStageHarness::appLogic()
+{
+    return 0;
+}
+
+int stdMotionStageHarness::appShutdown()
+{
+    return 0;
+}
+
+int stdMotionStageHarness::stop()
+{
+    return 0;
+}
+
+int stdMotionStageHarness::startHoming()
+{
+    return 0;
+}
+
+float stdMotionStageHarness::presetNumber()
+{
+    return 0.0f;
+}
+
+int stdMotionStageHarness::moveTo( float target )
+{
+    m_lastMoveTarget = target;
+    ++m_moveCalls;
+
+    return 0;
+}
+
+/// Verify stdMotionStage logs and rejects invalid preset-name selections before issuing motion requests.
+/**
+ * \ingroup stdMotionStage_tests
+ */
+TEST_CASE( "stdMotionStage rejects invalid preset-name selections", "[dev::stdMotionStage]" )
+{
+    // clang-format off
+    #ifdef STDMOTIONSTAGE_TEST_DOXYGEN_REF
+    MagAOX::app::dev::stdMotionStage<libXWCTest::appTest::devTest::stdMotionStageHarness>::newCallBack_m_indiP_presetName( pcf::IndiProperty() );
+    #endif
+    // clang-format on
+
+    SECTION( "quoted preset names are logged and rejected" )
+    {
+        stdMotionStageHarness app;
+
+        app.configurePresets( { "open", "focus" }, "preset" );
+        stdMotionStageHarness::resetLogState();
+
+        REQUIRE( app.applyPresetNameRequest( { { "\"focus\"", pcf::IndiElement::On } } ) == -1 );
+        REQUIRE( stdMotionStageHarness::logCount() == 1 );
+        REQUIRE( stdMotionStageHarness::lastLogLevel() == logPrio::LOG_ERROR );
+        REQUIRE( stdMotionStageHarness::lastLogMessage() == "Unknown presetName selected: \"focus\"" );
+        REQUIRE( app.moveCalls() == 0 );
+        REQUIRE( app.lastMoveTarget() == -1.0f );
+    }
+
+    SECTION( "invalid names are rejected even when a valid preset is also selected" )
+    {
+        stdMotionStageHarness app;
+
+        app.configurePresets( { "open", "focus" }, "filter" );
+        stdMotionStageHarness::resetLogState();
+
+        REQUIRE( app.applyPresetNameRequest(
+                     { { "open", pcf::IndiElement::On }, { "bogus", pcf::IndiElement::On } } ) == -1 );
+        REQUIRE( stdMotionStageHarness::logCount() == 1 );
+        REQUIRE( stdMotionStageHarness::lastLogLevel() == logPrio::LOG_ERROR );
+        REQUIRE( stdMotionStageHarness::lastLogMessage() == "Unknown filterName selected: bogus" );
+        REQUIRE( app.moveCalls() == 0 );
+        REQUIRE( app.lastMoveTarget() == -1.0f );
+    }
+}
+
+} // namespace devTest
+} // namespace appTest
+} // namespace libXWCTest


### PR DESCRIPTION
This work was performed by GPT-5 in response to the prompt: "Please review cameraGUI-focus-button.md and follow the instructions. This should be implemented in picamCtrl."

## Summary
- add optional focus support to `dev::stdCamera` with published `focus.state` and `goto_focus.request`
- add stdCamera helpers for monitoring an external focus-state switch and for deriving a goto-focus command from multiple INDI switch properties
- enable the feature in `picamCtrl`
- update `cameraGUI` to show a `goto focus` button when supported, disable it when `focus.state` is `On`, and keep the control layout aligned

## Follow-up fixes from integration testing
- add `focus.stateElementOnMeansInFocus` so monitored focus-state polarity can be inverted when `On` means in-focus
- update `focus.state` immediately when the monitored source property changes
- subscribe `cameraGUI` directly to `focus` and `goto_focus` so the UI refreshes without manual `getINDI`
- strip wrapping quotes from `focus.gotoFocus.format` before synthesizing preset targets
- log the dispatched goto-focus target from `stdCamera`
- log and reject invalid `presetName` selections in `stdMotionStage`

## Testing
- `make -C /home/jrmales/Source/MagAOX/gui/apps/cameraGUI -j4`
- `./apps/cameraSim/tests/cameraSim_test`
- `./libMagAOX/app/dev/tests/stdMotionStage_test`

## Notes
- new focus-helper configs include `focus.stateProperty`, `focus.stateElement`, `focus.stateElementOnMeansInFocus`, `focus.gotoFocus.numSwitches`, `focus.gotoFocus.propertyN`, `focus.gotoFocus.format`, and `focus.gotoFocus.targetProperty`
- `picamCtrl` could not be fully built locally because `picam_advanced.h` was not available under `/opt/PrincetonInstruments/picam/includes/`
