### PR TITLE
siglentSDG: fix pulse width logic to invert high and low widths

### DIFF
--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -1857,19 +1857,24 @@ int siglentSDG::changeFreq( int channel,
    // we want to automatically set the pulse width when setting a new frequency
    if(m_waveform == "PULSE"){
       // we want to auto change the pulse duration, want either 0.000250 or 0.5%
-      double wdth250 = 1 / newFreq  - 0.000250; // Ideal puse width 250us, subtract from period to get width
-      double wdthLim = 0.5 / newFreq ;          // this is the limit for periods < 2 * 250us
-      double newWdth = wdth250;
+      if(newFreq == 0){
+         // something upstream is crashing, but let us not make a NAN
+         newWdth = 0.0;
+         log<text_log>("Ch. " + std::to_string(channel) + " WDTH defaulting to 0.0 for invalid freq: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+      } else{
+         double wdth250 = 1 / newFreq  - 0.000250; // Ideal pulse width 250us, subtract from period to get width
+         double wdthLim = 0.5 / newFreq ;          // this is the limit for periods < 2 * 250us
+         double newWdth = wdth250;
 
-      if(wdthLim > wdth250){
-         // if keeping the ideal 250 pulse width gives a pulse is shorter than 50% of the period
-         // switch to the duty cycle limit
-         newWdth = wdthLim;
-         log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to duty cycle limit: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
-      }else{
-         log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to 250us ideal case: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+         if(wdthLim > wdth250){
+            // if keeping the ideal 250 pulse width gives a pulse is shorter than 50% of the period
+            // switch to the duty cycle limit
+            newWdth = wdthLim;
+            log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to duty cycle limit: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+         }else{
+            log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to 250us ideal case: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+         }                                      
       }
-
       //changing pulse width
       changeWdth(channel, newWdth);
    }

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -1097,6 +1097,33 @@ std::string makeCommand( int channel,
    return command;
 }
 
+/// Calculate the auto pulse width for a requested pulse frequency.
+/** Returns 0 for non-positive frequency, otherwise uses the larger of:
+  * - fixed 250 us pulse width target
+  * - 50% duty cycle limit
+  */
+inline
+double autoPulseWidthFromFrequency( const double freqHz /**< [in] requested pulse frequency [Hz] */ )
+{
+   if(freqHz <= 0)
+   {
+      return 0.0;
+   }
+
+   constexpr double targetPulseS = 0.000250;
+   constexpr double maxDutyCycle = 0.5;
+
+   const double wdth250 = 1.0 / freqHz - targetPulseS;
+   const double wdthLim = maxDutyCycle / freqHz;
+
+   if(wdthLim > wdth250)
+   {
+      return wdthLim;
+   }
+
+   return wdth250;
+}
+
 inline
 int siglentSDG::queryMDWV( std::string & state,
                            int channel
@@ -1854,28 +1881,24 @@ int siglentSDG::changeFreq( int channel,
       return -1;
    }
 
-   // we want to automatically set the pulse width when setting a new frequency
-   if(m_waveform == "PULSE"){
-      // we want to auto change the pulse duration, want either 0.000250 or 0.5%
-      if(newFreq == 0){
-         // something upstream is crashing, but let us not make a NAN
-         newWdth = 0.0;
-         log<text_log>("Ch. " + std::to_string(channel) + " WDTH defaulting to 0.0 for invalid freq: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
-      } else{
-         double wdth250 = 1 / newFreq  - 0.000250; // Ideal pulse width 250us, subtract from period to get width
-         double wdthLim = 0.5 / newFreq ;          // this is the limit for periods < 2 * 250us
-         double newWdth = wdth250;
+   // automatically set the pulse width when setting a new frequency
+   if(m_waveform == "PULSE")
+   {
+      const double newWdth = autoPulseWidthFromFrequency(newFreq);
 
-         if(wdthLim > wdth250){
-            // if keeping the ideal 250 pulse width gives a pulse is shorter than 50% of the period
-            // switch to the duty cycle limit
-            newWdth = wdthLim;
-            log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to duty cycle limit: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
-         }else{
-            log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to 250us ideal case: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
-         }                                      
+      if(newFreq <= 0)
+      {
+         log<text_log>("Ch. " + std::to_string(channel) + " WDTH defaulting to 0.0 for invalid freq: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
       }
-      //changing pulse width
+      else if(newFreq > 2000.0)
+      {
+         log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to duty cycle limit: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+      }
+      else
+      {
+         log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to 250us ideal case: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
+      }
+
       changeWdth(channel, newWdth);
    }
 

--- a/apps/siglentSDG/siglentSDG.hpp
+++ b/apps/siglentSDG/siglentSDG.hpp
@@ -1857,12 +1857,14 @@ int siglentSDG::changeFreq( int channel,
    // we want to automatically set the pulse width when setting a new frequency
    if(m_waveform == "PULSE"){
       // we want to auto change the pulse duration, want either 0.000250 or 0.5%
-      double wdthLim = 0.5 / newFreq ;         // this is the limit if we don't have long enough frequencies
-      double wdth250 = 0.000250;  // this is the ideal length of low dip WHACK THINGS.. it's doubling, want to be 0.00025
-      double newWdth = wdthLim;
+      double wdth250 = 1 / newFreq  - 0.000250; // Ideal puse width 250us, subtract from period to get width
+      double wdthLim = 0.5 / newFreq ;          // this is the limit for periods < 2 * 250us
+      double newWdth = wdth250;
 
       if(wdthLim > wdth250){
-         newWdth = wdth250;
+         // if keeping the ideal 250 pulse width gives a pulse is shorter than 50% of the period
+         // switch to the duty cycle limit
+         newWdth = wdthLim;
          log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to duty cycle limit: " + std::to_string(newWdth), logPrio::LOG_NOTICE);
       }else{
          log<text_log>("Ch. " + std::to_string(channel) + " WDTH auto-changing to 250us ideal case: " + std::to_string(newWdth), logPrio::LOG_NOTICE);

--- a/apps/siglentSDG/tests/siglentSDG_test.cpp
+++ b/apps/siglentSDG/tests/siglentSDG_test.cpp
@@ -180,6 +180,33 @@ SCENARIO( "Parsing the OUTP? response", "[siglentSDG]" )
     }
 }
 
+/// Verify automatic pulse width calculation across the requested frequency regimes.
+/**
+ * \ingroup siglentSDG_unit_test
+ */
+TEST_CASE( "auto pulse width from frequency", "[siglentSDG]" )
+{
+    SECTION( "below 2 kHz uses 250 us target" )
+    {
+        REQUIRE( autoPulseWidthFromFrequency( 1000.0 ) == Approx( 0.00075 ) );
+    }
+
+    SECTION( "at 2 kHz equals 250 us" )
+    {
+        REQUIRE( autoPulseWidthFromFrequency( 2000.0 ) == Approx( 0.00025 ) );
+    }
+
+    SECTION( "above 2 kHz uses 50 percent duty limit" )
+    {
+        REQUIRE( autoPulseWidthFromFrequency( 4000.0 ) == Approx( 0.000125 ) );
+    }
+
+    SECTION( "zero frequency yields zero width" )
+    {
+        REQUIRE( autoPulseWidthFromFrequency( 0.0 ) == Approx( 0.0 ) );
+    }
+}
+
 } // namespace siglentSDGTest
 
 } // namespace libXWCTest


### PR DESCRIPTION
After behavior change during 26A run, the inverse of the previous 250us logic is needed. For rates < 2kHz we need to have 1/freq - 250us pulse widths instead of a fixed 250us as done previously. 