### PR TITLE
Add configurable upstream-follow-closed behavior to loop apps

### DIFF
--- a/apps/alignLoop/alignLoop.hpp
+++ b/apps/alignLoop/alignLoop.hpp
@@ -1,541 +1,625 @@
 /** \file alignLoop.hpp
-  * \brief The MagAO-X XXXXXX header file
-  *
-  * \ingroup alignLoop_files
-  */
+ * \brief The MagAO-X alignment loop application header file.
+ *
+ * \ingroup alignLoop_files
+ */
 
 #ifndef alignLoop_hpp
 #define alignLoop_hpp
-
 
 #include "../../libMagAOX/libMagAOX.hpp" //Note this is included on command line to trigger pch
 #include "../../magaox_git_version.h"
 
 /** \defgroup alignLoop
-  * \brief The XXXXXX application to do YYYYYYY
-  *
-  * <a href="../handbook/operating/software/apps/XXXXXX.html">Application Documentation</a>
-  *
-  * \ingroup apps
-  *
-  */
+ * \brief The MagAO-X application for alignment-loop control.
+ *
+ * <a href="../handbook/operating/software/apps/XXXXXX.html">Application Documentation</a>
+ *
+ * \ingroup apps
+ *
+ */
 
 /** \defgroup alignLoop_files
-  * \ingroup alignLoop
-  */
+ * \ingroup alignLoop
+ */
 
 namespace MagAOX
 {
 namespace app
 {
 
-/// The MagAO-X xxxxxxxx
+/// The MagAO-X alignment-loop controller.
 /**
-  * \ingroup alignLoop
-  */
+ * \ingroup alignLoop
+ */
 class alignLoop : public MagAOXApp<true>, public dev::shmimMonitor<alignLoop>
 {
-   //Give the test harness access.
-   friend class alignLoop_test;
+    // Give the test harness access.
+    friend class alignLoop_test;
 
-   friend class dev::shmimMonitor<alignLoop>;
+    friend class dev::shmimMonitor<alignLoop>;
 
-public:
-   //The base shmimMonitor type
-   typedef dev::shmimMonitor<alignLoop> shmimMonitorT;
+  public:
+    // The base shmimMonitor type
+    typedef dev::shmimMonitor<alignLoop> shmimMonitorT;
 
-protected:
-
-   /** \name Configurable Parameters
+  protected:
+    /** \name Configurable Parameters
      *@{
      */
 
-   std::vector<std::string> m_ctrlDevices;
-   std::vector<std::string> m_ctrlProperties;
-   std::vector<std::string> m_ctrlCurrents;
-   std::vector<std::string> m_ctrlTargets;
+    std::vector<std::string> m_ctrlDevices;    ///< Device names of the controlled axes.
+    std::vector<std::string> m_ctrlProperties; ///< INDI properties used to send loop commands.
+    std::vector<std::string> m_ctrlCurrents;   ///< INDI elements holding the current controller values.
+    std::vector<std::string> m_ctrlTargets;    ///< INDI elements to which updated commands are written.
 
-   std::vector<float> m_currents;
+    std::vector<float> m_currents; ///< Most recently received controller values.
 
-   std::vector<pcf::IndiProperty> m_indiP_ctrl;
+    std::vector<pcf::IndiProperty> m_indiP_ctrl; ///< Registered controller properties for each axis.
 
-   std::string m_intMatFile;
+    std::string m_intMatFile; ///< Interaction matrix file name from configuration.
 
-   std::vector<float> m_defaultGains;
+    std::vector<float> m_defaultGains; ///< Default per-axis gains loaded from configuration.
 
-   std::string m_upstreamDevice;
-   std::string m_upstreamProperty {"loop_state"};
-   bool m_upstreamFollowClosed {false};
+    std::string m_upstreamDevice;                   ///< Upstream loop device that this loop can follow.
+    std::string m_upstreamProperty{ "loop_state" }; ///< Toggle property on the upstream loop to monitor.
+    bool        m_upstreamFollowClosed{ false };    ///< If true, this loop closes when the upstream loop closes.
 
+    ///@}
 
-   ///@}
+    mx::improc::eigenImage<float> m_intMat; ///< Interaction matrix mapping measurements to commands.
 
-   mx::improc::eigenImage<float> m_intMat;
+    mx::improc::eigenImage<float> m_measurements; ///< Most recent measured loop disturbance vector.
+    float                         m_delta0{ 0 };  ///< Latest first-axis residual.
+    float                         m_delta1{ 0 };  ///< Latest second-axis residual.
 
-   mx::improc::eigenImage<float> m_measurements;
-   float m_delta0 {0};
-   float m_delta1 {0};
+    mx::improc::eigenImage<float> m_commands; ///< Most recent command delta vector.
 
-   mx::improc::eigenImage<float> m_commands;
+    float m_ggain{ 0 }; ///< Global loop gain applied to all axes.
 
-   float m_ggain {0};
+    std::vector<float> m_gains; ///< Active per-axis gains.
 
-   std::vector<float> m_gains;
+    bool m_ctrlEnabled{ false }; ///< True when the loop is closed and may send controller commands.
 
-   bool m_ctrlEnabled {false};
+  public:
+    /// Default c'tor.
+    alignLoop();
 
-public:
-   /// Default c'tor.
-   alignLoop();
+    /// D'tor, declared and defined for noexcept.
+    ~alignLoop() noexcept
+    {
+    }
 
-   /// D'tor, declared and defined for noexcept.
-   ~alignLoop() noexcept
-   {}
+    /// Set up the app configuration interface.
+    virtual void setupConfig();
 
-   virtual void setupConfig();
-
-   /// Implementation of loadConfig logic, separated for testing.
-   /** This is called by loadConfig().
+    /// Implementation of loadConfig logic, separated for testing.
+    /** This is called by loadConfig().
      */
-   int loadConfigImpl( mx::app::appConfigurator & _config /**< [in] an application configuration from which to load values*/);
+    int loadConfigImpl(
+        mx::app::appConfigurator &_config /**< [in] an application configuration from which to load values*/ );
 
-   virtual void loadConfig();
+    /// Load the application configuration.
+    virtual void loadConfig();
 
-   /// Startup function
-   /**
+    /// Startup function
+    /**
      *
      */
-   virtual int appStartup();
+    virtual int appStartup();
 
-   /// Implementation of the FSM for alignLoop.
-   /**
+    /// Implementation of the FSM for alignLoop.
+    /**
      * \returns 0 on no critical error
      * \returns -1 on an error requiring shutdown
      */
-   virtual int appLogic();
+    virtual int appLogic();
 
-   /// Shutdown the app.
-   /**
+    /// Shutdown the app.
+    /**
      *
      */
-   virtual int appShutdown();
+    virtual int appShutdown();
 
-   int toggleLoop( bool onoff );
+    /// Change the loop state.
+    int toggleLoop( bool onoff /**< [in] true to close the loop and false to open it */ );
 
-   // shmimMonitor interface:
-   int allocate( const dev::shmimT &);
+    // shmimMonitor interface:
+    /// Allocate working memory for the monitored image stream.
+    int allocate( const dev::shmimT &dummy /**< [in] ignored shmim descriptor */ );
 
-   int processImage( void* curr_src,
-                     const dev::shmimT &
-                    );
+    /// Process a new measurement image from the monitored stream.
+    int processImage( void              *curr_src /**< [in] pointer to the current image buffer */,
+                      const dev::shmimT &dummy /**< [in] ignored shmim descriptor */
+    );
 
-   int sendCommands(std::vector<float> & commands);
+    /// Send the newly computed commands to the controller devices.
+    int sendCommands( std::vector<float> &commands /**< [in] command values to transmit */ );
 
-   //INDI
+    // INDI
 
-   pcf::IndiProperty m_indiP_deltas;
+    pcf::IndiProperty m_indiP_deltas; ///< Published loop residual values.
 
-   pcf::IndiProperty m_indiP_ggain;
-   pcf::IndiProperty m_indiP_ctrlEnabled;
+    pcf::IndiProperty m_indiP_ggain;       ///< INDI property exposing the global loop gain.
+    pcf::IndiProperty m_indiP_ctrlEnabled; ///< INDI property exposing the loop open/closed state.
 
-   INDI_NEWCALLBACK_DECL(alignLoop, m_indiP_ggain);
-   INDI_NEWCALLBACK_DECL(alignLoop, m_indiP_ctrlEnabled);
+    INDI_NEWCALLBACK_DECL( alignLoop, m_indiP_ggain );
+    INDI_NEWCALLBACK_DECL( alignLoop, m_indiP_ctrlEnabled );
 
-   static int st_setCallBack_ctrl( void * app, const pcf::IndiProperty &ipRecv)
-   {
-      return static_cast<alignLoop *>(app)->setCallBack_ctrl(ipRecv);
-   }
+    /// Route controller property updates into the instance callback.
+    static int st_setCallBack_ctrl( void                    *app /**< [in] application instance pointer */,
+                                    const pcf::IndiProperty &ipRecv /**< [in] controller property update */
+    )
+    {
+        return static_cast<alignLoop *>( app )->setCallBack_ctrl( ipRecv );
+    }
 
-   int setCallBack_ctrl(const pcf::IndiProperty &ipRecv);
+    /// Update cached controller current values from an INDI property callback.
+    int setCallBack_ctrl( const pcf::IndiProperty &ipRecv /**< [in] controller property update */ );
 
-   int m_upstreamState {0};
-   pcf::IndiProperty m_indiP_upstream; ///< Property used to report the loop state
+    int               m_upstreamState{ 0 }; ///< Cached upstream state indicator.
+    pcf::IndiProperty m_indiP_upstream;     ///< Property used to monitor the upstream loop state.
 
-   INDI_SETCALLBACK_DECL(alignLoop, m_indiP_upstream);
+    INDI_SETCALLBACK_DECL( alignLoop, m_indiP_upstream );
 };
 
-alignLoop::alignLoop() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
+alignLoop::alignLoop() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
 
-   return;
+    return;
 }
 
 void alignLoop::setupConfig()
 {
-   shmimMonitorT::setupConfig(config);
+    shmimMonitorT::setupConfig( config );
 
-   config.add("ctrl.devices", "", "ctrl.devices", argType::Required, "ctrl", "devices", false, "string", "Device names of the controller(s) (one per element).");
-   config.add("ctrl.properties", "", "ctrl.properties", argType::Required, "ctrl", "properties", false, "string", "Properties of the ctrl devices to which to give the commands. One per element");
-   config.add("ctrl.currents", "", "ctrl.currents", argType::Required, "ctrl", "currents", false, "vector<string>", "current elements of the properties on which base the commands.");
-   config.add("ctrl.targets", "", "ctrl.targets", argType::Required, "ctrl", "targets", false, "vector<string>", "target elements of the properties to which to send the commands.");
+    config.add( "ctrl.devices",
+                "",
+                "ctrl.devices",
+                argType::Required,
+                "ctrl",
+                "devices",
+                false,
+                "string",
+                "Device names of the controller(s) (one per element)." );
+    config.add( "ctrl.properties",
+                "",
+                "ctrl.properties",
+                argType::Required,
+                "ctrl",
+                "properties",
+                false,
+                "string",
+                "Properties of the ctrl devices to which to give the commands. One per element" );
+    config.add( "ctrl.currents",
+                "",
+                "ctrl.currents",
+                argType::Required,
+                "ctrl",
+                "currents",
+                false,
+                "vector<string>",
+                "current elements of the properties on which base the commands." );
+    config.add( "ctrl.targets",
+                "",
+                "ctrl.targets",
+                argType::Required,
+                "ctrl",
+                "targets",
+                false,
+                "vector<string>",
+                "target elements of the properties to which to send the commands." );
 
-   config.add("loop.gain", "", "loop.gain", argType::Required, "loop", "gain", false, "float", "default global loop gain.");
-   config.add("loop.intMat", "", "loop.intMat", argType::Required, "loop", "intMat", false, "string", "file name of the interaction matrix.");
-   config.add("loop.gains", "", "loop.gains", argType::Required, "loop", "gains", false, "vector<float>", "default loop gains.  If single number, it is applied to all axes.");
-   config.add("loop.upstream", "", "loop.upstream", argType::Required, "loop", "upstream", false, "string", "Upstream loop device name.  This loop will open, and optionally close, with the upstream loop.  Default none.");
-   config.add("loop.upstreamProperty", "", "loop.upstreamProperty", argType::Required, "loop", "upstreamProperty", false, "string", "Property of upstream loop device to follow.  Must be a toggle.  Default is loop_state.");
-
+    config.add(
+        "loop.gain", "", "loop.gain", argType::Required, "loop", "gain", false, "float", "default global loop gain." );
+    config.add( "loop.intMat",
+                "",
+                "loop.intMat",
+                argType::Required,
+                "loop",
+                "intMat",
+                false,
+                "string",
+                "file name of the interaction matrix." );
+    config.add( "loop.gains",
+                "",
+                "loop.gains",
+                argType::Required,
+                "loop",
+                "gains",
+                false,
+                "vector<float>",
+                "default loop gains.  If single number, it is applied to all axes." );
+    config.add( "loop.upstream",
+                "",
+                "loop.upstream",
+                argType::Required,
+                "loop",
+                "upstream",
+                false,
+                "string",
+                "Upstream loop device name.  This loop will open, and optionally close, with the upstream loop.  "
+                "Default none." );
+    config.add( "loop.upstreamProperty",
+                "",
+                "loop.upstreamProperty",
+                argType::Required,
+                "loop",
+                "upstreamProperty",
+                false,
+                "string",
+                "Property of upstream loop device to follow.  Must be a toggle.  Default is loop_state." );
+    config.add( "loop.upstreamFollowClosed",
+                "",
+                "loop.upstreamFollowClosed",
+                argType::Required,
+                "loop",
+                "upstreamFollowClosed",
+                false,
+                "bool",
+                "If true, this loop also closes when the upstream loop closes. Default is false." );
 }
 
-int alignLoop::loadConfigImpl( mx::app::appConfigurator & _config )
+int alignLoop::loadConfigImpl( mx::app::appConfigurator &_config )
 {
-   shmimMonitorT::loadConfig(_config);
+    shmimMonitorT::loadConfig( _config );
 
-   _config(m_ctrlDevices, "ctrl.devices");
-   _config(m_ctrlProperties, "ctrl.properties");
-   _config(m_ctrlCurrents, "ctrl.currents");
-   _config(m_ctrlTargets, "ctrl.targets");
-   _config(m_ggain, "loop.gain");
-   _config(m_intMatFile, "loop.intMat");
-   _config(m_defaultGains, "loop.gains");
-   _config(m_upstreamDevice, "loop.upstream");
-   _config(m_upstreamProperty, "loop.upstreamProperty");
-   return 0;
+    _config( m_ctrlDevices, "ctrl.devices" );
+    _config( m_ctrlProperties, "ctrl.properties" );
+    _config( m_ctrlCurrents, "ctrl.currents" );
+    _config( m_ctrlTargets, "ctrl.targets" );
+    _config( m_ggain, "loop.gain" );
+    _config( m_intMatFile, "loop.intMat" );
+    _config( m_defaultGains, "loop.gains" );
+    _config( m_upstreamDevice, "loop.upstream" );
+    _config( m_upstreamProperty, "loop.upstreamProperty" );
+    _config( m_upstreamFollowClosed, "loop.upstreamFollowClosed" );
+    return 0;
 }
 
 void alignLoop::loadConfig()
 {
-   loadConfigImpl(config);
+    loadConfigImpl( config );
 }
 
 int alignLoop::appStartup()
 {
-   if(shmimMonitorT::appStartup() < 0)
-   {
-      return log<software_error,-1>({__FILE__, __LINE__});
-   }
+    if( shmimMonitorT::appStartup() < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
 
-   if(m_ctrlTargets.size() != m_ctrlDevices.size())
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "ctrl.Targets and ctrl.devices are not the same size"});
-   }
+    if( m_ctrlTargets.size() != m_ctrlDevices.size() )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "ctrl.Targets and ctrl.devices are not the same size" } );
+    }
 
-   if(m_ctrlTargets.size() != m_ctrlProperties.size())
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "ctrl.Targets and ctrl.properties are not the same size"});
-   }
+    if( m_ctrlTargets.size() != m_ctrlProperties.size() )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "ctrl.Targets and ctrl.properties are not the same size" } );
+    }
 
-   if(m_ctrlTargets.size() != m_ctrlCurrents.size())
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "ctrl.Currents and ctrl.properties are not the same size"});
-   }
+    if( m_ctrlTargets.size() != m_ctrlCurrents.size() )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "ctrl.Currents and ctrl.properties are not the same size" } );
+    }
 
-   if(m_ctrlTargets.size() != m_defaultGains.size())
-   {
-      if(m_defaultGains.size()==1)
-      {
-         float g = m_defaultGains[0];
-         m_defaultGains.resize(m_ctrlTargets.size(), g);
-         log<text_log>("Setting loop.gains gains to be same size as ctrl.Targets", logPrio::LOG_NOTICE);
-      }
-      else
-      {
-         return log<software_error, -1>({__FILE__, __LINE__, "ctrl.Targets and loop.gains are not the same size"});
-      }
-   }
+    if( m_ctrlTargets.size() != m_defaultGains.size() )
+    {
+        if( m_defaultGains.size() == 1 )
+        {
+            float g = m_defaultGains[0];
+            m_defaultGains.resize( m_ctrlTargets.size(), g );
+            log<text_log>( "Setting loop.gains gains to be same size as ctrl.Targets", logPrio::LOG_NOTICE );
+        }
+        else
+        {
+            return log<software_error, -1>(
+                { __FILE__, __LINE__, "ctrl.Targets and loop.gains are not the same size" } );
+        }
+    }
 
-   CREATE_REG_INDI_RO_NUMBER( m_indiP_deltas, "deltas", "Deltas", "Deltas");
-   m_indiP_deltas.add(pcf::IndiElement("delta0"));
-   m_indiP_deltas["delta0"] = 0;
-   m_indiP_deltas.add(pcf::IndiElement("delta1"));
-   m_indiP_deltas["delta1"] = 0;
+    CREATE_REG_INDI_RO_NUMBER( m_indiP_deltas, "deltas", "Deltas", "Deltas" );
+    m_indiP_deltas.add( pcf::IndiElement( "delta0" ) );
+    m_indiP_deltas["delta0"] = 0;
+    m_indiP_deltas.add( pcf::IndiElement( "delta1" ) );
+    m_indiP_deltas["delta1"] = 0;
 
-   m_gains.resize(m_defaultGains.size());
-   for(size_t n=0; n < m_defaultGains.size(); ++n) m_gains[n] = m_defaultGains[n];
+    m_gains.resize( m_defaultGains.size() );
+    for( size_t n = 0; n < m_defaultGains.size(); ++n )
+        m_gains[n] = m_defaultGains[n];
 
-   createStandardIndiNumber<unsigned>( m_indiP_ggain, "loop_gain", 0, 1, 0, "%0.2f");
-   m_indiP_ggain["current"] = m_ggain;
-   m_indiP_ggain["target"] = m_ggain;
-   if( registerIndiPropertyNew( m_indiP_ggain, INDI_NEWCALLBACK(m_indiP_ggain)) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
+    createStandardIndiNumber<unsigned>( m_indiP_ggain, "loop_gain", 0, 1, 0, "%0.2f" );
+    m_indiP_ggain["current"] = m_ggain;
+    m_indiP_ggain["target"]  = m_ggain;
+    if( registerIndiPropertyNew( m_indiP_ggain, INDI_NEWCALLBACK( m_indiP_ggain ) ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
 
-   createStandardIndiToggleSw( m_indiP_ctrlEnabled, "loop_state");
-   if( registerIndiPropertyNew( m_indiP_ctrlEnabled, INDI_NEWCALLBACK(m_indiP_ctrlEnabled)) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
+    createStandardIndiToggleSw( m_indiP_ctrlEnabled, "loop_state" );
+    if( registerIndiPropertyNew( m_indiP_ctrlEnabled, INDI_NEWCALLBACK( m_indiP_ctrlEnabled ) ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
 
-   m_currents.resize(m_ctrlDevices.size(), -1e15);
+    m_currents.resize( m_ctrlDevices.size(), -1e15 );
 
-   m_indiP_ctrl.resize(m_ctrlDevices.size());
+    m_indiP_ctrl.resize( m_ctrlDevices.size() );
 
-   for(size_t n=0; n< m_ctrlDevices.size();++n)
-   {
-      registerIndiPropertySet( m_indiP_ctrl[n], m_ctrlDevices[n], m_ctrlProperties[n], &st_setCallBack_ctrl);
-   }
+    for( size_t n = 0; n < m_ctrlDevices.size(); ++n )
+    {
+        registerIndiPropertySet( m_indiP_ctrl[n], m_ctrlDevices[n], m_ctrlProperties[n], &st_setCallBack_ctrl );
+    }
 
-   m_commands.resize(m_ctrlTargets.size(), m_ctrlTargets.size()) ;
-   m_commands.setZero();
+    m_commands.resize( m_ctrlTargets.size(), m_ctrlTargets.size() );
+    m_commands.setZero();
 
-   m_intMat.resize(m_ctrlTargets.size(), m_ctrlTargets.size()) ;
-   m_intMat.setZero();
-   m_intMat(1,0) = 0.926;
-   m_intMat(1,1) = -0.370;
-   m_intMat(0,0) = 0.185;
-   m_intMat(0,1) = 0.926;
+    m_intMat.resize( m_ctrlTargets.size(), m_ctrlTargets.size() );
+    m_intMat.setZero();
+    m_intMat( 1, 0 ) = 0.926;
+    m_intMat( 1, 1 ) = -0.370;
+    m_intMat( 0, 0 ) = 0.185;
+    m_intMat( 0, 1 ) = 0.926;
 
-/*
-   std::string intMatPath = m_calibDir + "/" + m_intMatFile;
+    /*
+       std::string intMatPath = m_calibDir + "/" + m_intMatFile;
 
-   mx::fits::fitsFile<float> ff;
-   try
-   {
-      ff.read(m_intMat, intMatPath);
-   }
-   catch(...)
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "error reading loop.intMatFile.  Does it exist?"});
-   }
+       mx::fits::fitsFile<float> ff;
+       try
+       {
+          ff.read(m_intMat, intMatPath);
+       }
+       catch(...)
+       {
+          return log<software_error, -1>({__FILE__, __LINE__, "error reading loop.intMatFile.  Does it exist?"});
+       }
 
-   if(m_intMat.rows() != m_ctrlTargets.size())
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "interaction matrix wrong size: rows do not match sensor Targets"});
-   }
+       if(m_intMat.rows() != m_ctrlTargets.size())
+       {
+          return log<software_error, -1>({__FILE__, __LINE__, "interaction matrix wrong size: rows do not match sensor
+       Targets"});
+       }
 
-   if(m_intMat.cols() != m_correctorTargets.size())
-   {
-      return log<software_error, -1>({__FILE__, __LINE__, "interaction matrix wrong size: cols do not match corrector Targets"});
-   }
-*/
+       if(m_intMat.cols() != m_correctorTargets.size())
+       {
+          return log<software_error, -1>({__FILE__, __LINE__, "interaction matrix wrong size: cols do not match
+       corrector Targets"});
+       }
+    */
 
-   //Get the loop state for managing offloading
-   if(m_upstreamDevice != "")
-   {
-      REG_INDI_SETPROP(m_indiP_upstream, m_upstreamDevice, m_upstreamProperty);
-   }
+    // Get the loop state for managing offloading
+    if( m_upstreamDevice != "" )
+    {
+        REG_INDI_SETPROP( m_indiP_upstream, m_upstreamDevice, m_upstreamProperty );
+    }
 
-   return 0;
+    return 0;
 }
 
 int alignLoop::appLogic()
 {
-   if( shmimMonitorT::appLogic() < 0)
-   {
-      return log<software_error,-1>({__FILE__,__LINE__});
-   }
+    if( shmimMonitorT::appLogic() < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
 
-   state(stateCodes::OPERATING);
+    state( stateCodes::OPERATING );
 
-   return 0;
+    return 0;
 }
 
 int alignLoop::appShutdown()
 {
-   shmimMonitorT::appShutdown();
+    shmimMonitorT::appShutdown();
 
-   return 0;
+    return 0;
 }
 
-int alignLoop::toggleLoop(bool onoff)
+int alignLoop::toggleLoop( bool onoff )
 {
-   if(!m_ctrlEnabled && onoff) //not enabled so change
-   {
-      m_ctrlEnabled = true;
-      log<loop_closed>();
-      updateSwitchIfChanged(m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::On, INDI_OK);
-      return 0;
-   }
+    if( !m_ctrlEnabled && onoff ) // not enabled so change
+    {
+        m_ctrlEnabled = true;
+        log<loop_closed>();
+        updateSwitchIfChanged( m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::On, INDI_OK );
+        return 0;
+    }
 
-   if(m_ctrlEnabled && !onoff)
-   {
-      m_ctrlEnabled = false;
-      log<loop_open>();
-      updateSwitchIfChanged(m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::Off, INDI_IDLE);
+    if( m_ctrlEnabled && !onoff )
+    {
+        m_ctrlEnabled = false;
+        log<loop_open>();
+        updateSwitchIfChanged( m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::Off, INDI_IDLE );
 
-      return 0;
-   }
+        return 0;
+    }
 
-   return 0;
+    return 0;
 }
 
-inline
-int alignLoop::allocate(const dev::shmimT & dummy)
+inline int alignLoop::allocate( const dev::shmimT &dummy )
 {
-   static_cast<void>(dummy);
+    static_cast<void>( dummy );
 
-   std::lock_guard<std::mutex> guard(m_indiMutex);
+    std::lock_guard<std::mutex> guard( m_indiMutex );
 
-   std::cerr << shmimMonitorT::m_width << shmimMonitorT::m_height << "\n";
-   m_measurements.resize(shmimMonitorT::m_width, shmimMonitorT::m_height);
+    std::cerr << shmimMonitorT::m_width << shmimMonitorT::m_height << "\n";
+    m_measurements.resize( shmimMonitorT::m_width, shmimMonitorT::m_height );
 
-   return 0;
+    return 0;
 }
 
-inline
-int alignLoop::processImage( void* curr_src,
-                            const dev::shmimT & dummy
-                           )
+inline int alignLoop::processImage( void *curr_src, const dev::shmimT &dummy )
 {
-   static_cast<void>(dummy);
+    static_cast<void>( dummy );
 
-   for(unsigned nn=0; nn < shmimMonitorT::m_width*shmimMonitorT::m_height; ++nn)
-   {
-      m_measurements.data()[nn] = (static_cast<float*>(curr_src)) [nn];
-   }
+    for( unsigned nn = 0; nn < shmimMonitorT::m_width * shmimMonitorT::m_height; ++nn )
+    {
+        m_measurements.data()[nn] = ( static_cast<float *>( curr_src ) )[nn];
+    }
 
+    m_delta0 = m_measurements( 0, 0 );
+    m_delta1 = m_measurements( 1, 0 );
 
-   m_delta0 = m_measurements(0,0);
-   m_delta1 = m_measurements(1,0);
+    std::cout << "measurements: ";
+    for( int cc = 0; cc < m_measurements.rows(); ++cc )
+    {
+        std::cout << m_measurements( cc, 0 ) << " ";
+    }
+    std::cout << "\n";
 
-   std::cout << "measurements: ";
-   for(int cc = 0; cc < m_measurements.rows(); ++cc)
-   {
-      std::cout << m_measurements(cc,0) << " ";
-   }
-   std::cout << "\n";
+    if( m_currents[0] < -1e14 )
+        return 0;
 
-   if(m_currents[0] < -1e14) return 0;
+    m_commands.matrix() = m_intMat.matrix() * m_measurements.matrix();
 
-   m_commands.matrix() = m_intMat.matrix() * m_measurements.matrix();
+    std::cout << "delta commands:    ";
+    for( int cc = 0; cc < m_measurements.rows(); ++cc )
+    {
+        std::cout << -m_commands( cc, 0 ) << " ";
+    }
+    std::cout << "\n";
 
+    std::vector<float> commands;
+    commands.resize( m_measurements.rows() );
 
+    std::cout << "commands:    ";
+    for( int cc = 0; cc < m_measurements.rows(); ++cc )
+    {
+        commands[cc] = m_currents[cc] - m_ggain * m_gains[cc] * m_commands( cc, 0 );
+        std::cout << commands[cc] << " ";
+    }
+    std::cout << "\n";
 
-   std::cout << "delta commands:    ";
-   for(int cc = 0; cc < m_measurements.rows(); ++cc)
-   {
-      std::cout << -m_commands(cc,0) << " ";
-   }
-   std::cout << "\n";
+    // And send commands.
+    int rv;
+    if( m_ctrlEnabled )
+    {
+        rv = sendCommands( commands );
+    }
+    else
+    {
+        rv = 0;
+    }
 
-   std::vector<float> commands;
-   commands.resize(m_measurements.rows());
-
-   std::cout << "commands:    ";
-   for(int cc = 0; cc < m_measurements.rows(); ++cc)
-   {
-      commands[cc] = m_currents[cc] - m_ggain*m_gains[cc]*m_commands(cc,0);
-      std::cout << commands[cc] << " ";
-   }
-   std::cout << "\n";
-
-   //And send commands.
-   int rv;
-   if(m_ctrlEnabled)
-   {
-      rv = sendCommands(commands);
-   }
-   else
-   {
-      rv = 0;
-   }
-
-   updateIfChanged(m_indiP_deltas, std::vector<std::string>({"delta0", "delta1"}), std::vector<float>({m_delta0, m_delta1}));
-   return rv;
+    updateIfChanged( m_indiP_deltas,
+                     std::vector<std::string>( { "delta0", "delta1" } ),
+                     std::vector<float>( { m_delta0, m_delta1 } ) );
+    return rv;
 }
 
-inline
-int alignLoop::sendCommands(std::vector<float> & commands)
+inline int alignLoop::sendCommands( std::vector<float> &commands )
 {
-   for(size_t n=0; n < m_ctrlDevices.size(); ++n)
-   {
-      pcf::IndiProperty ip(pcf::IndiProperty::Number);
+    for( size_t n = 0; n < m_ctrlDevices.size(); ++n )
+    {
+        pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-      ip.setDevice(m_ctrlDevices[n]);
-      ip.setName(m_ctrlProperties[n]);
-      ip.add(pcf::IndiElement(m_ctrlTargets[n]));
-      ip[m_ctrlTargets[n]] = commands[n];
+        ip.setDevice( m_ctrlDevices[n] );
+        ip.setName( m_ctrlProperties[n] );
+        ip.add( pcf::IndiElement( m_ctrlTargets[n] ) );
+        ip[m_ctrlTargets[n]] = commands[n];
 
-      sendNewProperty(ip);
-   }
+        sendNewProperty( ip );
+    }
 
-   return 0;
+    return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(alignLoop, m_indiP_ggain)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( alignLoop, m_indiP_ggain )( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getName() != m_indiP_ggain.getName())
-   {
-      log<software_error>({__FILE__, __LINE__, "invalid indi property received"});
-      return -1;
-   }
+    if( ipRecv.getName() != m_indiP_ggain.getName() )
+    {
+        log<software_error>( { __FILE__, __LINE__, "invalid indi property received" } );
+        return -1;
+    }
 
-   float target;
+    float target;
 
-   if( indiTargetUpdate( m_indiP_ggain, target, ipRecv, true) < 0)
-   {
-      log<software_error>({__FILE__,__LINE__});
-      return -1;
-   }
+    if( indiTargetUpdate( m_indiP_ggain, target, ipRecv, true ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
 
-   m_ggain = target;
+    m_ggain = target;
 
-   updateIfChanged(m_indiP_ggain, "current", m_ggain);
-   updateIfChanged(m_indiP_ggain, "target", m_ggain);
+    updateIfChanged( m_indiP_ggain, "current", m_ggain );
+    updateIfChanged( m_indiP_ggain, "target", m_ggain );
 
-   log<text_log>("set global gain to " + std::to_string(m_ggain), logPrio::LOG_NOTICE);
+    log<text_log>( "set global gain to " + std::to_string( m_ggain ), logPrio::LOG_NOTICE );
 
-   return 0;
+    return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(alignLoop, m_indiP_ctrlEnabled)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( alignLoop, m_indiP_ctrlEnabled )( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getName() != m_indiP_ctrlEnabled.getName())
-   {
-      log<software_error>({__FILE__, __LINE__, "invalid indi property received"});
-      return -1;
-   }
+    if( ipRecv.getName() != m_indiP_ctrlEnabled.getName() )
+    {
+        log<software_error>( { __FILE__, __LINE__, "invalid indi property received" } );
+        return -1;
+    }
 
-   //switch is toggled to on
-   if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On)
-   {
-      return toggleLoop(true);
-   }
+    // switch is toggled to on
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
+    {
+        return toggleLoop( true );
+    }
 
-   //switch is toggle to off
-   if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off)
-   {
-      return toggleLoop(false);
-   }
+    // switch is toggle to off
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
+    {
+        return toggleLoop( false );
+    }
 
-   return 0;
+    return 0;
 }
 
-inline
-int alignLoop::setCallBack_ctrl(const pcf::IndiProperty &ipRecv)
+inline int alignLoop::setCallBack_ctrl( const pcf::IndiProperty &ipRecv )
 {
-   for(size_t n = 0; n < m_ctrlDevices.size(); ++n)
-   {
-      if( ipRecv.getDevice() == m_ctrlDevices[n])
-      {
-         if(ipRecv.getName() == m_ctrlProperties[n] && ipRecv.find(m_ctrlCurrents[n]))
-         {
-            m_currents[n] = ipRecv[m_ctrlCurrents[n]].get<float>();
-         }
-      }
-   }
+    for( size_t n = 0; n < m_ctrlDevices.size(); ++n )
+    {
+        if( ipRecv.getDevice() == m_ctrlDevices[n] )
+        {
+            if( ipRecv.getName() == m_ctrlProperties[n] && ipRecv.find( m_ctrlCurrents[n] ) )
+            {
+                m_currents[n] = ipRecv[m_ctrlCurrents[n]].get<float>();
+            }
+        }
+    }
 
-   return 0;
+    return 0;
 }
 
-INDI_SETCALLBACK_DEFN(alignLoop, m_indiP_upstream)(const pcf::IndiProperty &ipRecv)
+INDI_SETCALLBACK_DEFN( alignLoop, m_indiP_upstream )( const pcf::IndiProperty &ipRecv )
 {
-   if(ipRecv.getName() != m_indiP_upstream.getName())
-   {
-      return log<software_error>({__FILE__,__LINE__, "wrong INDI property received"});
-   }
+    if( ipRecv.getName() != m_indiP_upstream.getName() )
+    {
+        return log<software_error>( { __FILE__, __LINE__, "wrong INDI property received" } );
+    }
 
-   if(!ipRecv.find("toggle")) return 0;
+    if( !ipRecv.find( "toggle" ) )
+        return 0;
 
-   if(ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_upstreamFollowClosed)
-   {
-      std::cerr << "upstream on\n";
-      return toggleLoop(true);
-   }
-   else if(ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off)
-   {
-      std::cerr << "upstream off\n";
-      return toggleLoop(false);
-   }
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_upstreamFollowClosed )
+    {
+        std::cerr << "upstream on\n";
+        return toggleLoop( true );
+    }
+    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
+    {
+        std::cerr << "upstream off\n";
+        return toggleLoop( false );
+    }
 
-   return 0;
+    return 0;
 }
 
+} // namespace app
+} // namespace MagAOX
 
-} //namespace app
-} //namespace MagAOX
-
-#endif //alignLoop_hpp
+#endif // alignLoop_hpp

--- a/apps/closedLoopIndi/closedLoopIndi.hpp
+++ b/apps/closedLoopIndi/closedLoopIndi.hpp
@@ -1,28 +1,27 @@
 /** \file closedLoopIndi.hpp
-  * \brief The MagAO-X INDI Closed Loop header file
-  *
-  * \ingroup closedLoopIndi_files
-  */
+ * \brief The MagAO-X INDI Closed Loop header file
+ *
+ * \ingroup closedLoopIndi_files
+ */
 
 #ifndef closedLoopIndi_hpp
 #define closedLoopIndi_hpp
-
 
 #include "../../libMagAOX/libMagAOX.hpp" //Note this is included on command line to trigger pch
 #include "../../magaox_git_version.h"
 
 /** \defgroup closedLoopIndi
-  * \brief The MagAO-X application to do closed-loop control using INDI properties
-  *
-  * <a href="../handbook/operating/software/apps/closedLoopIndi.html">Application Documentation</a>
-  *
-  * \ingroup apps
-  *
-  */
+ * \brief The MagAO-X application to do closed-loop control using INDI properties
+ *
+ * <a href="../handbook/operating/software/apps/closedLoopIndi.html">Application Documentation</a>
+ *
+ * \ingroup apps
+ *
+ */
 
 /** \defgroup closedLoopIndi_files
-  * \ingroup closedLoopIndi
-  */
+ * \ingroup closedLoopIndi
+ */
 
 namespace MagAOX
 {
@@ -31,32 +30,39 @@ namespace app
 
 /// The MagAO-X application to do closed-loop control using INDI properties
 /**
-  * \ingroup closedLoopIndi
-  */
+ * \ingroup closedLoopIndi
+ */
 class closedLoopIndi : public MagAOXApp<true>
 {
-   //Give the test harness access.
-   friend class closedLoopIndi_test;
+    // Give the test harness access.
+    friend class closedLoopIndi_test;
 
-protected:
-
+  protected:
     /** \name Configurable Parameters
-      *@{
-      */
+     *@{
+     */
 
-    std::string m_inputDevice;                           ///< The device with the input disturbances and frame counter.
-    std::string m_inputProperty;                         ///< The property with the input disturbances and frame counter.
-    std::vector<std::string> m_inputElements {"x", "y"}; ///< The elements with the input disturbances.  Must be two, defaults are "x" and "y".
-    std::string m_inputCounterElement {"counter"};       ///< The element with the frame counter, a monotonically increasing integer. Default is "counter".
+    std::string              m_inputDevice;   ///< The device with the input disturbances and frame counter.
+    std::string              m_inputProperty; ///< The property with the input disturbances and frame counter.
+    std::vector<std::string> m_inputElements{
+        "x", "y" }; ///< The elements with the input disturbances.  Must be two, defaults are "x" and "y".
+    std::string m_inputCounterElement{
+        "counter" }; ///< The element with the frame counter, a monotonically increasing integer. Default is "counter".
 
-    std::vector<std::string> m_ctrlDevices;                         ///< Device names of the controller(s). If only one, it's used for both properties.  Max two.
-    std::vector<std::string> m_ctrlProperties;                      ///< Properties of the ctrl device(s) to which to give the commands. Must specify two.
-    std::vector<std::string> m_ctrlCurrents {"current", "current"}; ///< current elements of the properties on which to base the commands. Must specify 0 or 2. Default is 'current'.
-    std::vector<std::string> m_ctrlTargets {"target", "target"};    ///< target elements of the properties to which to send the commands. Must specify 0 or 2. Default is 'target'.
+    std::vector<std::string>
+        m_ctrlDevices; ///< Device names of the controller(s). If only one, it's used for both properties.  Max two.
+    std::vector<std::string>
+        m_ctrlProperties; ///< Properties of the ctrl device(s) to which to give the commands. Must specify two.
+    std::vector<std::string> m_ctrlCurrents{ "current",
+                                             "current" }; ///< current elements of the properties on which to base the
+                                                          ///< commands. Must specify 0 or 2. Default is 'current'.
+    std::vector<std::string> m_ctrlTargets{ "target",
+                                            "target" }; ///< target elements of the properties to which to send the
+                                                        ///< commands. Must specify 0 or 2. Default is 'target'.
 
     mx::improc::eigenImage<float> m_references; ///< The reference values of the disturbances
 
-    bool m_operatingOK {false}; ///< If true then it's ok for the ctrl device to be OPERATING when a command is sent
+    bool m_operatingOK{ false }; ///< If true then it's ok for the ctrl device to be OPERATING when a command is sent
 
     std::unordered_map<std::string, std::string> m_fsmStates; ///< The FSM states of the control devices.
 
@@ -66,215 +72,367 @@ protected:
 
     std::vector<float> m_defaultGains; ///< The default gains, per-axis
 
-    std::string m_upstreamDevice;                  ///< The upstream device to monitor to automatically open this loop if it's loop opens
-    std::string m_upstreamProperty {"loop_state"}; ///< The name of the toggle switch to monitor
+    std::string m_upstreamDevice; ///< The upstream device to monitor to automatically open this loop if it's loop opens
+    std::string m_upstreamProperty{ "loop_state" }; ///< The name of the toggle switch to monitor
+    bool        m_upstreamFollowClosed{ false };    ///< If true, this loop also closes when the upstream loop closes.
 
     ///@}
 
-    int64_t m_counter = -1; ///< The latest value of the loop counter
+    int64_t                       m_counter = -1; ///< The latest value of the loop counter
     mx::improc::eigenImage<float> m_measurements; ///< The latest value of the measurements
-    float m_delta0 {0};
-    float m_delta1 {0};
+    float                         m_delta0{ 0 };  ///< Latest first-axis residual.
+    float                         m_delta1{ 0 };  ///< Latest second-axis residual.
 
     mx::improc::eigenImage<float> m_commands; ///< The latest commands
 
-    float m_ggain {0}; ///< The global gain
+    float m_ggain{ 0 }; ///< The global gain
 
     std::vector<float> m_gains; ///< The axis gains
 
-    bool m_loopClosed {false}; ///< Whether or not the loop is closed
+    bool m_loopClosed{ false }; ///< Whether or not the loop is closed
 
-public:
+  public:
     /// Default c'tor.
     closedLoopIndi();
 
     /// D'tor, declared and defined for noexcept.
     ~closedLoopIndi() noexcept
-    {}
+    {
+    }
 
+    /// Set up the app configuration interface.
     virtual void setupConfig();
 
     /// Implementation of loadConfig logic, separated for testing.
     /** This is called by loadConfig().
-      */
-    int loadConfigImpl( mx::app::appConfigurator & _config /**< [in] an application configuration from which to load values*/);
+     */
+    int loadConfigImpl(
+        mx::app::appConfigurator &_config /**< [in] an application configuration from which to load values*/ );
 
+    /// Load the application configuration.
     virtual void loadConfig();
 
     /// Startup function
     /**
-      *
-      */
+     *
+     */
     virtual int appStartup();
 
     /// Implementation of the FSM for closedLoopIndi.
     /**
-      * \returns 0 on no critical error
-      * \returns -1 on an error requiring shutdown
-      */
+     * \returns 0 on no critical error
+     * \returns -1 on an error requiring shutdown
+     */
     virtual int appLogic();
 
     /// Shutdown the app.
     /**
-      *
-      */
+     *
+     */
     virtual int appShutdown();
 
     /// Change the loop state
-    int toggleLoop( bool onoff );
+    int toggleLoop( bool onoff /**< [in] true to close the loop and false to open it */ );
 
     /// Update the loop with a new command
     int updateLoop();
 
     /// Send commands to the control devices
-    int sendCommands(std::vector<float> & commands);
+    int sendCommands( std::vector<float> &commands /**< [in] command values to transmit */ );
 
-    //INDI
+    // INDI
 
-    pcf::IndiProperty m_indiP_deltas;
+    pcf::IndiProperty m_indiP_deltas; ///< Published loop residual values.
 
-    pcf::IndiProperty m_indiP_reference0;
-    INDI_NEWCALLBACK_DECL(closedLoopIndi, m_indiP_reference0);
+    pcf::IndiProperty m_indiP_reference0; ///< INDI property exposing the first reference value.
+    INDI_NEWCALLBACK_DECL( closedLoopIndi, m_indiP_reference0 );
 
-    pcf::IndiProperty m_indiP_reference1;
-    INDI_NEWCALLBACK_DECL(closedLoopIndi, m_indiP_reference1);
+    pcf::IndiProperty m_indiP_reference1; ///< INDI property exposing the second reference value.
+    INDI_NEWCALLBACK_DECL( closedLoopIndi, m_indiP_reference1 );
 
-    pcf::IndiProperty m_indiP_inputs;
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_inputs);
+    pcf::IndiProperty m_indiP_inputs; ///< INDI property monitored for incoming disturbances.
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_inputs );
 
-    pcf::IndiProperty m_indiP_ggain;
-    INDI_NEWCALLBACK_DECL(closedLoopIndi, m_indiP_ggain);
+    pcf::IndiProperty m_indiP_ggain; ///< INDI property exposing the global loop gain.
+    INDI_NEWCALLBACK_DECL( closedLoopIndi, m_indiP_ggain );
 
-    pcf::IndiProperty m_indiP_ctrlEnabled;
-    INDI_NEWCALLBACK_DECL(closedLoopIndi, m_indiP_ctrlEnabled);
+    pcf::IndiProperty m_indiP_ctrlEnabled; ///< INDI property exposing the loop open/closed state.
+    INDI_NEWCALLBACK_DECL( closedLoopIndi, m_indiP_ctrlEnabled );
 
-    pcf::IndiProperty m_indiP_counterReset;
-    INDI_NEWCALLBACK_DECL(closedLoopIndi, m_indiP_counterReset);
+    pcf::IndiProperty m_indiP_counterReset; ///< INDI property used to request a counter reset.
+    INDI_NEWCALLBACK_DECL( closedLoopIndi, m_indiP_counterReset );
 
     pcf::IndiProperty m_indiP_ctrl0_fsm; ///< The INDI property for fsm state of axis 0
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_ctrl0_fsm);
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_ctrl0_fsm );
 
     pcf::IndiProperty m_indiP_ctrl0; ///< The INDI property used for control of axis 0
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_ctrl0);
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_ctrl0 );
 
     pcf::IndiProperty m_indiP_ctrl1_fsm; ///< The INDI property for fsm state of axis 1
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_ctrl1_fsm);
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_ctrl1_fsm );
 
     pcf::IndiProperty m_indiP_ctrl1; ///< The INDI property used for control of axis 1
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_ctrl1);
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_ctrl1 );
 
-    pcf::IndiProperty m_indiP_upstream; ///< Property used to report the upstream loop state
-    INDI_SETCALLBACK_DECL(closedLoopIndi, m_indiP_upstream);
+    pcf::IndiProperty m_indiP_upstream; ///< Property used to monitor the upstream loop state.
+    INDI_SETCALLBACK_DECL( closedLoopIndi, m_indiP_upstream );
 };
 
-closedLoopIndi::closedLoopIndi() : MagAOXApp(MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED)
+closedLoopIndi::closedLoopIndi() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
     return;
 }
 
 void closedLoopIndi::setupConfig()
 {
-    config.add("input.device", "", "input.device", argType::Required, "input", "device", false, "string", "The device with the input disturbances and frame counter.");
-    config.add("input.property", "", "input.property", argType::Required, "input", "property", false, "string", "The property with the input disturbances and counter.");
-    config.add("input.elements", "", "input.elements", argType::Required, "input", "elements", false, "vector<string>", " The elements with the input disturbances.  Must be two, defaults are 'x' and 'y'.");
-    config.add("input.counterElement", "", "input.counterElement", argType::Required, "input", "counterElement", false, "string", "The element with the frame counter, a monotonically increasing integer. Default is 'counter'.");
+    config.add( "input.device",
+                "",
+                "input.device",
+                argType::Required,
+                "input",
+                "device",
+                false,
+                "string",
+                "The device with the input disturbances and frame counter." );
+    config.add( "input.property",
+                "",
+                "input.property",
+                argType::Required,
+                "input",
+                "property",
+                false,
+                "string",
+                "The property with the input disturbances and counter." );
+    config.add( "input.elements",
+                "",
+                "input.elements",
+                argType::Required,
+                "input",
+                "elements",
+                false,
+                "vector<string>",
+                " The elements with the input disturbances.  Must be two, defaults are 'x' and 'y'." );
+    config.add( "input.counterElement",
+                "",
+                "input.counterElement",
+                argType::Required,
+                "input",
+                "counterElement",
+                false,
+                "string",
+                "The element with the frame counter, a monotonically increasing integer. Default is 'counter'." );
 
-    config.add("input.references", "", "input.references", argType::Required, "input", "references", false, "vector<float>", "The reference values for the input disturbances.");
+    config.add( "input.references",
+                "",
+                "input.references",
+                argType::Required,
+                "input",
+                "references",
+                false,
+                "vector<float>",
+                "The reference values for the input disturbances." );
 
-    config.add("ctrl.devices", "", "ctrl.devices", argType::Required, "ctrl", "devices", false, "string", "Device names of the controller(s). If only one, it's used for both properties.  Max two.");
-    config.add("ctrl.properties", "", "ctrl.properties", argType::Required, "ctrl", "properties", false, "string", "Properties of the ctrl device(s) to which to give the commands. Must specify two.");
-    config.add("ctrl.currents", "", "ctrl.currents", argType::Required, "ctrl", "currents", false, "vector<string>", "current elements of the properties on which to base the commands. Must specify 0 or 2. Default is 'current'");
-    config.add("ctrl.targets", "", "ctrl.targets", argType::Required, "ctrl", "targets", false, "vector<string>", "target elements of the properties to which to send the commands. Must specify 0 or 2. Default is 'target'.");
-    config.add("ctrl.operatingOK", "", "ctrl.operatingOK", argType::Required, "ctrl", "operatingOK", false, "bool", "If true then it's ok for the ctrl device to be OPERATING when a command is sent. Default is false.");
+    config.add( "ctrl.devices",
+                "",
+                "ctrl.devices",
+                argType::Required,
+                "ctrl",
+                "devices",
+                false,
+                "string",
+                "Device names of the controller(s). If only one, it's used for both properties.  Max two." );
+    config.add( "ctrl.properties",
+                "",
+                "ctrl.properties",
+                argType::Required,
+                "ctrl",
+                "properties",
+                false,
+                "string",
+                "Properties of the ctrl device(s) to which to give the commands. Must specify two." );
+    config.add(
+        "ctrl.currents",
+        "",
+        "ctrl.currents",
+        argType::Required,
+        "ctrl",
+        "currents",
+        false,
+        "vector<string>",
+        "current elements of the properties on which to base the commands. Must specify 0 or 2. Default is 'current'" );
+    config.add(
+        "ctrl.targets",
+        "",
+        "ctrl.targets",
+        argType::Required,
+        "ctrl",
+        "targets",
+        false,
+        "vector<string>",
+        "target elements of the properties to which to send the commands. Must specify 0 or 2. Default is 'target'." );
+    config.add( "ctrl.operatingOK",
+                "",
+                "ctrl.operatingOK",
+                argType::Required,
+                "ctrl",
+                "operatingOK",
+                false,
+                "bool",
+                "If true then it's ok for the ctrl device to be OPERATING when a command is sent. Default is false." );
 
+    config.add( "loop.intMat00",
+                "",
+                "loop.intMat00",
+                argType::Required,
+                "loop",
+                "intMat00",
+                false,
+                "float",
+                "element (0,0) of the interaction matrix. Default is 1." );
+    config.add( "loop.intMat01",
+                "",
+                "loop.intMat01",
+                argType::Required,
+                "loop",
+                "intMat01",
+                false,
+                "float",
+                "element (0,1) of the interaction matrix. Default is 0." );
+    config.add( "loop.intMat10",
+                "",
+                "loop.intMat10",
+                argType::Required,
+                "loop",
+                "intMat10",
+                false,
+                "float",
+                "element (1,0) of the interaction matrix. Default is 0." );
+    config.add( "loop.intMat11",
+                "",
+                "loop.intMat11",
+                argType::Required,
+                "loop",
+                "intMat11",
+                false,
+                "float",
+                "element (1,1) of the interaction matrix. Default is 1." );
 
-    config.add("loop.intMat00", "", "loop.intMat00", argType::Required, "loop", "intMat00", false, "float", "element (0,0) of the interaction matrix. Default is 1.");
-    config.add("loop.intMat01", "", "loop.intMat01", argType::Required, "loop", "intMat01", false, "float", "element (0,1) of the interaction matrix. Default is 0.");
-    config.add("loop.intMat10", "", "loop.intMat10", argType::Required, "loop", "intMat10", false, "float", "element (1,0) of the interaction matrix. Default is 0.");
-    config.add("loop.intMat11", "", "loop.intMat11", argType::Required, "loop", "intMat11", false, "float", "element (1,1) of the interaction matrix. Default is 1.");
-
-    config.add("loop.gain", "", "loop.gain", argType::Required, "loop", "gain", false, "float", "default global loop gain.");
-    config.add("loop.gains", "", "loop.gains", argType::Required, "loop", "gains", false, "vector<float>", "default loop gains.  If single number, it is applied to all axes.");
-    config.add("loop.upstream", "", "loop.upstream", argType::Required, "loop", "upstream", false, "string", "Upstream loop device name.  This loop will open, and optionally close, with the upstream loop.  Default none.");
-    config.add("loop.upstreamProperty", "", "loop.upstreamProperty", argType::Required, "loop", "upstreamProperty", false, "string", "Property of upstream loop device to follow.  Must be a toggle.  Default is loop_state.");
-
+    config.add(
+        "loop.gain", "", "loop.gain", argType::Required, "loop", "gain", false, "float", "default global loop gain." );
+    config.add( "loop.gains",
+                "",
+                "loop.gains",
+                argType::Required,
+                "loop",
+                "gains",
+                false,
+                "vector<float>",
+                "default loop gains.  If single number, it is applied to all axes." );
+    config.add( "loop.upstream",
+                "",
+                "loop.upstream",
+                argType::Required,
+                "loop",
+                "upstream",
+                false,
+                "string",
+                "Upstream loop device name.  This loop will open, and optionally close, with the upstream loop.  "
+                "Default none." );
+    config.add( "loop.upstreamProperty",
+                "",
+                "loop.upstreamProperty",
+                argType::Required,
+                "loop",
+                "upstreamProperty",
+                false,
+                "string",
+                "Property of upstream loop device to follow.  Must be a toggle.  Default is loop_state." );
+    config.add( "loop.upstreamFollowClosed",
+                "",
+                "loop.upstreamFollowClosed",
+                argType::Required,
+                "loop",
+                "upstreamFollowClosed",
+                false,
+                "bool",
+                "If true, this loop also closes when the upstream loop closes. Default is false." );
 }
 
-int closedLoopIndi::loadConfigImpl( mx::app::appConfigurator & _config )
+int closedLoopIndi::loadConfigImpl( mx::app::appConfigurator &_config )
 {
-    _config(m_inputDevice, "input.device");
-    _config(m_inputProperty, "input.property");
-    _config(m_inputElements, "input.elements");
-    _config(m_inputCounterElement, "input.counterElement");
+    _config( m_inputDevice, "input.device" );
+    _config( m_inputProperty, "input.property" );
+    _config( m_inputElements, "input.elements" );
+    _config( m_inputCounterElement, "input.counterElement" );
 
-    if(m_inputDevice == "")
+    if( m_inputDevice == "" )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "no input device specified"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "no input device specified" } );
     }
 
-    if(m_inputProperty == "")
+    if( m_inputProperty == "" )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "no input property specified"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "no input property specified" } );
     }
 
-    if(m_inputElements.size() != 2)
+    if( m_inputElements.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify only two input.elements"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify only two input.elements" } );
     }
 
-    std::vector<float> refs({0,0});
-    _config(refs, "input.references");
-    if(refs.size() != 2)
+    std::vector<float> refs( { 0, 0 } );
+    _config( refs, "input.references" );
+    if( refs.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "input.references must have 2 elements"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "input.references must have 2 elements" } );
     }
 
-    m_references.resize(2,1);
-    m_references(0,0) = refs[0];
-    m_references(1,0) = refs[1];
+    m_references.resize( 2, 1 );
+    m_references( 0, 0 ) = refs[0];
+    m_references( 1, 0 ) = refs[1];
 
-    _config(m_ctrlDevices, "ctrl.devices");
-    _config(m_ctrlProperties, "ctrl.properties");
-    _config(m_ctrlCurrents, "ctrl.currents");
-    _config(m_ctrlTargets, "ctrl.targets");
-    _config(m_operatingOK, "ctrl.operatingOK");
+    _config( m_ctrlDevices, "ctrl.devices" );
+    _config( m_ctrlProperties, "ctrl.properties" );
+    _config( m_ctrlCurrents, "ctrl.currents" );
+    _config( m_ctrlTargets, "ctrl.targets" );
+    _config( m_operatingOK, "ctrl.operatingOK" );
 
-    if(m_ctrlDevices.size() == 1)
+    if( m_ctrlDevices.size() == 1 )
     {
-        m_ctrlDevices.push_back(m_ctrlDevices[0]);
+        m_ctrlDevices.push_back( m_ctrlDevices[0] );
     }
-    else if(m_ctrlDevices.size() != 2)
-    {
-        m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify two ctrl.devices"});
-    }
-
-    if(m_ctrlProperties.size() != 2)
+    else if( m_ctrlDevices.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify two ctrl.properties"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify two ctrl.devices" } );
     }
 
-    if(m_ctrlTargets.size() != 2)
+    if( m_ctrlProperties.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify two ctrl.targets"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify two ctrl.properties" } );
     }
 
-    if(m_ctrlCurrents.size() != 2)
+    if( m_ctrlTargets.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify two ctrl.currents"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify two ctrl.targets" } );
     }
 
-    if(m_ctrlTargets.size() != 2)
+    if( m_ctrlCurrents.size() != 2 )
     {
         m_shutdown = 1;
-        return log<software_error, -1>({__FILE__, __LINE__, "must specify two ctrl.targets"});
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify two ctrl.currents" } );
+    }
+
+    if( m_ctrlTargets.size() != 2 )
+    {
+        m_shutdown = 1;
+        return log<software_error, -1>( { __FILE__, __LINE__, "must specify two ctrl.targets" } );
     }
 
     float im00 = 1;
@@ -282,97 +440,99 @@ int closedLoopIndi::loadConfigImpl( mx::app::appConfigurator & _config )
     float im10 = 0;
     float im11 = 1;
 
-    _config(im00, "loop.intMat00");
-    _config(im01, "loop.intMat01");
-    _config(im10, "loop.intMat10");
-    _config(im11, "loop.intMat11");
+    _config( im00, "loop.intMat00" );
+    _config( im01, "loop.intMat01" );
+    _config( im10, "loop.intMat10" );
+    _config( im11, "loop.intMat11" );
 
-    m_intMat.resize(2, 2);
-    m_intMat(0,0) = im00;
-    m_intMat(0,1) = im01;
-    m_intMat(1,0) = im10;
-    m_intMat(1,1) = im11;
+    m_intMat.resize( 2, 2 );
+    m_intMat( 0, 0 ) = im00;
+    m_intMat( 0, 1 ) = im01;
+    m_intMat( 1, 0 ) = im10;
+    m_intMat( 1, 1 ) = im11;
 
-    _config(m_ggain, "loop.gain");
+    _config( m_ggain, "loop.gain" );
 
-    _config(m_defaultGains, "loop.gains");
-    _config(m_upstreamDevice, "loop.upstream");
-    _config(m_upstreamProperty, "loop.upstreamProperty");
+    _config( m_defaultGains, "loop.gains" );
+    _config( m_upstreamDevice, "loop.upstream" );
+    _config( m_upstreamProperty, "loop.upstreamProperty" );
+    _config( m_upstreamFollowClosed, "loop.upstreamFollowClosed" );
 
     return 0;
 }
 
 void closedLoopIndi::loadConfig()
 {
-   loadConfigImpl(config);
+    loadConfigImpl( config );
 }
 
 int closedLoopIndi::appStartup()
 {
-    REG_INDI_SETPROP(m_indiP_inputs, m_inputDevice, m_inputProperty);
+    REG_INDI_SETPROP( m_indiP_inputs, m_inputDevice, m_inputProperty );
 
-    CREATE_REG_INDI_RO_NUMBER( m_indiP_deltas, "deltas", "Deltas", "Deltas");
-    m_indiP_deltas.add(pcf::IndiElement("delta0"));
+    CREATE_REG_INDI_RO_NUMBER( m_indiP_deltas, "deltas", "Deltas", "Deltas" );
+    m_indiP_deltas.add( pcf::IndiElement( "delta0" ) );
     m_indiP_deltas["delta0"] = 0;
-    m_indiP_deltas.add(pcf::IndiElement("delta1"));
+    m_indiP_deltas.add( pcf::IndiElement( "delta1" ) );
     m_indiP_deltas["delta1"] = 0;
 
-    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_reference0, "reference0", -1e15, 1e15, 1, "%g", "reference0", "references");
-    m_indiP_reference0["current"] = m_references(0,0);
-    m_indiP_reference0["target"] = m_references(0,0);
+    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_reference0, "reference0", -1e15, 1e15, 1, "%g", "reference0", "references" );
+    m_indiP_reference0["current"] = m_references( 0, 0 );
+    m_indiP_reference0["target"]  = m_references( 0, 0 );
 
-    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_reference1, "reference1", -1e15, 1e15, 1, "%g", "reference1", "references");
-    m_indiP_reference1["current"] = m_references(1,0);
-    m_indiP_reference1["target"] = m_references(1,0);
+    CREATE_REG_INDI_NEW_NUMBERF( m_indiP_reference1, "reference1", -1e15, 1e15, 1, "%g", "reference1", "references" );
+    m_indiP_reference1["current"] = m_references( 1, 0 );
+    m_indiP_reference1["target"]  = m_references( 1, 0 );
 
-    if(m_ctrlTargets.size() != m_defaultGains.size())
+    if( m_ctrlTargets.size() != m_defaultGains.size() )
     {
-        if(m_defaultGains.size()==1)
+        if( m_defaultGains.size() == 1 )
         {
-            m_defaultGains.push_back(m_defaultGains[0]);
-           log<text_log>("Setting loop.gains gains to be same size as ctrl.Targets", logPrio::LOG_NOTICE);
+            m_defaultGains.push_back( m_defaultGains[0] );
+            log<text_log>( "Setting loop.gains gains to be same size as ctrl.Targets", logPrio::LOG_NOTICE );
         }
         else
         {
-           return log<software_error, -1>({__FILE__, __LINE__, "ctrl.Targets and loop.gains are not the same size"});
+            return log<software_error, -1>(
+                { __FILE__, __LINE__, "ctrl.Targets and loop.gains are not the same size" } );
         }
     }
 
-    m_gains.resize(m_defaultGains.size());
-    for(size_t n=0; n < m_defaultGains.size(); ++n) m_gains[n] = m_defaultGains[n];
+    m_gains.resize( m_defaultGains.size() );
+    for( size_t n = 0; n < m_defaultGains.size(); ++n )
+        m_gains[n] = m_defaultGains[n];
 
-    CREATE_REG_INDI_NEW_NUMBERU( m_indiP_ggain, "loop_gain", 0, 1, 0, "%0.2f", "gain", "loop");
+    CREATE_REG_INDI_NEW_NUMBERU( m_indiP_ggain, "loop_gain", 0, 1, 0, "%0.2f", "gain", "loop" );
     m_indiP_ggain["current"] = m_ggain;
-    m_indiP_ggain["target"] = m_ggain;
+    m_indiP_ggain["target"]  = m_ggain;
 
+    CREATE_REG_INDI_NEW_TOGGLESWITCH( m_indiP_ctrlEnabled, "loop_state" );
 
-    CREATE_REG_INDI_NEW_TOGGLESWITCH( m_indiP_ctrlEnabled, "loop_state");
+    CREATE_REG_INDI_NEW_REQUESTSWITCH( m_indiP_counterReset, "counter_reset" );
 
-    CREATE_REG_INDI_NEW_REQUESTSWITCH( m_indiP_counterReset, "counter_reset");
-
-    m_measurements.resize(2,1);
+    m_measurements.resize( 2, 1 );
     m_measurements.setZero();
 
-    m_currents.resize(m_ctrlDevices.size(), -1e15);
+    m_currents.resize( m_ctrlDevices.size(), -1e15 );
 
-    REG_INDI_SETPROP(m_indiP_ctrl0_fsm, m_ctrlDevices[0], "fsm");
+    REG_INDI_SETPROP( m_indiP_ctrl0_fsm, m_ctrlDevices[0], "fsm" );
 
-    REG_INDI_SETPROP(m_indiP_ctrl0, m_ctrlDevices[0], m_ctrlProperties[0]);
+    REG_INDI_SETPROP( m_indiP_ctrl0, m_ctrlDevices[0], m_ctrlProperties[0] );
 
-    if(m_ctrlDevices[1] != m_ctrlDevices[0])
+    if( m_ctrlDevices[1] != m_ctrlDevices[0] )
     {
-        REG_INDI_SETPROP(m_indiP_ctrl1_fsm, m_ctrlDevices[1], "fsm");
+        REG_INDI_SETPROP( m_indiP_ctrl1_fsm, m_ctrlDevices[1], "fsm" );
     }
 
-    REG_INDI_SETPROP(m_indiP_ctrl1, m_ctrlDevices[1], m_ctrlProperties[1]);
+    REG_INDI_SETPROP( m_indiP_ctrl1, m_ctrlDevices[1], m_ctrlProperties[1] );
 
-    m_commands.resize(2, 2);
+    m_commands.resize( 2, 2 );
     m_commands.setZero();
 
-    //Get the loop state for managing offloading
-    if(m_upstreamDevice != "")
+    // Get the loop state for managing offloading
+    if( m_upstreamDevice != "" )
     {
-        REG_INDI_SETPROP(m_indiP_upstream, m_upstreamDevice, m_upstreamProperty);
+        REG_INDI_SETPROP( m_indiP_upstream, m_upstreamDevice, m_upstreamProperty );
     }
 
     return 0;
@@ -380,13 +540,13 @@ int closedLoopIndi::appStartup()
 
 int closedLoopIndi::appLogic()
 {
-    if(m_loopClosed)
+    if( m_loopClosed )
     {
-        state(stateCodes::OPERATING);
+        state( stateCodes::OPERATING );
     }
     else
     {
-        state(stateCodes::READY);
+        state( stateCodes::READY );
     }
 
     return 0;
@@ -397,40 +557,39 @@ int closedLoopIndi::appShutdown()
     return 0;
 }
 
-int closedLoopIndi::toggleLoop(bool onoff)
+int closedLoopIndi::toggleLoop( bool onoff )
 {
-   if(!m_loopClosed && onoff) //not enabled so change
-   {
-      m_loopClosed = true;
-      log<loop_closed>();
-      updateSwitchIfChanged(m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::On, INDI_OK);
-      return 0;
-   }
+    if( !m_loopClosed && onoff ) // not enabled so change
+    {
+        m_loopClosed = true;
+        log<loop_closed>();
+        updateSwitchIfChanged( m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::On, INDI_OK );
+        return 0;
+    }
 
-   if(m_loopClosed && !onoff)
-   {
-      m_loopClosed = false;
-      log<loop_open>();
-      updateSwitchIfChanged(m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::Off, INDI_IDLE);
+    if( m_loopClosed && !onoff )
+    {
+        m_loopClosed = false;
+        log<loop_open>();
+        updateSwitchIfChanged( m_indiP_ctrlEnabled, "toggle", pcf::IndiElement::Off, INDI_IDLE );
 
-      return 0;
-   }
+        return 0;
+    }
 
-   return 0;
+    return 0;
 }
 
-
-inline
-int closedLoopIndi::updateLoop()
+inline int closedLoopIndi::updateLoop()
 {
     bool ready = false;
 
-    //This should only give ready == true if all devices exist and are ready
-    for(size_t n = 0; n < m_ctrlDevices.size(); ++n)
+    // This should only give ready == true if all devices exist and are ready
+    for( size_t n = 0; n < m_ctrlDevices.size(); ++n )
     {
-        if(m_fsmStates.count(m_ctrlDevices[n]) > 0)
+        if( m_fsmStates.count( m_ctrlDevices[n] ) > 0 )
         {
-            if(m_fsmStates[m_ctrlDevices[n]] == "READY" || (m_operatingOK && m_fsmStates[m_ctrlDevices[n]] == "OPERATING")  )
+            if( m_fsmStates[m_ctrlDevices[n]] == "READY" ||
+                ( m_operatingOK && m_fsmStates[m_ctrlDevices[n]] == "OPERATING" ) )
             {
                 ready = true;
             }
@@ -447,112 +606,120 @@ int closedLoopIndi::updateLoop()
         }
     }
 
-    if(ready != true)
+    if( ready != true )
     {
         return 0;
     }
 
-    m_delta0 = m_measurements(0,0) - m_references(0,0);
-    m_delta1 = m_measurements(1,0) - m_references(1,0);
+    m_delta0 = m_measurements( 0, 0 ) - m_references( 0, 0 );
+    m_delta1 = m_measurements( 1, 0 ) - m_references( 1, 0 );
 
-    m_commands.matrix() = m_intMat.matrix() * (m_measurements - m_references).matrix();
+    m_commands.matrix() = m_intMat.matrix() * ( m_measurements - m_references ).matrix();
 
     std::vector<float> commands;
-    commands.resize(m_measurements.rows());
+    commands.resize( m_measurements.rows() );
 
-    for(int cc = 0; cc < m_measurements.rows(); ++cc)
+    for( int cc = 0; cc < m_measurements.rows(); ++cc )
     {
-        commands[cc] = m_currents[cc] - m_ggain*m_gains[cc]*m_commands(cc,0);
+        commands[cc] = m_currents[cc] - m_ggain * m_gains[cc] * m_commands( cc, 0 );
     }
 
-    //And send commands.
+    // And send commands.
     int rv;
-    if(m_loopClosed)
+    if( m_loopClosed )
     {
-        rv = sendCommands(commands);
+        rv = sendCommands( commands );
     }
     else
     {
         rv = 0;
     }
 
-    updateIfChanged(m_indiP_deltas, std::vector<std::string>({"delta0", "delta1"}), std::vector<float>({m_delta0, m_delta1}));
+    updateIfChanged( m_indiP_deltas,
+                     std::vector<std::string>( { "delta0", "delta1" } ),
+                     std::vector<float>( { m_delta0, m_delta1 } ) );
     return rv;
 }
 
-inline
-int closedLoopIndi::sendCommands(std::vector<float> & commands)
+inline int closedLoopIndi::sendCommands( std::vector<float> &commands )
 {
-    for(size_t n=0; n < m_ctrlDevices.size(); ++n)
+    for( size_t n = 0; n < m_ctrlDevices.size(); ++n )
     {
-       pcf::IndiProperty ip(pcf::IndiProperty::Number);
+        pcf::IndiProperty ip( pcf::IndiProperty::Number );
 
-       ip.setDevice(m_ctrlDevices[n]);
-       ip.setName(m_ctrlProperties[n]);
-       ip.add(pcf::IndiElement(m_ctrlTargets[n]));
-       ip[m_ctrlTargets[n]] = commands[n];
+        ip.setDevice( m_ctrlDevices[n] );
+        ip.setName( m_ctrlProperties[n] );
+        ip.add( pcf::IndiElement( m_ctrlTargets[n] ) );
+        ip[m_ctrlTargets[n]] = commands[n];
 
-       sendNewProperty(ip);
+        sendNewProperty( ip );
     }
 
     return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(closedLoopIndi, m_indiP_reference0)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( closedLoopIndi, m_indiP_reference0 )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_reference0);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_reference0 );
 
     float target;
 
-    if( indiTargetUpdate( m_indiP_reference0, target, ipRecv, true) < 0)
+    if( indiTargetUpdate( m_indiP_reference0, target, ipRecv, true ) < 0 )
     {
-       return log<software_error, -1>({__FILE__,__LINE__});
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
     }
 
-    m_references(0,0) = target;
+    m_references( 0, 0 ) = target;
 
-    updateIfChanged(m_indiP_reference0, std::vector<std::string>({"current", "target"}), std::vector<float>({m_references(0,0), m_references(0,0)}));
+    updateIfChanged( m_indiP_reference0,
+                     std::vector<std::string>( { "current", "target" } ),
+                     std::vector<float>( { m_references( 0, 0 ), m_references( 0, 0 ) } ) );
 
-    log<text_log>("set reference0 to " + std::to_string(m_references(0,0)), logPrio::LOG_NOTICE);
+    log<text_log>( "set reference0 to " + std::to_string( m_references( 0, 0 ) ), logPrio::LOG_NOTICE );
 
     return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(closedLoopIndi, m_indiP_reference1)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( closedLoopIndi, m_indiP_reference1 )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_reference1);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_reference1 );
 
     float target;
 
-    if( indiTargetUpdate( m_indiP_reference1, target, ipRecv, true) < 0)
+    if( indiTargetUpdate( m_indiP_reference1, target, ipRecv, true ) < 0 )
     {
-       return log<software_error, -1>({__FILE__,__LINE__});
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
     }
 
-    m_references(1,0) = target;
+    m_references( 1, 0 ) = target;
 
-    updateIfChanged(m_indiP_reference1, std::vector<std::string>({"current", "target"}), std::vector<float>({m_references(1,0), m_references(1,0)}));
+    updateIfChanged( m_indiP_reference1,
+                     std::vector<std::string>( { "current", "target" } ),
+                     std::vector<float>( { m_references( 1, 0 ), m_references( 1, 0 ) } ) );
 
-    log<text_log>("set reference1 to " + std::to_string(m_references(1,0)), logPrio::LOG_NOTICE);
+    log<text_log>( "set reference1 to " + std::to_string( m_references( 1, 0 ) ), logPrio::LOG_NOTICE );
 
     return 0;
 }
 
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_inputs)(const pcf::IndiProperty &ipRecv)
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_inputs )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_inputs)
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_inputs )
 
-    if(!ipRecv.find(m_inputElements[0])) return -1;
-    if(!ipRecv.find(m_inputElements[1])) return -1;
-    if(!ipRecv.find(m_inputCounterElement)) return -1;
+    if( !ipRecv.find( m_inputElements[0] ) )
+        return -1;
+    if( !ipRecv.find( m_inputElements[1] ) )
+        return -1;
+    if( !ipRecv.find( m_inputCounterElement ) )
+        return -1;
 
     int counter = ipRecv[m_inputCounterElement].get<int>();
 
-    if(counter != m_counter)
+    if( counter != m_counter )
     {
-        m_counter = counter;
-        m_measurements(0,0) = ipRecv[m_inputElements[0]].get<float>();
-        m_measurements(1,0) = ipRecv[m_inputElements[1]].get<float>();
+        m_counter              = counter;
+        m_measurements( 0, 0 ) = ipRecv[m_inputElements[0]].get<float>();
+        m_measurements( 1, 0 ) = ipRecv[m_inputElements[1]].get<float>();
 
         return updateLoop();
     }
@@ -560,131 +727,130 @@ INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_inputs)(const pcf::IndiProperty &i
     return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(closedLoopIndi, m_indiP_ggain)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( closedLoopIndi, m_indiP_ggain )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ggain);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ggain );
 
     float target;
 
-    if( indiTargetUpdate( m_indiP_ggain, target, ipRecv, true) < 0)
+    if( indiTargetUpdate( m_indiP_ggain, target, ipRecv, true ) < 0 )
     {
-       log<software_error>({__FILE__,__LINE__});
-       return -1;
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
     }
 
     m_ggain = target;
 
-    updateIfChanged(m_indiP_ggain, "current", m_ggain);
-    updateIfChanged(m_indiP_ggain, "target", m_ggain);
+    updateIfChanged( m_indiP_ggain, "current", m_ggain );
+    updateIfChanged( m_indiP_ggain, "target", m_ggain );
 
-    log<text_log>("set global gain to " + std::to_string(m_ggain), logPrio::LOG_NOTICE);
-
-    return 0;
-}
-
-INDI_NEWCALLBACK_DEFN(closedLoopIndi, m_indiP_ctrlEnabled)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ctrlEnabled);
-
-    //switch is toggled to on
-    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On)
-    {
-       return toggleLoop(true);
-    }
-
-    //switch is toggle to off
-    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off)
-    {
-       return toggleLoop(false);
-    }
+    log<text_log>( "set global gain to " + std::to_string( m_ggain ), logPrio::LOG_NOTICE );
 
     return 0;
 }
 
-INDI_NEWCALLBACK_DEFN(closedLoopIndi, m_indiP_counterReset)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( closedLoopIndi, m_indiP_ctrlEnabled )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_counterReset);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ctrlEnabled );
 
-    //switch is toggled to on
-    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On)
+    // switch is toggled to on
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
     {
-       m_counter = -1;
+        return toggleLoop( true );
     }
 
+    // switch is toggle to off
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
+    {
+        return toggleLoop( false );
+    }
 
     return 0;
 }
 
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_ctrl0_fsm)(const pcf::IndiProperty &ipRecv)
+INDI_NEWCALLBACK_DEFN( closedLoopIndi, m_indiP_counterReset )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ctrl0_fsm);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_counterReset );
 
-    if(ipRecv.find("state"))
+    // switch is toggled to on
+    if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+    {
+        m_counter = -1;
+    }
+
+    return 0;
+}
+
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_ctrl0_fsm )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ctrl0_fsm );
+
+    if( ipRecv.find( "state" ) )
     {
         m_fsmStates[ipRecv.getDevice()] = ipRecv["state"].get();
     }
 
-   return 0;
+    return 0;
 }
 
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_ctrl0)(const pcf::IndiProperty &ipRecv)
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_ctrl0 )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ctrl0);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ctrl0 );
 
-    if(ipRecv.find(m_ctrlCurrents[0]))
+    if( ipRecv.find( m_ctrlCurrents[0] ) )
     {
         m_currents[0] = ipRecv[m_ctrlCurrents[0]].get<float>();
     }
 
-   return 0;
+    return 0;
 }
 
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_ctrl1_fsm)(const pcf::IndiProperty &ipRecv)
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_ctrl1_fsm )( const pcf::IndiProperty &ipRecv )
 {
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ctrl1_fsm);
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ctrl1_fsm );
 
-    if(ipRecv.find("state"))
+    if( ipRecv.find( "state" ) )
     {
         m_fsmStates[ipRecv.getDevice()] = ipRecv["state"].get();
-    }
-
-   return 0;
-}
-
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_ctrl1)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_ctrl1);
-
-    if(ipRecv.find(m_ctrlCurrents[1]))
-    {
-        m_currents[1] = ipRecv[m_ctrlCurrents[1]].get<float>();
-    }
-
-   return 0;
-}
-
-INDI_SETCALLBACK_DEFN(closedLoopIndi, m_indiP_upstream)(const pcf::IndiProperty &ipRecv)
-{
-    INDI_VALIDATE_CALLBACK_PROPS(ipRecv, m_indiP_upstream);
-
-    if(!ipRecv.find("toggle")) return 0;
-
-    if(ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On)
-    {
-       std::cerr << "upstream on\n";
-       return toggleLoop(true);
-    }
-    else if(ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off)
-    {
-       std::cerr << "upstream off\n";
-       return toggleLoop(false);
     }
 
     return 0;
 }
 
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_ctrl1 )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_ctrl1 );
 
-} //namespace app
-} //namespace MagAOX
+    if( ipRecv.find( m_ctrlCurrents[1] ) )
+    {
+        m_currents[1] = ipRecv[m_ctrlCurrents[1]].get<float>();
+    }
 
-#endif //closedLoopIndi_hpp
+    return 0;
+}
+
+INDI_SETCALLBACK_DEFN( closedLoopIndi, m_indiP_upstream )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( ipRecv, m_indiP_upstream );
+
+    if( !ipRecv.find( "toggle" ) )
+        return 0;
+
+    if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_upstreamFollowClosed )
+    {
+        std::cerr << "upstream on\n";
+        return toggleLoop( true );
+    }
+    else if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off )
+    {
+        std::cerr << "upstream off\n";
+        return toggleLoop( false );
+    }
+
+    return 0;
+}
+
+} // namespace app
+} // namespace MagAOX
+
+#endif // closedLoopIndi_hpp


### PR DESCRIPTION
This work was performed by GPT-5 in response to the prompt: "in alignLoop there is a flag m_upstreamFollowClosed. We need to add the same flag to closedLoopIndi (wiht same default) and in both apps add ability to configure this."

## Summary
- add `loop.upstreamFollowClosed` as a configurable parameter in `alignLoop`
- add the same `m_upstreamFollowClosed` flag and `loop.upstreamFollowClosed` config to `closedLoopIndi`
- make `closedLoopIndi` follow upstream loop closure only when `loop.upstreamFollowClosed = true`
- preserve the default behavior by leaving the new flag defaulted to `false`

## Validation
- ran `clang-format` on touched headers
- verified behavior on the instrument

## Notes
- upstream `Off` still opens the downstream loop in both apps
- downstream closing on upstream `On` is now opt-in via configuration
