### PR TITLE
Jrmales/strehl estimator optimum speed

### DIFF
--- a/agents/plans/2026-04/strehlEstimator_optimum_speed.md
+++ b/agents/plans/2026-04/strehlEstimator_optimum_speed.md
@@ -1,0 +1,109 @@
+We need to add a tool to strehlEstimator that shows the optimum loop speed given star brightness.  This should be calculated at 100 Hz intervals from 100 Hz to 3000 Hz.  To support using this for planning, we need a new INDI element to the `star_mag` property called 'estimated', add a property to report `seeing` with `current` and `estimated`, and a `wind_speed` property with `current` and `estimated`.   We need a toggle switch for `use_estimates`.  When on, the estimated values are used. When off, the current values are used.  For `star_mag` and `seeing` the current values should be kept up to date with the on-line values.  For `wind_speed` `current` should just mirror `estimated`.
+
+Please review AGENTS.md, then make a plan to implement this new tool.  Fill in this document with the plan below, but do not edit this prompt.  Do not make begin implementing until I have review the plan.
+
+Plan:
+1. Review the current `strehlEstimator` implementation and keep the existing live behavior intact while adding a planning path on top of it.
+   The current app is a header-only MagAO-X app that already:
+   - derives live star magnitude from WFS counts in `calcMag()`
+   - subscribes to live `fps`, `emgain`, beamsplitter stage, TCS seeing, and telescope elevation
+   - computes predicted Strehl and WFE in `appLogic()` using `m_aosys`
+   The implementation should preserve that existing live path, stage-dependent photometric calibration, and current INDI output names unless a new planning surface specifically requires a new property.
+
+2. Split the atmospheric/planning inputs into explicit `current`, `estimated`, and selected values so the `use_estimates` toggle has a single well-defined effect.
+   The planned runtime state is:
+   - `star_mag.current`: still driven by WFS counts and camera settings
+   - `star_mag.estimated`: operator-entered planning value
+   - `seeing.current`: still driven by the live `tcsi.seeing.dimm_fwhm_corr` feed
+   - `seeing.estimated`: operator-entered planning value
+   - `wind_speed.estimated`: operator-entered planning value
+   - `wind_speed.current`: mirrored from `estimated`, per the prompt, with no new external wind subscription in this change
+   - `use_estimates`: boolean switch that selects whether predicted performance calculations use the live/current or estimated inputs
+   To keep the logic easy to reason about, the implementation should add helper accessors or a small update helper that returns the selected star magnitude, selected seeing, selected wind speed, and the derived `r0` used by `m_aosys`.
+
+3. Expand the INDI interface so the planning inputs can actually be edited online.
+   The current `star_mag` property is read-only and only exposes `current`, so it cannot support the requested `estimated` input without being reworked.
+   The plan is to:
+   - convert `star_mag` from a read-only number property to a writable/custom number property that still publishes `current` but accepts `estimated`
+   - add a writable `seeing` number property with `current` and `estimated`
+   - add a writable `wind_speed` number property with `current` and `estimated`
+   - add a writable `use_estimates` toggle switch
+   - keep the properties in the existing Error Budget/operator-facing area unless a better local group name is already in use nearby
+   Because the prompt explicitly asks for `current` and `estimated` element names rather than the usual `current` and `target`, this likely needs explicit property construction and `registerIndiPropertyNew(...)` callbacks rather than the standard `CREATE_REG_INDI_NEW_NUMBER*` helpers that assume `target`.
+
+4. Reuse the existing live properties where that keeps the change smaller, and keep the new callback behavior narrow and predictable.
+   The current plan is:
+   - continue using `m_indiP_mag` for `star_mag`
+   - repurpose the already-declared `m_indiP_seeing_magaox` member for the new local `seeing` property rather than introducing a redundant second seeing member
+   - add one new `pcf::IndiProperty` for `wind_speed`
+   - add one new `pcf::IndiProperty` for `use_estimates`
+   Callback rules should be:
+   - operator writes update only the `estimated` element, never `current`
+   - writes to `current` are ignored or overwritten on the next update cycle
+   - changing `wind_speed.estimated` updates both `estimated` and `current`
+   - changing `use_estimates` immediately changes which inputs are fed into the predicted-performance calculations
+   - invalid operator payloads such as non-finite or non-positive seeing/wind values should be rejected without disturbing the last valid estimate
+
+5. Centralize the AO-model setup so both the current-speed prediction and the new optimum-speed tool use the same selected inputs and the same physical assumptions.
+   The implementation should add a helper that configures an `aoSystem` instance from:
+   - selected star magnitude
+   - selected seeing converted to `r0`
+   - selected wind speed applied through `m_aosys.atm.v_wind(...)`
+   - current elevation, stage-dependent wavelength/flux terms, EM gain, and WFS pixel count
+   - a requested loop speed expressed as `tauWFS = 1 / fps`
+   This keeps the current live prediction and the new scan consistent and avoids duplicating the AO-system setup across `appLogic()` and several callbacks.
+
+6. Implement the optimum loop-speed scan as a discrete sweep from 100 Hz through 3000 Hz in 100 Hz steps, and keep it separate from the live/current-speed prediction.
+   The planned evaluation path is:
+   - keep the existing predicted Strehl/WFE outputs for the actual loop speed, using the selected current-vs-estimated inputs based on `use_estimates`
+   - add a second calculation path that evaluates the same AO model at each candidate speed in the fixed 100 Hz grid
+   - explicitly set `optTau(false)` for the scan path and set both `minTauWFS` and `tauWFS` to the sampled `1 / fps` value so the scan honors the requested discrete rates instead of letting the analytic model optimize continuously
+   - use a local `aoSystem` copy or a temporary model object for the scan so the sweep does not perturb the live `m_aosys` state used for the current-speed outputs
+   - choose the best sampled speed by maximum Strehl; on exact ties, keep the first maximum encountered so the lower FPS wins ties deterministically
+
+7. Publish the scan result through a new read-only summary property rather than exploding the INDI surface with thirty per-speed elements in the first pass.
+   The initial plan is to add one new read-only property, tentatively named something like `loop_speed_optimum`, containing at least:
+   - `fps`
+   - `strehl`
+   - `wfe_total`
+   - optionally `wfe_measurement`, `wfe_time_delay`, and `wfe_fitting` if the extra breakdown is useful to operators and mirrors the existing `wfe_predicted` property
+   This keeps the first implementation focused on the requested operator question, "what speed is best?", while still computing the full 100-3000 Hz sweep internally.
+   If later review says operators also need the full sampled curve, the scan helper from this change can be extended to populate an additional per-FPS property without redesigning the core logic.
+
+8. Make sure the update triggers are broad enough that both the live/current-speed prediction and the optimum-speed summary stay fresh as conditions change.
+   After this change, recalculation should occur when any of the following change:
+   - WFS counts or mask-derived `npix`
+   - `fps`
+   - `emgain`
+   - beamsplitter preset / photometric calibration branch
+   - TCS seeing
+   - telescope elevation
+   - any operator-entered `estimated` value
+   - `use_estimates`
+   This can likely be implemented by keeping the existing callback updates and having them call a common "refresh predictions" helper or by continuing to recalculate in `appLogic()` while only updating the underlying state in callbacks.
+
+9. Add unit-test coverage for the new input-selection and optimum-speed behavior instead of leaving the file as a placeholder harness.
+   The intended test coverage is:
+   - default construction still succeeds
+   - the new writable INDI properties are created with the expected elements
+   - `star_mag.current` continues to track `calcMag()` while `star_mag.estimated` remains operator-controlled
+   - live TCS seeing updates only `seeing.current`
+   - wind-speed writes mirror `estimated` into `current`
+   - `use_estimates` flips the selected inputs used by the prediction path
+   - invalid estimated seeing/wind payloads are rejected cleanly
+   - the optimum-speed helper scans only the requested discrete 100 Hz grid
+   - the optimum-speed helper returns the best sampled FPS with deterministic tie handling
+   - stage and camera-setting changes still propagate into the predictions
+   The test file should also be brought up to the current documentation style across the full file, including per-`TEST_CASE` Doxygen blocks and any needed Doxygen-only symbol references if the test harness hides the real API under test.
+
+10. Run the normal cleanup and verification steps after implementation.
+   The planned verification pass is:
+   - run `clang-format` on touched source/header/test files
+   - build the `strehlEstimator` unit-test target
+   - run the relevant `strehlEstimator` tests
+   - if an interactive INDI smoke test is practical, confirm that `star_mag`, `seeing`, `wind_speed`, `use_estimates`, and the new optimum-speed summary property all update as expected while toggling between live and estimated inputs
+
+Assumptions captured in this plan:
+- `seeing.current` should continue to come from `tcsi.seeing.dimm_fwhm_corr` in this change.  The existing `mag1`/`mag2` seeing fields can remain unused until there is a separate request to choose among them.
+- `wind_speed.current` intentionally mirrors `wind_speed.estimated`; no new TCS or telemetry wind feed is planned here.
+- The first implementation should publish the best sampled operating point, not the entire 30-point curve, unless review says the extra surface is needed immediately.

--- a/agents/plans/2026-04/strehlEstimator_optimum_speed.md
+++ b/agents/plans/2026-04/strehlEstimator_optimum_speed.md
@@ -107,3 +107,6 @@ Assumptions captured in this plan:
 - `seeing.current` should continue to come from `tcsi.seeing.dimm_fwhm_corr` in this change.  The existing `mag1`/`mag2` seeing fields can remain unused until there is a separate request to choose among them.
 - `wind_speed.current` intentionally mirrors `wind_speed.estimated`; no new TCS or telemetry wind feed is planned here.
 - The first implementation should publish the best sampled operating point, not the entire 30-point curve, unless review says the extra surface is needed immediately.
+
+Implementation note:
+- The delivered follow-up UI changed `wind_speed` from a numeric `current`/`estimated` property to a one-of-many switch with `slow`, `normal`, and `fast` options mapped to `9.4`, `18.7`, and `23.4` m/s.

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -8,6 +8,7 @@
 #define strehlEstimator_hpp
 
 #include <cmath>
+#include <mutex>
 
 #include <mx/ao/analysis/aoSystem.hpp>
 using namespace mx::math;
@@ -207,6 +208,9 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Seconds since midnight of the latest MAG2 measurement.
     int m_mag2_time{ 0 };
 
+    /// Protects the live telemetry and planning-input state while prediction snapshots are assembled.
+    mutable std::mutex m_stateMutex;
+
     ///@}
 
   public:
@@ -260,6 +264,61 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Recalculate the live guide-star magnitude from the current WFS counts.
     void calcMag();
 
+    /// Snapshot of the scalar inputs used to update the AO prediction model.
+    struct predictionInputs
+    {
+        /// Live loop speed in Hz.
+        float m_fps{ 0.0f };
+
+        /// Live EM gain.
+        float m_emg{ 0.0f };
+
+        /// Active quantum efficiency.
+        float m_qe{ 0.0f };
+
+        /// Active zero-magnitude photon flux.
+        float m_F0{ 0.0f };
+
+        /// Active wavelength in microns.
+        float m_lam0{ 0.0f };
+
+        /// Telescope elevation in degrees.
+        float m_elevation{ 0.0f };
+
+        /// Current illuminated WFS-pixel count.
+        int m_npix{ 0 };
+
+        /// Live guide-star magnitude.
+        float m_mag{ 0.0f };
+
+        /// Operator-entered guide-star magnitude estimate.
+        float m_magEstimated{ 0.0f };
+
+        /// Selected guide-star magnitude used for prediction.
+        float m_selectedMag{ 0.0f };
+
+        /// Live seeing in arcseconds.
+        float m_seeing{ 0.0f };
+
+        /// Operator-entered seeing estimate in arcseconds.
+        float m_seeingEstimated{ 0.0f };
+
+        /// Selected seeing used for prediction.
+        float m_selectedSeeing{ 0.0f };
+
+        /// Operator-entered wind-speed estimate in m/s.
+        float m_windSpeedEstimated{ 0.0f };
+
+        /// Selected wind speed used for prediction.
+        float m_selectedWindSpeed{ 0.0f };
+
+        /// Whether estimated planning inputs are currently selected.
+        bool m_useEstimates{ false };
+    };
+
+    /// Snapshot the scalar state used by the planning properties and AO-model calculations.
+    predictionInputs snapshotPredictionInputs() const;
+
     /// Return the selected star magnitude for prediction calculations.
     float selectedStarMag() const;
 
@@ -278,8 +337,10 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Return whether a value is finite and strictly positive.
     static bool finitePositiveValue( float value /**< [in] value to test */ );
 
-    /// Convert AO model phase variance into WFE in nm RMS at the active wavelength.
-    float wfeNm( float variance /**< [in] phase variance at the science wavelength */ ) const;
+    /// Convert AO model phase variance into WFE in nm RMS at the specified wavelength.
+    static float wfeNm( float variance, /**< [in] phase variance at the science wavelength */
+                        float lam0      /**< [in] active wavelength in microns */
+    );
 
     /// Create a writable number property with `current` and `estimated` elements.
     int createCurrentEstimatedProperty( pcf::IndiProperty &prop,  /**< [out] property to initialize */
@@ -292,16 +353,17 @@ class strehlEstimator : public MagAOXApp<true>,
     void updatePlanningProperties();
 
     /// Configure an AO model for the selected inputs and requested loop speed.
-    void configureAoSystem( aoSystemT &aosys,      /**< [in,out] AO model instance to configure */
-                            float      fps,        /**< [in] loop speed in Hz */
-                            bool       optimizeTau /**< [in] true to preserve the current optimal-tau behavior */
+    void configureAoSystem( aoSystemT              &aosys,  /**< [in,out] AO model instance to configure */
+                            const predictionInputs &inputs, /**< [in] scalar state snapshot to apply */
+                            float                   fps,    /**< [in] loop speed in Hz */
+                            bool optimizeTau /**< [in] true to preserve the current optimal-tau behavior */
     );
 
     /// Refresh the predicted Strehl, WFE, and optimum-loop-speed properties.
     void updatePredictionOutputs();
 
     /// Refresh the fixed-grid optimum-loop-speed summary property.
-    void updateOptimumLoopSpeed();
+    void updateOptimumLoopSpeed( const predictionInputs &inputs /**< [in] scalar state snapshot to evaluate */ );
 
     /** \name INDI - Data
      * @{
@@ -475,6 +537,8 @@ int strehlEstimator::createCurrentEstimatedProperty( pcf::IndiProperty &prop,
 
 float strehlEstimator::selectedStarMag() const
 {
+    std::lock_guard<std::mutex> lock( m_stateMutex );
+
     if( m_useEstimates )
     {
         return m_magEstimated;
@@ -485,6 +549,8 @@ float strehlEstimator::selectedStarMag() const
 
 float strehlEstimator::selectedSeeing() const
 {
+    std::lock_guard<std::mutex> lock( m_stateMutex );
+
     if( m_useEstimates )
     {
         return m_seeingEstimated;
@@ -495,7 +561,46 @@ float strehlEstimator::selectedSeeing() const
 
 float strehlEstimator::selectedWindSpeed() const
 {
+    std::lock_guard<std::mutex> lock( m_stateMutex );
     return m_windSpeedEstimated;
+}
+
+strehlEstimator::predictionInputs strehlEstimator::snapshotPredictionInputs() const
+{
+    predictionInputs inputs;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+
+        inputs.m_fps                = m_fps;
+        inputs.m_emg                = m_emg;
+        inputs.m_qe                 = m_qe;
+        inputs.m_F0                 = m_F0;
+        inputs.m_lam0               = m_lam0;
+        inputs.m_elevation          = m_elevation;
+        inputs.m_npix               = m_npix;
+        inputs.m_mag                = m_mag;
+        inputs.m_magEstimated       = m_magEstimated;
+        inputs.m_seeing             = m_seeing;
+        inputs.m_seeingEstimated    = m_seeingEstimated;
+        inputs.m_windSpeedEstimated = m_windSpeedEstimated;
+        inputs.m_useEstimates       = m_useEstimates;
+    }
+
+    if( inputs.m_useEstimates )
+    {
+        inputs.m_selectedMag       = inputs.m_magEstimated;
+        inputs.m_selectedSeeing    = inputs.m_seeingEstimated;
+        inputs.m_selectedWindSpeed = inputs.m_windSpeedEstimated;
+    }
+    else
+    {
+        inputs.m_selectedMag       = inputs.m_mag;
+        inputs.m_selectedSeeing    = inputs.m_seeing;
+        inputs.m_selectedWindSpeed = inputs.m_windSpeedEstimated;
+    }
+
+    return inputs;
 }
 
 float strehlEstimator::seeingToR0( float seeing )
@@ -513,66 +618,72 @@ bool strehlEstimator::finitePositiveValue( float value )
     return finiteValue( value ) && value > 0.0f;
 }
 
-float strehlEstimator::wfeNm( float variance ) const
+float strehlEstimator::wfeNm( float variance, float lam0 )
 {
     if( variance <= 0.0f )
     {
         return 0.0f;
     }
 
-    return std::sqrt( variance ) * ( 1000.0f * m_lam0 / two_pi<float>() );
+    return std::sqrt( variance ) * ( 1000.0f * lam0 / two_pi<float>() );
 }
 
 void strehlEstimator::updatePlanningProperties()
 {
+    predictionInputs inputs = snapshotPredictionInputs();
+
     if( !m_indiDriver )
     {
-        m_indiP_mag["current"].set( m_mag );
-        m_indiP_mag["estimated"].set( m_magEstimated );
+        m_indiP_mag["current"].set( inputs.m_mag );
+        m_indiP_mag["estimated"].set( inputs.m_magEstimated );
         m_indiP_mag.setState( INDI_OK );
 
-        m_indiP_seeing_magaox["current"].set( m_seeing );
-        m_indiP_seeing_magaox["estimated"].set( m_seeingEstimated );
+        m_indiP_seeing_magaox["current"].set( inputs.m_seeing );
+        m_indiP_seeing_magaox["estimated"].set( inputs.m_seeingEstimated );
         m_indiP_seeing_magaox.setState( INDI_OK );
 
-        m_indiP_windSpeed["current"].set( m_windSpeedEstimated );
-        m_indiP_windSpeed["estimated"].set( m_windSpeedEstimated );
+        m_indiP_windSpeed["current"].set( inputs.m_windSpeedEstimated );
+        m_indiP_windSpeed["estimated"].set( inputs.m_windSpeedEstimated );
         m_indiP_windSpeed.setState( INDI_OK );
 
-        m_indiP_useEstimates["toggle"].setSwitchState( m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off );
-        m_indiP_useEstimates.setState( m_useEstimates ? INDI_OK : INDI_IDLE );
+        m_indiP_useEstimates["toggle"].setSwitchState( inputs.m_useEstimates ? pcf::IndiElement::On
+                                                                             : pcf::IndiElement::Off );
+        m_indiP_useEstimates.setState( inputs.m_useEstimates ? INDI_OK : INDI_IDLE );
 
         return;
     }
 
-    updatesIfChanged<float>( m_indiP_mag, { "current", "estimated" }, { m_mag, m_magEstimated } );
-    updatesIfChanged<float>( m_indiP_seeing_magaox, { "current", "estimated" }, { m_seeing, m_seeingEstimated } );
+    updatesIfChanged<float>( m_indiP_mag, { "current", "estimated" }, { inputs.m_mag, inputs.m_magEstimated } );
     updatesIfChanged<float>(
-        m_indiP_windSpeed, { "current", "estimated" }, { m_windSpeedEstimated, m_windSpeedEstimated } );
+        m_indiP_seeing_magaox, { "current", "estimated" }, { inputs.m_seeing, inputs.m_seeingEstimated } );
+    updatesIfChanged<float>(
+        m_indiP_windSpeed, { "current", "estimated" }, { inputs.m_windSpeedEstimated, inputs.m_windSpeedEstimated } );
     updateSwitchIfChanged( m_indiP_useEstimates,
                            "toggle",
-                           m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
-                           m_useEstimates ? INDI_OK : INDI_IDLE );
+                           inputs.m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
+                           inputs.m_useEstimates ? INDI_OK : INDI_IDLE );
 }
 
-void strehlEstimator::configureAoSystem( aoSystemT &aosys, float fps, bool optimizeTau )
+void strehlEstimator::configureAoSystem( aoSystemT &aosys, const predictionInputs &inputs, float fps, bool optimizeTau )
 {
     aosys.optTau( optimizeTau );
-    aosys.starMag( selectedStarMag() );
-    aosys.F0( m_qe * m_F0 );
-    aosys.lam_wfs( m_lam0 * 1.0e-6f );
-    aosys.lam_sci( m_lam0 * 1.0e-6f );
-    aosys.ron_wfs( std::vector<float>( { 245.0f / m_emg } ) );
-    aosys.npix_wfs( std::vector<float>( { static_cast<float>( m_npix ) } ) );
+    aosys.starMag( inputs.m_selectedMag );
+    aosys.F0( inputs.m_qe * inputs.m_F0 );
+    aosys.lam_wfs( inputs.m_lam0 * 1.0e-6f );
+    aosys.lam_sci( inputs.m_lam0 * 1.0e-6f );
+    aosys.ron_wfs( std::vector<float>( { 245.0f / inputs.m_emg } ) );
+    aosys.npix_wfs( std::vector<float>( { static_cast<float>( inputs.m_npix ) } ) );
     aosys.minTauWFS( std::vector<float>( { 1.0f / fps } ) );
     aosys.tauWFS( 1.0f / fps );
-    aosys.atm.r_0( seeingToR0( selectedSeeing() ), 0.5e-6f );
-    aosys.atm.v_wind( selectedWindSpeed() );
-    aosys.zeta( ( 90.0f - m_elevation ) * pi<float>() / 180.0f );
+    aosys.atm.r_0( seeingToR0( inputs.m_selectedSeeing ), 0.5e-6f );
+    aosys.atm.v_wind( inputs.m_selectedWindSpeed );
+    aosys.zeta( ( 90.0f - inputs.m_elevation ) * pi<float>() / 180.0f );
 }
 
-void strehlEstimator::updateOptimumLoopSpeed()
+void strehlEstimator::updateOptimumLoopSpeed( const predictionInputs &inputs )
 {
+    constexpr float strehlTieTolerance = 1.0e-4f;
+
     float bestFPS            = 0.0f;
     float bestStrehl         = -1.0f;
     float bestTotalWfe       = 0.0f;
@@ -582,7 +693,7 @@ void strehlEstimator::updateOptimumLoopSpeed()
 
     for( int fps = 100; fps <= 3000; fps += 100 )
     {
-        configureAoSystem( m_aosysScan, static_cast<float>( fps ), false );
+        configureAoSystem( m_aosysScan, inputs, static_cast<float>( fps ), false );
 
         float strehl = m_aosysScan.strehl();
         if( !finiteValue( strehl ) )
@@ -590,14 +701,14 @@ void strehlEstimator::updateOptimumLoopSpeed()
             continue;
         }
 
-        if( bestFPS == 0.0f || strehl > bestStrehl )
+        if( bestFPS == 0.0f || strehl > bestStrehl + strehlTieTolerance )
         {
             bestFPS            = static_cast<float>( fps );
             bestStrehl         = strehl;
-            bestTotalWfe       = wfeNm( m_aosysScan.wfeVar() );
-            bestMeasurementWfe = wfeNm( m_aosysScan.measurementErrorTotal() );
-            bestTimeDelayWfe   = wfeNm( m_aosysScan.timeDelayErrorTotal() );
-            bestFittingWfe     = wfeNm( m_aosysScan.fittingErrorTotal() );
+            bestTotalWfe       = wfeNm( m_aosysScan.wfeVar(), inputs.m_lam0 );
+            bestMeasurementWfe = wfeNm( m_aosysScan.measurementErrorTotal(), inputs.m_lam0 );
+            bestTimeDelayWfe   = wfeNm( m_aosysScan.timeDelayErrorTotal(), inputs.m_lam0 );
+            bestFittingWfe     = wfeNm( m_aosysScan.fittingErrorTotal(), inputs.m_lam0 );
         }
     }
 
@@ -621,24 +732,26 @@ void strehlEstimator::updateOptimumLoopSpeed()
 
 void strehlEstimator::updatePredictionOutputs()
 {
-    if( !finitePositiveValue( m_fps ) || !finitePositiveValue( m_emg ) || !finitePositiveValue( m_qe ) ||
-        !finitePositiveValue( m_F0 ) || !finitePositiveValue( selectedSeeing() ) ||
-        !finitePositiveValue( selectedWindSpeed() ) )
+    predictionInputs inputs = snapshotPredictionInputs();
+
+    if( !finitePositiveValue( inputs.m_fps ) || !finitePositiveValue( inputs.m_emg ) ||
+        !finitePositiveValue( inputs.m_qe ) || !finitePositiveValue( inputs.m_F0 ) ||
+        !finitePositiveValue( inputs.m_selectedSeeing ) || !finitePositiveValue( inputs.m_selectedWindSpeed ) )
     {
         return;
     }
 
-    configureAoSystem( m_aosys, m_fps, true );
+    configureAoSystem( m_aosys, inputs, inputs.m_fps, true );
 
     if( !m_indiDriver )
     {
         m_indiP_strehl["pyramid"].set( m_aosys.strehl() );
         m_indiP_strehl.setState( INDI_OK );
 
-        m_indiP_wfe["total"].set( wfeNm( m_aosys.wfeVar() ) );
-        m_indiP_wfe["measurement"].set( wfeNm( m_aosys.measurementErrorTotal() ) );
-        m_indiP_wfe["time_delay"].set( wfeNm( m_aosys.timeDelayErrorTotal() ) );
-        m_indiP_wfe["fitting"].set( wfeNm( m_aosys.fittingErrorTotal() ) );
+        m_indiP_wfe["total"].set( wfeNm( m_aosys.wfeVar(), inputs.m_lam0 ) );
+        m_indiP_wfe["measurement"].set( wfeNm( m_aosys.measurementErrorTotal(), inputs.m_lam0 ) );
+        m_indiP_wfe["time_delay"].set( wfeNm( m_aosys.timeDelayErrorTotal(), inputs.m_lam0 ) );
+        m_indiP_wfe["fitting"].set( wfeNm( m_aosys.fittingErrorTotal(), inputs.m_lam0 ) );
         m_indiP_wfe.setState( INDI_OK );
     }
     else
@@ -646,13 +759,13 @@ void strehlEstimator::updatePredictionOutputs()
         updateIfChanged( m_indiP_strehl, "pyramid", m_aosys.strehl() );
         updatesIfChanged<float>( m_indiP_wfe,
                                  { "total", "measurement", "time_delay", "fitting" },
-                                 { wfeNm( m_aosys.wfeVar() ),
-                                   wfeNm( m_aosys.measurementErrorTotal() ),
-                                   wfeNm( m_aosys.timeDelayErrorTotal() ),
-                                   wfeNm( m_aosys.fittingErrorTotal() ) } );
+                                 { wfeNm( m_aosys.wfeVar(), inputs.m_lam0 ),
+                                   wfeNm( m_aosys.measurementErrorTotal(), inputs.m_lam0 ),
+                                   wfeNm( m_aosys.timeDelayErrorTotal(), inputs.m_lam0 ),
+                                   wfeNm( m_aosys.fittingErrorTotal(), inputs.m_lam0 ) } );
     }
 
-    updateOptimumLoopSpeed();
+    updateOptimumLoopSpeed( inputs );
 }
 
 int strehlEstimator::appStartup()
@@ -761,14 +874,28 @@ int strehlEstimator::processImage( void *curr_src, const wfsavgShmimT &dummy )
 {
     static_cast<void>( dummy );
 
-    m_wfsavg = mx::improc::eigenMap<float>(
+    auto wfsavg = mx::improc::eigenMap<float>(
         reinterpret_cast<float *>( curr_src ), wfsavgShmimMonitorT::m_width, wfsavgShmimMonitorT::m_height );
 
-    if( m_wfsavg.rows() == m_wfsmask.rows() && m_wfsavg.cols() == m_wfsmask.cols() )
-    {
-        m_counts = ( m_wfsavg * m_wfsmask ).sum();
+    float counts     = 0.0f;
+    bool  haveCounts = false;
 
-        std::cerr << "counts: " << m_counts << '\n';
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+
+        m_wfsavg = wfsavg;
+
+        if( m_wfsavg.rows() == m_wfsmask.rows() && m_wfsavg.cols() == m_wfsmask.cols() )
+        {
+            m_counts   = ( m_wfsavg * m_wfsmask ).sum();
+            counts     = m_counts;
+            haveCounts = true;
+        }
+    }
+
+    if( haveCounts )
+    {
+        std::cerr << "counts: " << counts << '\n';
 
         calcMag();
     }
@@ -788,16 +915,27 @@ int strehlEstimator::processImage( void *curr_src, const wfsmaskShmimT &dummy )
 {
     static_cast<void>( dummy );
 
-    m_wfsmask = mx::improc::eigenMap<float>(
+    auto wfsmask = mx::improc::eigenMap<float>(
         reinterpret_cast<float *>( curr_src ), wfsmaskShmimMonitorT::m_width, wfsmaskShmimMonitorT::m_height );
 
-    m_npix = static_cast<int>( m_wfsmask.sum() );
+    bool haveCounts = false;
 
-    if( m_wfsavg.rows() == m_wfsmask.rows() && m_wfsavg.cols() == m_wfsmask.cols() )
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+
+        m_wfsmask = wfsmask;
+        m_npix    = static_cast<int>( std::lround( m_wfsmask.sum() ) );
+
+        if( m_wfsavg.rows() == m_wfsmask.rows() && m_wfsavg.cols() == m_wfsmask.cols() )
+        {
+            // update counts because we might have been waiting on this.
+            m_counts   = ( m_wfsavg * m_wfsmask ).sum();
+            haveCounts = true;
+        }
+    }
+
+    if( haveCounts )
     {
-        // update counts because we might have been waiting on this.
-        m_counts = ( m_wfsavg * m_wfsmask ).sum();
-
         calcMag();
     }
 
@@ -806,20 +944,42 @@ int strehlEstimator::processImage( void *curr_src, const wfsmaskShmimT &dummy )
 
 void strehlEstimator::calcMag()
 {
-    std::cerr << "calcMag: " << m_counts << ' ' << m_again << ' ' << ' ' << m_emg << ' ' << m_fps << ' ' << m_qe << ' '
-              << m_F0 << '\n';
+    float counts  = 0.0f;
+    float emg     = 0.0f;
+    float fps     = 0.0f;
+    float qe      = 0.0f;
+    float F0      = 0.0f;
+    bool  updated = false;
 
-    if( !finitePositiveValue( m_counts ) || !finitePositiveValue( m_again ) || !finitePositiveValue( m_emg ) ||
-        !finitePositiveValue( m_fps ) || !finitePositiveValue( m_qe ) || !finitePositiveValue( m_F0 ) )
-    {
-        return;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+
+        counts = m_counts;
+        emg    = m_emg;
+        fps    = m_fps;
+        qe     = m_qe;
+        F0     = m_F0;
+
+        if( finitePositiveValue( m_counts ) && finitePositiveValue( m_again ) && finitePositiveValue( m_emg ) &&
+            finitePositiveValue( m_fps ) && finitePositiveValue( m_qe ) && finitePositiveValue( m_F0 ) )
+        {
+            m_mag = -2.5f * std::log10( m_counts * m_again / m_emg * m_fps / ( m_qe * m_F0 ) );
+
+            if( !m_useEstimates && !m_magEstimatedManual )
+            {
+                m_magEstimated = m_mag;
+            }
+
+            updated = true;
+        }
     }
 
-    m_mag = -2.5f * std::log10( m_counts * m_again / m_emg * m_fps / ( m_qe * m_F0 ) );
+    std::cerr << "calcMag: " << counts << ' ' << m_again << ' ' << ' ' << emg << ' ' << fps << ' ' << qe << ' ' << F0
+              << '\n';
 
-    if( !m_useEstimates && !m_magEstimatedManual )
+    if( !updated )
     {
-        m_magEstimated = m_mag;
+        return;
     }
 
     updatePlanningProperties();
@@ -834,10 +994,20 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_fps )( const pcf::IndiProperty &
     {
         float fps = ipRecv["current"].get<float>();
 
-        if( finitePositiveValue( fps ) && fps != m_fps )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finitePositiveValue( fps ) && fps != m_fps )
+            {
+                m_fps   = fps;
+                changed = true;
+            }
+        }
+
+        if( changed )
         {
-            m_fps = fps;
-            std::cerr << "Got FPS: " << m_fps << '\n';
+            std::cerr << "Got FPS: " << fps << '\n';
 
             calcMag();
         }
@@ -853,10 +1023,20 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_emg )( const pcf::IndiProperty &
     {
         float emg = ipRecv["current"].get<float>();
 
-        if( finitePositiveValue( emg ) && emg != m_emg )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finitePositiveValue( emg ) && emg != m_emg )
+            {
+                m_emg   = emg;
+                changed = true;
+            }
+        }
+
+        if( changed )
         {
-            m_emg = emg;
-            std::cerr << "Got EMG: " << m_emg << '\n';
+            std::cerr << "Got EMG: " << emg << '\n';
 
             calcMag();
         }
@@ -881,17 +1061,21 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_stage )( const pcf::IndiProperty
 
     std::cerr << "Got stage bs: " << preset << '\n';
 
-    if( preset == "ha-ir" )
-    {
-        m_F0   = m_F0_HaIR;
-        m_lam0 = m_lam0_HaIR;
-        m_qe   = m_qe_HaIR;
-    }
-    else
-    {
-        m_F0   = m_F0_6535;
-        m_lam0 = m_lam0_6535;
-        m_qe   = m_qe_6535;
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+
+        if( preset == "ha-ir" )
+        {
+            m_F0   = m_F0_HaIR;
+            m_lam0 = m_lam0_HaIR;
+            m_qe   = m_qe_HaIR;
+        }
+        else
+        {
+            m_F0   = m_F0_6535;
+            m_lam0 = m_lam0_6535;
+            m_qe   = m_qe_6535;
+        }
     }
 
     calcMag();
@@ -907,18 +1091,29 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_tcsi_seeing )( const pcf::IndiPr
     {
         float seeing = ipRecv["dimm_fwhm_corr"].get<float>();
 
-        if( finitePositiveValue( seeing ) && seeing != m_seeing )
-        {
-            m_seeing         = seeing;
-            m_r0             = seeingToR0( m_seeing );
-            m_dimm_fwhm_corr = seeing;
+        bool changed = false;
 
-            if( !m_useEstimates && !m_seeingEstimatedManual )
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+
+            if( finitePositiveValue( seeing ) && seeing != m_seeing )
             {
-                m_seeingEstimated = m_seeing;
-            }
+                m_seeing         = seeing;
+                m_r0             = seeingToR0( m_seeing );
+                m_dimm_fwhm_corr = seeing;
 
-            std::cerr << "Got seeing: " << m_seeing << '\n';
+                if( !m_useEstimates && !m_seeingEstimatedManual )
+                {
+                    m_seeingEstimated = m_seeing;
+                }
+
+                changed = true;
+            }
+        }
+
+        if( changed )
+        {
+            std::cerr << "Got seeing: " << seeing << '\n';
 
             updatePlanningProperties();
             updatePredictionOutputs();
@@ -936,10 +1131,20 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_tcsi_telpos )( const pcf::IndiPr
     {
         float elevation = ipRecv["el"].get<float>();
 
-        if( finiteValue( elevation ) && elevation != m_elevation )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finiteValue( elevation ) && elevation != m_elevation )
+            {
+                m_elevation = elevation;
+                changed     = true;
+            }
+        }
+
+        if( changed )
         {
-            m_elevation = elevation;
-            std::cerr << "Got elevation: " << m_elevation << '\n';
+            std::cerr << "Got elevation: " << elevation << '\n';
 
             updatePredictionOutputs();
         }
@@ -955,10 +1160,20 @@ INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_mag )( const pcf::IndiProperty &
     {
         float mag = ipRecv["estimated"].get<float>();
 
-        if( finiteValue( mag ) && mag != m_magEstimated )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finiteValue( mag ) && mag != m_magEstimated )
+            {
+                m_magEstimated       = mag;
+                m_magEstimatedManual = true;
+                changed              = true;
+            }
+        }
+
+        if( changed )
         {
-            m_magEstimated       = mag;
-            m_magEstimatedManual = true;
             updatePlanningProperties();
             updatePredictionOutputs();
         }
@@ -975,10 +1190,20 @@ INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_seeing_magaox )( const pcf::Indi
     {
         float seeing = ipRecv["estimated"].get<float>();
 
-        if( finitePositiveValue( seeing ) && seeing != m_seeingEstimated )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finitePositiveValue( seeing ) && seeing != m_seeingEstimated )
+            {
+                m_seeingEstimated       = seeing;
+                m_seeingEstimatedManual = true;
+                changed                 = true;
+            }
+        }
+
+        if( changed )
         {
-            m_seeingEstimated       = seeing;
-            m_seeingEstimatedManual = true;
             updatePlanningProperties();
             updatePredictionOutputs();
         }
@@ -995,9 +1220,19 @@ INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_windSpeed )( const pcf::IndiProp
     {
         float windSpeed = ipRecv["estimated"].get<float>();
 
-        if( finitePositiveValue( windSpeed ) && windSpeed != m_windSpeedEstimated )
+        bool changed = false;
+
+        { // mutex scope
+            std::lock_guard<std::mutex> lock( m_stateMutex );
+            if( finitePositiveValue( windSpeed ) && windSpeed != m_windSpeedEstimated )
+            {
+                m_windSpeedEstimated = windSpeed;
+                changed              = true;
+            }
+        }
+
+        if( changed )
         {
-            m_windSpeedEstimated = windSpeed;
             updatePlanningProperties();
             updatePredictionOutputs();
         }
@@ -1016,19 +1251,22 @@ INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_useEstimates )( const pcf::IndiP
     }
 
     bool useEstimates = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
+    bool changed      = false;
 
-    if( useEstimates != m_useEstimates )
-    {
-        m_useEstimates = useEstimates;
-        updatePlanningProperties();
-        updatePredictionOutputs();
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        if( useEstimates != m_useEstimates )
+        {
+            m_useEstimates = useEstimates;
+            changed        = true;
+        }
     }
-    else
+
+    updatePlanningProperties();
+
+    if( changed )
     {
-        updateSwitchIfChanged( m_indiP_useEstimates,
-                               "toggle",
-                               m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
-                               m_useEstimates ? INDI_OK : INDI_IDLE );
+        updatePredictionOutputs();
     }
 
     return 0;

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -344,6 +344,13 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Return whether a value is finite and strictly positive.
     static bool finitePositiveValue( float value /**< [in] value to test */ );
 
+    /// Return whether two scalar AO-model inputs are effectively equal.
+    static bool nearlyEqual( float a,      /**< [in] first value */
+                             float b,      /**< [in] second value */
+                             float relTol, /**< [in] relative tolerance */
+                             float absTol  /**< [in] absolute tolerance */
+    );
+
     /// Convert AO model phase variance into WFE in nm RMS at the specified wavelength.
     static float wfeNm( float variance, /**< [in] phase variance at the science wavelength */
                         float lam0      /**< [in] active wavelength in microns */
@@ -625,6 +632,23 @@ bool strehlEstimator::finitePositiveValue( float value )
     return finiteValue( value ) && value > 0.0f;
 }
 
+bool strehlEstimator::nearlyEqual( float a, float b, float relTol, float absTol )
+{
+    float diff = std::fabs( a - b );
+    if( diff <= absTol )
+    {
+        return true;
+    }
+
+    float scale = std::fabs( a );
+    if( std::fabs( b ) > scale )
+    {
+        scale = std::fabs( b );
+    }
+
+    return diff <= relTol * scale;
+}
+
 float strehlEstimator::wfeNm( float variance, float lam0 )
 {
     if( variance <= 0.0f )
@@ -794,12 +818,41 @@ void strehlEstimator::updateOptimumLoopSpeed( const predictionInputs &inputs )
 void strehlEstimator::updatePredictionOutputs()
 {
     std::lock_guard<std::mutex> predictionLock( m_predictionMutex );
+    constexpr float             predictionRelTol = 1.0e-6f;
+    constexpr float             predictionAbsTol = 1.0e-7f;
 
     predictionInputs inputs = snapshotPredictionInputs();
 
     if( !finitePositiveValue( inputs.m_fps ) || !finitePositiveValue( inputs.m_emg ) ||
         !finitePositiveValue( inputs.m_qe ) || !finitePositiveValue( inputs.m_F0 ) ||
-        !finitePositiveValue( inputs.m_selectedSeeing ) || !finitePositiveValue( inputs.m_selectedWindSpeed ) )
+        !finitePositiveValue( inputs.m_selectedSeeing ) || !finitePositiveValue( inputs.m_selectedWindSpeed ) ||
+        inputs.m_npix <= 0 )
+    {
+        return;
+    }
+
+    const float configuredF0   = inputs.m_qe * inputs.m_F0;
+    const float configuredLam  = inputs.m_lam0 * 1.0e-6f;
+    const float configuredRon  = 245.0f / inputs.m_emg;
+    const float configuredNpix = static_cast<float>( inputs.m_npix );
+    const float configuredTau  = 1.0f / inputs.m_fps;
+    const float configuredZeta = ( 90.0f - inputs.m_elevation ) * pi<float>() / 180.0f;
+
+    bool sameConfiguredInputs =
+        m_aosys.optTau() == true && m_aosys.ron_wfs().size() > 0 && m_aosys.npix_wfs().size() > 0 &&
+        m_aosys.minTauWFS().size() > 0 &&
+        nearlyEqual( m_aosys.starMag(), inputs.m_selectedMag, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.F0(), configuredF0, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.lam_wfs(), configuredLam, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.lam_sci(), configuredLam, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.ron_wfs( 0 ), configuredRon, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.npix_wfs( 0 ), configuredNpix, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.minTauWFS( 0 ), configuredTau, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.tauWFS(), configuredTau, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.atm.v_wind(), inputs.m_selectedWindSpeed, predictionRelTol, predictionAbsTol ) &&
+        nearlyEqual( m_aosys.zeta(), configuredZeta, predictionRelTol, predictionAbsTol );
+
+    if( sameConfiguredInputs )
     {
         return;
     }

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -817,7 +817,7 @@ void strehlEstimator::calcMag()
 
     m_mag = -2.5f * std::log10( m_counts * m_again / m_emg * m_fps / ( m_qe * m_F0 ) );
 
-    if( !m_magEstimatedManual )
+    if( !m_useEstimates && !m_magEstimatedManual )
     {
         m_magEstimated = m_mag;
     }
@@ -913,7 +913,7 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_tcsi_seeing )( const pcf::IndiPr
             m_r0             = seeingToR0( m_seeing );
             m_dimm_fwhm_corr = seeing;
 
-            if( !m_seeingEstimatedManual )
+            if( !m_useEstimates && !m_seeingEstimatedManual )
             {
                 m_seeingEstimated = m_seeing;
             }

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -1,11 +1,13 @@
 /** \file strehlEstimator.hpp
- * \brief The MagAO-X XXXXXX header file
+ * \brief Declares the `strehlEstimator` MagAO-X application.
  *
  * \ingroup strehlEstimator_files
  */
 
 #ifndef strehlEstimator_hpp
 #define strehlEstimator_hpp
+
+#include <cmath>
 
 #include <mx/ao/analysis/aoSystem.hpp>
 using namespace mx::math;
@@ -14,7 +16,7 @@ using namespace mx::math;
 #include "../../magaox_git_version.h"
 
 /** \defgroup strehlEstimator
- * \brief The XXXXXX application to do YYYYYYY
+ * \brief Predicts Strehl and WFE for live or operator-estimated observing conditions.
  *
  * <a href="../handbook/operating/software/apps/XXXXXX.html">Application Documentation</a>
  *
@@ -31,33 +33,39 @@ namespace MagAOX
 namespace app
 {
 
+/// Tag type for the live WFS average shmim monitor.
 struct wfsavgShmimT
 {
+    /// Return the configuration section name for this shmim monitor.
     static std::string configSection()
     {
         return "wfsavgShmim";
     };
 
+    /// Return the INDI prefix for this shmim monitor.
     static std::string indiPrefix()
     {
         return "wfsavg";
     };
 };
 
+/// Tag type for the WFS mask shmim monitor.
 struct wfsmaskShmimT
 {
+    /// Return the configuration section name for this shmim monitor.
     static std::string configSection()
     {
         return "wfsmaskShmim";
     };
 
+    /// Return the INDI prefix for this shmim monitor.
     static std::string indiPrefix()
     {
         return "wfsmask";
     };
 };
 
-/// The MagAO-X xxxxxxxx
+/// Predicts Strehl and WFE from live WFS telemetry and optional planning overrides.
 /**
  * \ingroup strehlEstimator
  */
@@ -73,155 +81,300 @@ class strehlEstimator : public MagAOXApp<true>,
     friend class dev::shmimMonitor<strehlEstimator, wfsmaskShmimT>;
 
   public:
-    typedef dev::shmimMonitor<strehlEstimator, wfsavgShmimT>  wfsavgShmimMonitorT;
-    typedef dev::shmimMonitor<strehlEstimator, wfsmaskShmimT> wfsmaskShmimMonitorT;
+    typedef dev::shmimMonitor<strehlEstimator, wfsavgShmimT>                              wfsavgShmimMonitorT;
+    typedef dev::shmimMonitor<strehlEstimator, wfsmaskShmimT>                             wfsmaskShmimMonitorT;
+    typedef mx::AO::analysis::aoSystem<float, mx::AO::analysis::vonKarmanSpectrum<float>> aoSystemT;
 
   protected:
-    /** \name Configurable Parameters
+    /** \name Configurable Parameters - Data
      *@{
      */
 
-    int m_loopNum{ 1 }; ///< The number of the loop. Used to set shmim names, as in aolN_wfsmask.
+    /// Loop number used to resolve the WFS shmim names.
+    int m_loopNum{ 1 };
 
+    /// WFS device providing the live FPS property.
     std::string m_wfsDevice{ "camwfs" };
 
+    /// Beamsplitter stage device used to choose the active photometric calibration.
     std::string m_stagebsDevice{ "stagebs" };
 
-    float m_again{ 28.547 };
+    /// Analog gain factor converting WFS counts into photo-electrons.
+    float m_again{ 28.547f };
 
-    float m_qe{ 0.53 };
+    /// Active WFS quantum efficiency for the currently selected beamsplitter branch.
+    float m_qe{ 0.53f };
 
-    float m_F0_6535{ 4.2e10 };
+    /// Zero-magnitude photon flux for the 65/35 beamsplitter branch.
+    float m_F0_6535{ 4.2e10f };
 
-    float m_F0_HaIR{ 5.3e10 };
+    /// Zero-magnitude photon flux for the Ha/IR beamsplitter branch.
+    float m_F0_HaIR{ 5.3e10f };
 
-    float m_lam0_6535{ 0.791 };
+    /// Effective WFS wavelength in microns for the 65/35 beamsplitter branch.
+    float m_lam0_6535{ 0.791f };
 
-    float m_lam0_HaIR{ 0.837 };
+    /// Effective WFS wavelength in microns for the Ha/IR beamsplitter branch.
+    float m_lam0_HaIR{ 0.837f };
 
-    float m_qe_6535{ 0.53 };
+    /// WFS QE for the 65/35 beamsplitter branch.
+    float m_qe_6535{ 0.53f };
 
-    float m_qe_HaIR{ 0.53 };
+    /// WFS QE for the Ha/IR beamsplitter branch.
+    float m_qe_HaIR{ 0.53f };
 
     ///@}
 
-    float m_fps{ 2000 };
+    /** \name Runtime State - Data
+     *@{
+     */
 
-    float m_emg{ 1 };
+    /// Live WFS frame rate in Hz.
+    float m_fps{ 2000.0f };
 
+    /// Live EM gain reported by the WFS camera.
+    float m_emg{ 1.0f };
+
+    /// Active zero-magnitude photon flux for the selected beamsplitter branch.
     float m_F0{ m_F0_6535 };
 
+    /// Active WFS/science wavelength in microns for the selected beamsplitter branch.
     float m_lam0{ m_lam0_6535 };
 
-    float m_seeing{ 0.64 };
+    /// Live seeing estimate in arcseconds from `tcsi.seeing.dimm_fwhm_corr`.
+    float m_seeing{ 0.64f };
 
-    float m_r0{ 0.16 };
+    /// Live Fried parameter corresponding to `m_seeing`.
+    float m_r0{ 0.2063f * 0.5f / 0.64f };
 
-    float m_elevation{ 90 };
+    /// Telescope elevation in degrees.
+    float m_elevation{ 90.0f };
 
-    int m_npix;
+    /// Number of illuminated WFS pixels in the current mask.
+    int m_npix{ 0 };
 
-    float m_counts{ 0 };
+    /// Total masked WFS counts used to derive the live guide-star magnitude.
+    float m_counts{ 0.0f };
 
-    float m_mag{ 0 };
+    /// Live guide-star magnitude derived from `m_counts`.
+    float m_mag{ 0.0f };
 
+    /// Operator-entered star magnitude used when planning overrides are enabled.
+    float m_magEstimated{ 0.0f };
+
+    /// Tracks whether the estimated star magnitude has been explicitly set by an operator.
+    bool m_magEstimatedManual{ false };
+
+    /// Operator-entered seeing in arcseconds used when planning overrides are enabled.
+    float m_seeingEstimated{ 0.64f };
+
+    /// Tracks whether the estimated seeing has been explicitly set by an operator.
+    bool m_seeingEstimatedManual{ false };
+
+    /// Operator-entered wind speed in m/s used for planning calculations.
+    float m_windSpeedEstimated{ 10.0f };
+
+    /// Selects whether predicted outputs use the live or estimated planning inputs.
+    bool m_useEstimates{ false };
+
+    /// Latest WFS mask image.
     mx::improc::eigenImage<float> m_wfsmask;
+
+    /// Latest WFS average image.
     mx::improc::eigenImage<float> m_wfsavg;
 
-    mx::AO::analysis::aoSystem<float, mx::AO::analysis::vonKarmanSpectrum<float>> m_aosys;
+    /// AO model used for the current predicted Strehl and WFE outputs.
+    aoSystemT m_aosys;
 
-    double m_dimm_fwhm_corr{ 0 }; ///< DIMM elevation corrected FWHM
-    int    m_dimm_time{ 0 };      ///< Seconds since midnight of DIMM measurement.
+    /// AO model dedicated to the fixed-FPS optimum-loop-speed scan.
+    aoSystemT m_aosysScan;
 
-    double m_mag1_fwhm_corr{ 0 }; ///< MAG1 elevation corrected FWHM
-    int    m_mag1_time{ 0 };      ///< Seconds since midnight of MAG1 measurement.
+    /// Latest DIMM elevation-corrected FWHM.
+    double m_dimm_fwhm_corr{ 0.0 };
 
-    double m_mag2_fwhm_corr{ 0 }; ///< MAG2 elevation corrected FWHM
-    int    m_mag2_time{ 0 };      ///< Seconds since midnight of MAG2 measurement.
+    /// Seconds since midnight of the latest DIMM measurement.
+    int m_dimm_time{ 0 };
+
+    /// Latest MAG1 elevation-corrected FWHM.
+    double m_mag1_fwhm_corr{ 0.0 };
+
+    /// Seconds since midnight of the latest MAG1 measurement.
+    int m_mag1_time{ 0 };
+
+    /// Latest MAG2 elevation-corrected FWHM.
+    double m_mag2_fwhm_corr{ 0.0 };
+
+    /// Seconds since midnight of the latest MAG2 measurement.
+    int m_mag2_time{ 0 };
+
+    ///@}
 
   public:
-    /// Default c'tor.
+    /// Construct the application with the compiled git-version metadata.
     strehlEstimator();
 
-    /// D'tor, declared and defined for noexcept.
+    /// Destroy the application.
     ~strehlEstimator() noexcept
     {
     }
 
+    /// Declare configuration keys and initialize the AO models.
     virtual void setupConfig();
 
-    /// Implementation of loadConfig logic, separated for testing.
-    /** This is called by loadConfig().
+    /// Load configuration values after `setupConfig()` has registered them.
+    /**
+     * This is split from `loadConfig()` so the unit tests can call it directly.
      */
-    int loadConfigImpl(
-        mx::app::appConfigurator &_config /**< [in] an application configuration from which to load values*/ );
+    int loadConfigImpl( mx::app::appConfigurator &_config /**< [in] application configuration source to read from */ );
 
+    /// Load the configured runtime values.
     virtual void loadConfig();
 
-    /// Startup function
-    /**
-     *
-     */
+    /// Register INDI properties and transition the app into the operating state.
     virtual int appStartup();
 
-    /// Implementation of the FSM for strehlEstimator.
+    /// Refresh the AO predictions and service the shmim-monitor state machine.
     /**
      * \returns 0 on no critical error
      * \returns -1 on an error requiring shutdown
      */
     virtual int appLogic();
 
-    /// Shutdown the app.
-    /**
-     *
-     */
+    /// Shut down the shmim monitors.
     virtual int appShutdown();
 
-    int allocate( const wfsavgShmimT & ///< [in] tag to differentiate shmimMonitor parents.
-    );
+    /// React to allocation of the WFS average shmim stream.
+    int allocate( const wfsavgShmimT &dummy /**< [in] tag distinguishing the shmimMonitor parent */ );
 
-    int processImage( void *curr_src,      ///< [in] pointer to the start of the current frame
-                      const wfsavgShmimT & ///< [in] tag to differentiate shmimMonitor parents.
-    );
+    /// Process one WFS average frame.
+    int processImage( void               *curr_src, /**< [in] pointer to the start of the current frame */
+                      const wfsavgShmimT &dummy /**< [in] tag distinguishing the shmimMonitor parent */ );
 
-    int allocate( const wfsmaskShmimT & ///< [in] tag to differentiate shmimMonitor parents.
-    );
+    /// React to allocation of the WFS mask shmim stream.
+    int allocate( const wfsmaskShmimT &dummy /**< [in] tag distinguishing the shmimMonitor parent */ );
 
-    int processImage( void *curr_src,       ///< [in] pointer to the start of the current frame
-                      const wfsmaskShmimT & ///< [in] tag to differentiate shmimMonitor parents.
-    );
+    /// Process one WFS mask frame.
+    int processImage( void                *curr_src, /**< [in] pointer to the start of the current frame */
+                      const wfsmaskShmimT &dummy /**< [in] tag distinguishing the shmimMonitor parent */ );
 
+    /// Recalculate the live guide-star magnitude from the current WFS counts.
     void calcMag();
 
-    /** INDI
+    /// Return the selected star magnitude for prediction calculations.
+    float selectedStarMag() const;
+
+    /// Return the selected seeing for prediction calculations.
+    float selectedSeeing() const;
+
+    /// Return the selected wind speed for prediction calculations.
+    float selectedWindSpeed() const;
+
+    /// Convert seeing in arcseconds to Fried parameter `r0` in meters.
+    static float seeingToR0( float seeing /**< [in] seeing in arcseconds */ );
+
+    /// Return whether a value is finite.
+    static bool finiteValue( float value /**< [in] value to test */ );
+
+    /// Return whether a value is finite and strictly positive.
+    static bool finitePositiveValue( float value /**< [in] value to test */ );
+
+    /// Convert AO model phase variance into WFE in nm RMS at the active wavelength.
+    float wfeNm( float variance /**< [in] phase variance at the science wavelength */ ) const;
+
+    /// Create a writable number property with `current` and `estimated` elements.
+    int createCurrentEstimatedProperty( pcf::IndiProperty &prop,  /**< [out] property to initialize */
+                                        const std::string &name,  /**< [in] INDI property name */
+                                        const std::string &label, /**< [in] suggested GUI label */
+                                        const std::string &group  /**< [in] suggested GUI group */
+    );
+
+    /// Update the published planning-input properties from the current runtime state.
+    void updatePlanningProperties();
+
+    /// Configure an AO model for the selected inputs and requested loop speed.
+    void configureAoSystem( aoSystemT &aosys,      /**< [in,out] AO model instance to configure */
+                            float      fps,        /**< [in] loop speed in Hz */
+                            bool       optimizeTau /**< [in] true to preserve the current optimal-tau behavior */
+    );
+
+    /// Refresh the predicted Strehl, WFE, and optimum-loop-speed properties.
+    void updatePredictionOutputs();
+
+    /// Refresh the fixed-grid optimum-loop-speed summary property.
+    void updateOptimumLoopSpeed();
+
+    /** \name INDI - Data
      * @{
      */
 
+    /// Subscription to the live WFS FPS property.
     pcf::IndiProperty m_indiP_fps;
+
+    /// Subscription to the live WFS EM-gain property.
     pcf::IndiProperty m_indiP_emg;
 
+    /// Subscription to the beamsplitter preset state.
     pcf::IndiProperty m_indiP_stage;
 
+    /// Subscription to the TCS seeing property.
     pcf::IndiProperty m_indiP_tcsi_seeing;
+
+    /// Subscription to the TCS telescope position property.
     pcf::IndiProperty m_indiP_tcsi_telpos;
+
+    /// Local writable seeing property exposing `current` and `estimated`.
     pcf::IndiProperty m_indiP_seeing_magaox;
 
+    /// Local writable star-magnitude property exposing `current` and `estimated`.
     pcf::IndiProperty m_indiP_mag;
+
+    /// Local writable wind-speed property exposing `current` and `estimated`.
+    pcf::IndiProperty m_indiP_windSpeed;
+
+    /// Local toggle selecting whether predicted outputs use estimated inputs.
+    pcf::IndiProperty m_indiP_useEstimates;
+
+    /// Predicted Strehl property for the currently selected conditions.
     pcf::IndiProperty m_indiP_strehl;
+
+    /// Predicted WFE breakdown for the currently selected conditions.
     pcf::IndiProperty m_indiP_wfe;
 
+    /// Summary property for the best fixed-grid loop speed.
+    pcf::IndiProperty m_indiP_loopSpeedOptimum;
+
+    /// Callback for live FPS updates.
     INDI_SETCALLBACK_DECL( strehlEstimator, m_indiP_fps );
+
+    /// Callback for live EM-gain updates.
     INDI_SETCALLBACK_DECL( strehlEstimator, m_indiP_emg );
+
+    /// Callback for beamsplitter preset updates.
     INDI_SETCALLBACK_DECL( strehlEstimator, m_indiP_stage );
+
+    /// Callback for live TCS seeing updates.
     INDI_SETCALLBACK_DECL( strehlEstimator, m_indiP_tcsi_seeing );
+
+    /// Callback for live TCS elevation updates.
     INDI_SETCALLBACK_DECL( strehlEstimator, m_indiP_tcsi_telpos );
+
+    /// Callback for local star-magnitude estimate writes.
+    INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_mag );
+
+    /// Callback for local seeing estimate writes.
+    INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_seeing_magaox );
+
+    /// Callback for local wind-speed estimate writes.
+    INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_windSpeed );
+
+    /// Callback for the `use_estimates` toggle.
+    INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_useEstimates );
 
     ///@}
 };
 
 strehlEstimator::strehlEstimator() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
-
     wfsavgShmimMonitorT::m_getExistingFirst  = true;
     wfsmaskShmimMonitorT::m_getExistingFirst = true;
 
@@ -231,6 +384,9 @@ strehlEstimator::strehlEstimator() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO
 void strehlEstimator::setupConfig()
 {
     m_aosys.loadMagAOX();
+    m_aosysScan.loadMagAOX();
+
+    m_windSpeedEstimated = m_aosys.atm.v_wind();
 
     config.add( "loop.number",
                 "",
@@ -268,7 +424,6 @@ void strehlEstimator::setupConfig()
 
 int strehlEstimator::loadConfigImpl( mx::app::appConfigurator &_config )
 {
-
     _config( m_loopNum, "loop.number" );
 
     _config( m_qe_6535, "phot.qe_6535" );
@@ -291,32 +446,281 @@ void strehlEstimator::loadConfig()
     loadConfigImpl( config );
 }
 
+int strehlEstimator::createCurrentEstimatedProperty( pcf::IndiProperty &prop,
+                                                     const std::string &name,
+                                                     const std::string &label,
+                                                     const std::string &group )
+{
+    prop = pcf::IndiProperty( pcf::IndiProperty::Number );
+    prop.setDevice( configName() );
+    prop.setName( name );
+    prop.setPerm( pcf::IndiProperty::ReadWrite );
+    prop.setState( pcf::IndiProperty::Idle );
+
+    if( label != "" )
+    {
+        prop.setLabel( label );
+    }
+
+    if( group != "" )
+    {
+        prop.setGroup( group );
+    }
+
+    prop.add( pcf::IndiElement( "current", 0.0f ) );
+    prop.add( pcf::IndiElement( "estimated", 0.0f ) );
+
+    return 0;
+}
+
+float strehlEstimator::selectedStarMag() const
+{
+    if( m_useEstimates )
+    {
+        return m_magEstimated;
+    }
+
+    return m_mag;
+}
+
+float strehlEstimator::selectedSeeing() const
+{
+    if( m_useEstimates )
+    {
+        return m_seeingEstimated;
+    }
+
+    return m_seeing;
+}
+
+float strehlEstimator::selectedWindSpeed() const
+{
+    return m_windSpeedEstimated;
+}
+
+float strehlEstimator::seeingToR0( float seeing )
+{
+    return 0.2063f * 0.5f / seeing;
+}
+
+bool strehlEstimator::finiteValue( float value )
+{
+    return std::isfinite( value );
+}
+
+bool strehlEstimator::finitePositiveValue( float value )
+{
+    return finiteValue( value ) && value > 0.0f;
+}
+
+float strehlEstimator::wfeNm( float variance ) const
+{
+    if( variance <= 0.0f )
+    {
+        return 0.0f;
+    }
+
+    return std::sqrt( variance ) * ( 1000.0f * m_lam0 / two_pi<float>() );
+}
+
+void strehlEstimator::updatePlanningProperties()
+{
+    if( !m_indiDriver )
+    {
+        m_indiP_mag["current"].set( m_mag );
+        m_indiP_mag["estimated"].set( m_magEstimated );
+        m_indiP_mag.setState( INDI_OK );
+
+        m_indiP_seeing_magaox["current"].set( m_seeing );
+        m_indiP_seeing_magaox["estimated"].set( m_seeingEstimated );
+        m_indiP_seeing_magaox.setState( INDI_OK );
+
+        m_indiP_windSpeed["current"].set( m_windSpeedEstimated );
+        m_indiP_windSpeed["estimated"].set( m_windSpeedEstimated );
+        m_indiP_windSpeed.setState( INDI_OK );
+
+        m_indiP_useEstimates["toggle"].setSwitchState( m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off );
+        m_indiP_useEstimates.setState( m_useEstimates ? INDI_OK : INDI_IDLE );
+
+        return;
+    }
+
+    updatesIfChanged<float>( m_indiP_mag, { "current", "estimated" }, { m_mag, m_magEstimated } );
+    updatesIfChanged<float>( m_indiP_seeing_magaox, { "current", "estimated" }, { m_seeing, m_seeingEstimated } );
+    updatesIfChanged<float>(
+        m_indiP_windSpeed, { "current", "estimated" }, { m_windSpeedEstimated, m_windSpeedEstimated } );
+    updateSwitchIfChanged( m_indiP_useEstimates,
+                           "toggle",
+                           m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
+                           m_useEstimates ? INDI_OK : INDI_IDLE );
+}
+
+void strehlEstimator::configureAoSystem( aoSystemT &aosys, float fps, bool optimizeTau )
+{
+    aosys.optTau( optimizeTau );
+    aosys.starMag( selectedStarMag() );
+    aosys.F0( m_qe * m_F0 );
+    aosys.lam_wfs( m_lam0 * 1.0e-6f );
+    aosys.lam_sci( m_lam0 * 1.0e-6f );
+    aosys.ron_wfs( std::vector<float>( { 245.0f / m_emg } ) );
+    aosys.npix_wfs( std::vector<float>( { static_cast<float>( m_npix ) } ) );
+    aosys.minTauWFS( std::vector<float>( { 1.0f / fps } ) );
+    aosys.tauWFS( 1.0f / fps );
+    aosys.atm.r_0( seeingToR0( selectedSeeing() ), 0.5e-6f );
+    aosys.atm.v_wind( selectedWindSpeed() );
+    aosys.zeta( ( 90.0f - m_elevation ) * pi<float>() / 180.0f );
+}
+
+void strehlEstimator::updateOptimumLoopSpeed()
+{
+    float bestFPS            = 0.0f;
+    float bestStrehl         = -1.0f;
+    float bestTotalWfe       = 0.0f;
+    float bestMeasurementWfe = 0.0f;
+    float bestTimeDelayWfe   = 0.0f;
+    float bestFittingWfe     = 0.0f;
+
+    for( int fps = 100; fps <= 3000; fps += 100 )
+    {
+        configureAoSystem( m_aosysScan, static_cast<float>( fps ), false );
+
+        float strehl = m_aosysScan.strehl();
+        if( !finiteValue( strehl ) )
+        {
+            continue;
+        }
+
+        if( bestFPS == 0.0f || strehl > bestStrehl )
+        {
+            bestFPS            = static_cast<float>( fps );
+            bestStrehl         = strehl;
+            bestTotalWfe       = wfeNm( m_aosysScan.wfeVar() );
+            bestMeasurementWfe = wfeNm( m_aosysScan.measurementErrorTotal() );
+            bestTimeDelayWfe   = wfeNm( m_aosysScan.timeDelayErrorTotal() );
+            bestFittingWfe     = wfeNm( m_aosysScan.fittingErrorTotal() );
+        }
+    }
+
+    if( !m_indiDriver )
+    {
+        m_indiP_loopSpeedOptimum["fps"].set( bestFPS );
+        m_indiP_loopSpeedOptimum["strehl"].set( bestStrehl );
+        m_indiP_loopSpeedOptimum["wfe_total"].set( bestTotalWfe );
+        m_indiP_loopSpeedOptimum["wfe_measurement"].set( bestMeasurementWfe );
+        m_indiP_loopSpeedOptimum["wfe_time_delay"].set( bestTimeDelayWfe );
+        m_indiP_loopSpeedOptimum["wfe_fitting"].set( bestFittingWfe );
+        m_indiP_loopSpeedOptimum.setState( INDI_OK );
+        return;
+    }
+
+    updatesIfChanged<float>(
+        m_indiP_loopSpeedOptimum,
+        { "fps", "strehl", "wfe_total", "wfe_measurement", "wfe_time_delay", "wfe_fitting" },
+        { bestFPS, bestStrehl, bestTotalWfe, bestMeasurementWfe, bestTimeDelayWfe, bestFittingWfe } );
+}
+
+void strehlEstimator::updatePredictionOutputs()
+{
+    if( !finitePositiveValue( m_fps ) || !finitePositiveValue( m_emg ) || !finitePositiveValue( m_qe ) ||
+        !finitePositiveValue( m_F0 ) || !finitePositiveValue( selectedSeeing() ) ||
+        !finitePositiveValue( selectedWindSpeed() ) )
+    {
+        return;
+    }
+
+    configureAoSystem( m_aosys, m_fps, true );
+
+    if( !m_indiDriver )
+    {
+        m_indiP_strehl["pyramid"].set( m_aosys.strehl() );
+        m_indiP_strehl.setState( INDI_OK );
+
+        m_indiP_wfe["total"].set( wfeNm( m_aosys.wfeVar() ) );
+        m_indiP_wfe["measurement"].set( wfeNm( m_aosys.measurementErrorTotal() ) );
+        m_indiP_wfe["time_delay"].set( wfeNm( m_aosys.timeDelayErrorTotal() ) );
+        m_indiP_wfe["fitting"].set( wfeNm( m_aosys.fittingErrorTotal() ) );
+        m_indiP_wfe.setState( INDI_OK );
+    }
+    else
+    {
+        updateIfChanged( m_indiP_strehl, "pyramid", m_aosys.strehl() );
+        updatesIfChanged<float>( m_indiP_wfe,
+                                 { "total", "measurement", "time_delay", "fitting" },
+                                 { wfeNm( m_aosys.wfeVar() ),
+                                   wfeNm( m_aosys.measurementErrorTotal() ),
+                                   wfeNm( m_aosys.timeDelayErrorTotal() ),
+                                   wfeNm( m_aosys.fittingErrorTotal() ) } );
+    }
+
+    updateOptimumLoopSpeed();
+}
+
 int strehlEstimator::appStartup()
 {
-
     SHMIMMONITORT_APP_STARTUP( wfsavgShmimMonitorT );
     SHMIMMONITORT_APP_STARTUP( wfsmaskShmimMonitorT );
 
     REG_INDI_SETPROP( m_indiP_fps, m_wfsDevice, "fps" );
-
     REG_INDI_SETPROP( m_indiP_emg, m_wfsDevice, "emgain" );
-
     REG_INDI_SETPROP( m_indiP_stage, m_stagebsDevice, "presetName" );
-
     REG_INDI_SETPROP( m_indiP_tcsi_seeing, "tcsi", "seeing" );
     REG_INDI_SETPROP( m_indiP_tcsi_telpos, "tcsi", "telpos" );
 
-    CREATE_REG_INDI_RO_NUMBER( m_indiP_mag, "star_mag", "Star Magnitude", "Error Budget" );
-    m_indiP_mag.add( pcf::IndiElement( "current", 0 ) );
+    if( createCurrentEstimatedProperty( m_indiP_mag, "star_mag", "Star Magnitude", "Error Budget" ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from createCurrentEstimatedProperty" } );
+    }
+    if( registerIndiPropertyNew( m_indiP_mag, INDI_NEWCALLBACK( m_indiP_mag ) ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from registerIndiPropertyNew" } );
+    }
+
+    if( createCurrentEstimatedProperty( m_indiP_seeing_magaox, "seeing", "Seeing", "Error Budget" ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from createCurrentEstimatedProperty" } );
+    }
+    if( registerIndiPropertyNew( m_indiP_seeing_magaox, INDI_NEWCALLBACK( m_indiP_seeing_magaox ) ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from registerIndiPropertyNew" } );
+    }
+
+    if( createCurrentEstimatedProperty( m_indiP_windSpeed, "wind_speed", "Wind Speed", "Error Budget" ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from createCurrentEstimatedProperty" } );
+    }
+    if( registerIndiPropertyNew( m_indiP_windSpeed, INDI_NEWCALLBACK( m_indiP_windSpeed ) ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from registerIndiPropertyNew" } );
+    }
+
+    if( createStandardIndiToggleSw( m_indiP_useEstimates, "use_estimates", "Use Estimates", "Error Budget" ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from createStandardIndiToggleSw" } );
+    }
+    if( registerIndiPropertyNew( m_indiP_useEstimates, INDI_NEWCALLBACK( m_indiP_useEstimates ) ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from registerIndiPropertyNew" } );
+    }
 
     CREATE_REG_INDI_RO_NUMBER( m_indiP_strehl, "strehl_optimal", "Strehl", "Error Budget" );
-    m_indiP_strehl.add( pcf::IndiElement( "pyramid", 0 ) );
+    m_indiP_strehl.add( pcf::IndiElement( "pyramid", 0.0f ) );
 
     CREATE_REG_INDI_RO_NUMBER( m_indiP_wfe, "wfe_predicted", "WFE", "Error Budget" );
-    m_indiP_wfe.add( pcf::IndiElement( "total", 0 ) );
-    m_indiP_wfe.add( pcf::IndiElement( "measurement", 0 ) );
-    m_indiP_wfe.add( pcf::IndiElement( "time_delay", 0 ) );
-    m_indiP_wfe.add( pcf::IndiElement( "fitting", 0 ) );
+    m_indiP_wfe.add( pcf::IndiElement( "total", 0.0f ) );
+    m_indiP_wfe.add( pcf::IndiElement( "measurement", 0.0f ) );
+    m_indiP_wfe.add( pcf::IndiElement( "time_delay", 0.0f ) );
+    m_indiP_wfe.add( pcf::IndiElement( "fitting", 0.0f ) );
+
+    CREATE_REG_INDI_RO_NUMBER( m_indiP_loopSpeedOptimum, "loop_speed_optimum", "Optimum Loop Speed", "Error Budget" );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "fps", 0.0f ) );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "strehl", 0.0f ) );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_total", 0.0f ) );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_measurement", 0.0f ) );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_time_delay", 0.0f ) );
+    m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_fitting", 0.0f ) );
+
+    updatePlanningProperties();
+    updatePredictionOutputs();
 
     state( stateCodes::OPERATING );
 
@@ -331,24 +735,9 @@ int strehlEstimator::appLogic()
     SHMIMMONITORT_UPDATE_INDI( wfsavgShmimMonitorT );
     SHMIMMONITORT_UPDATE_INDI( wfsmaskShmimMonitorT );
 
-    m_aosys.starMag( m_mag );
-    m_aosys.F0( m_qe * m_F0 );
-    m_aosys.lam_wfs( m_lam0 * 1e-6 );
-    m_aosys.lam_sci( m_lam0 * 1e-6 );
-    m_aosys.ron_wfs( std::vector<float>( { 245.0f / m_emg } ) );
-    m_aosys.npix_wfs( std::vector<float>( { 1.0f * m_npix } ) );
-    m_aosys.minTauWFS( std::vector<float>( { 1.0f / m_fps } ) );
-    m_aosys.tauWFS( 1. / m_fps );
-    m_aosys.atm.r_0( m_r0, 0.5e-6 );
-    m_aosys.zeta( ( 90. - m_elevation ) * 3.14159 / 180. );
+    updatePlanningProperties();
+    updatePredictionOutputs();
 
-    updateIfChanged( m_indiP_strehl, "pyramid", m_aosys.strehl() );
-    updatesIfChanged<double>( m_indiP_wfe,
-                              { "total", "measurement", "time_delay", "fitting" },
-                              { sqrt( m_aosys.wfeVar() ) * ( 1000 * m_lam0 / two_pi<float>() ),
-                                sqrt( m_aosys.measurementErrorTotal() ) * ( 1000 * m_lam0 / two_pi<float>() ),
-                                sqrt( m_aosys.timeDelayErrorTotal() ) * ( 1000 * m_lam0 / two_pi<float>() ),
-                                sqrt( m_aosys.fittingErrorTotal() ) * ( 1000 * m_lam0 / two_pi<float>() ) } );
     return 0;
 }
 
@@ -402,7 +791,7 @@ int strehlEstimator::processImage( void *curr_src, const wfsmaskShmimT &dummy )
     m_wfsmask = mx::improc::eigenMap<float>(
         reinterpret_cast<float *>( curr_src ), wfsmaskShmimMonitorT::m_width, wfsmaskShmimMonitorT::m_height );
 
-    m_npix = m_wfsmask.sum();
+    m_npix = static_cast<int>( m_wfsmask.sum() );
 
     if( m_wfsavg.rows() == m_wfsmask.rows() && m_wfsavg.cols() == m_wfsmask.cols() )
     {
@@ -420,9 +809,21 @@ void strehlEstimator::calcMag()
     std::cerr << "calcMag: " << m_counts << ' ' << m_again << ' ' << ' ' << m_emg << ' ' << m_fps << ' ' << m_qe << ' '
               << m_F0 << '\n';
 
-    m_mag = -2.5 * log10( m_counts * m_again / m_emg * m_fps / ( m_qe * m_F0 ) );
+    if( !finitePositiveValue( m_counts ) || !finitePositiveValue( m_again ) || !finitePositiveValue( m_emg ) ||
+        !finitePositiveValue( m_fps ) || !finitePositiveValue( m_qe ) || !finitePositiveValue( m_F0 ) )
+    {
+        return;
+    }
 
-    updateIfChanged( m_indiP_mag, "current", m_mag );
+    m_mag = -2.5f * std::log10( m_counts * m_again / m_emg * m_fps / ( m_qe * m_F0 ) );
+
+    if( !m_magEstimatedManual )
+    {
+        m_magEstimated = m_mag;
+    }
+
+    updatePlanningProperties();
+    updatePredictionOutputs();
 }
 
 INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_fps )( const pcf::IndiProperty &ipRecv )
@@ -433,7 +834,7 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_fps )( const pcf::IndiProperty &
     {
         float fps = ipRecv["current"].get<float>();
 
-        if( fps != m_fps )
+        if( finitePositiveValue( fps ) && fps != m_fps )
         {
             m_fps = fps;
             std::cerr << "Got FPS: " << m_fps << '\n';
@@ -452,7 +853,7 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_emg )( const pcf::IndiProperty &
     {
         float emg = ipRecv["current"].get<float>();
 
-        if( emg != m_emg )
+        if( finitePositiveValue( emg ) && emg != m_emg )
         {
             m_emg = emg;
             std::cerr << "Got EMG: " << m_emg << '\n';
@@ -467,36 +868,33 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_stage )( const pcf::IndiProperty
 {
     INDI_VALIDATE_CALLBACK_PROPS( m_indiP_stage, ipRecv );
 
-    // if( ipRecv.find( "presetName" ) )
+    std::string preset = "none";
+
+    for( auto &&el : ipRecv.getElements() )
     {
-        std::string preset = "none";
-
-        for( auto &&el : ipRecv.getElements() )
+        if( el.second.getSwitchState() == pcf::IndiElement::On )
         {
-            if( el.second.getSwitchState() == pcf::IndiElement::On )
-            {
-                preset = el.first;
-                break;
-            }
+            preset = el.first;
+            break;
         }
-
-        std::cerr << "Got stage bs: " << preset << '\n';
-
-        if( preset == "ha-ir" )
-        {
-            m_F0   = m_F0_HaIR;
-            m_lam0 = m_lam0_HaIR;
-            m_qe   = m_qe_HaIR;
-        }
-        else
-        {
-            m_F0   = m_F0_6535;
-            m_lam0 = m_lam0_6535;
-            m_qe   = m_qe_6535;
-        }
-
-        calcMag();
     }
+
+    std::cerr << "Got stage bs: " << preset << '\n';
+
+    if( preset == "ha-ir" )
+    {
+        m_F0   = m_F0_HaIR;
+        m_lam0 = m_lam0_HaIR;
+        m_qe   = m_qe_HaIR;
+    }
+    else
+    {
+        m_F0   = m_F0_6535;
+        m_lam0 = m_lam0_6535;
+        m_qe   = m_qe_6535;
+    }
+
+    calcMag();
 
     return 0;
 }
@@ -509,12 +907,21 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_tcsi_seeing )( const pcf::IndiPr
     {
         float seeing = ipRecv["dimm_fwhm_corr"].get<float>();
 
-        if( seeing != m_seeing )
+        if( finitePositiveValue( seeing ) && seeing != m_seeing )
         {
-            m_seeing = seeing;
+            m_seeing         = seeing;
+            m_r0             = seeingToR0( m_seeing );
+            m_dimm_fwhm_corr = seeing;
+
+            if( !m_seeingEstimatedManual )
+            {
+                m_seeingEstimated = m_seeing;
+            }
+
             std::cerr << "Got seeing: " << m_seeing << '\n';
 
-            m_r0 = 0.2063 * 0.5 / m_seeing;
+            updatePlanningProperties();
+            updatePredictionOutputs();
         }
     }
 
@@ -529,12 +936,101 @@ INDI_SETCALLBACK_DEFN( strehlEstimator, m_indiP_tcsi_telpos )( const pcf::IndiPr
     {
         float elevation = ipRecv["el"].get<float>();
 
-        if( elevation != m_elevation )
+        if( finiteValue( elevation ) && elevation != m_elevation )
         {
             m_elevation = elevation;
             std::cerr << "Got elevation: " << m_elevation << '\n';
+
+            updatePredictionOutputs();
         }
     }
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_mag )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_mag, ipRecv );
+
+    if( ipRecv.find( "estimated" ) )
+    {
+        float mag = ipRecv["estimated"].get<float>();
+
+        if( finiteValue( mag ) && mag != m_magEstimated )
+        {
+            m_magEstimated       = mag;
+            m_magEstimatedManual = true;
+            updatePlanningProperties();
+            updatePredictionOutputs();
+        }
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_seeing_magaox )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_seeing_magaox, ipRecv );
+
+    if( ipRecv.find( "estimated" ) )
+    {
+        float seeing = ipRecv["estimated"].get<float>();
+
+        if( finitePositiveValue( seeing ) && seeing != m_seeingEstimated )
+        {
+            m_seeingEstimated       = seeing;
+            m_seeingEstimatedManual = true;
+            updatePlanningProperties();
+            updatePredictionOutputs();
+        }
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_windSpeed )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_windSpeed, ipRecv );
+
+    if( ipRecv.find( "estimated" ) )
+    {
+        float windSpeed = ipRecv["estimated"].get<float>();
+
+        if( finitePositiveValue( windSpeed ) && windSpeed != m_windSpeedEstimated )
+        {
+            m_windSpeedEstimated = windSpeed;
+            updatePlanningProperties();
+            updatePredictionOutputs();
+        }
+    }
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_useEstimates )( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_useEstimates, ipRecv );
+
+    if( !ipRecv.find( "toggle" ) )
+    {
+        return 0;
+    }
+
+    bool useEstimates = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
+
+    if( useEstimates != m_useEstimates )
+    {
+        m_useEstimates = useEstimates;
+        updatePlanningProperties();
+        updatePredictionOutputs();
+    }
+    else
+    {
+        updateSwitchIfChanged( m_indiP_useEstimates,
+                               "toggle",
+                               m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
+                               m_useEstimates ? INDI_OK : INDI_IDLE );
+    }
+
     return 0;
 }
 

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -9,6 +9,7 @@
 
 #include <cmath>
 #include <mutex>
+#include <sstream>
 
 #include <mx/ao/analysis/aoSystem.hpp>
 using namespace mx::math;
@@ -210,6 +211,12 @@ class strehlEstimator : public MagAOXApp<true>,
 
     /// Protects the live telemetry and planning-input state while prediction snapshots are assembled.
     mutable std::mutex m_stateMutex;
+
+    /// Serializes access to the shared AO-model instances and prediction-property updates.
+    mutable std::mutex m_predictionMutex;
+
+    /// Tracks the last suspicious optimum FPS reported in debug logging.
+    float m_lastLoggedSuspiciousOptimumFps{ -1.0f };
 
     ///@}
 
@@ -682,14 +689,28 @@ void strehlEstimator::configureAoSystem( aoSystemT &aosys, const predictionInput
 
 void strehlEstimator::updateOptimumLoopSpeed( const predictionInputs &inputs )
 {
+    struct scanPoint
+    {
+        int   fps{ 0 };
+        float strehl{ 0.0f };
+        float wfeMeasurement{ 0.0f };
+        float wfeTimeDelay{ 0.0f };
+        float wfeFitting{ 0.0f };
+        float wfeTotal{ 0.0f };
+        float dOpt{ 0.0f };
+        int   binOpt{ 0 };
+    };
+
     constexpr float strehlTieTolerance = 1.0e-4f;
 
-    float bestFPS            = 0.0f;
-    float bestStrehl         = -1.0f;
-    float bestTotalWfe       = 0.0f;
-    float bestMeasurementWfe = 0.0f;
-    float bestTimeDelayWfe   = 0.0f;
-    float bestFittingWfe     = 0.0f;
+    float                  bestFPS            = 0.0f;
+    float                  bestStrehl         = -1.0f;
+    float                  bestTotalWfe       = 0.0f;
+    float                  bestMeasurementWfe = 0.0f;
+    float                  bestTimeDelayWfe   = 0.0f;
+    float                  bestFittingWfe     = 0.0f;
+    std::vector<scanPoint> scanCurve;
+    scanCurve.reserve( 30 );
 
     for( int fps = 100; fps <= 3000; fps += 100 )
     {
@@ -701,15 +722,55 @@ void strehlEstimator::updateOptimumLoopSpeed( const predictionInputs &inputs )
             continue;
         }
 
+        scanPoint point;
+        point.fps            = fps;
+        point.strehl         = strehl;
+        point.wfeMeasurement = wfeNm( m_aosysScan.measurementErrorTotal(), inputs.m_lam0 );
+        point.wfeTimeDelay   = wfeNm( m_aosysScan.timeDelayErrorTotal(), inputs.m_lam0 );
+        point.wfeFitting     = wfeNm( m_aosysScan.fittingErrorTotal(), inputs.m_lam0 );
+        point.wfeTotal       = wfeNm( m_aosysScan.wfeVar(), inputs.m_lam0 );
+        point.dOpt           = m_aosysScan.d_opt();
+        point.binOpt         = m_aosysScan.bin_opt();
+        scanCurve.push_back( point );
+
         if( bestFPS == 0.0f || strehl > bestStrehl + strehlTieTolerance )
         {
             bestFPS            = static_cast<float>( fps );
             bestStrehl         = strehl;
-            bestTotalWfe       = wfeNm( m_aosysScan.wfeVar(), inputs.m_lam0 );
-            bestMeasurementWfe = wfeNm( m_aosysScan.measurementErrorTotal(), inputs.m_lam0 );
-            bestTimeDelayWfe   = wfeNm( m_aosysScan.timeDelayErrorTotal(), inputs.m_lam0 );
-            bestFittingWfe     = wfeNm( m_aosysScan.fittingErrorTotal(), inputs.m_lam0 );
+            bestTotalWfe       = point.wfeTotal;
+            bestMeasurementWfe = point.wfeMeasurement;
+            bestTimeDelayWfe   = point.wfeTimeDelay;
+            bestFittingWfe     = point.wfeFitting;
         }
+    }
+
+    bool suspiciousWinner = bestFPS > 0.0f && ( bestFPS <= 400.0f || bestStrehl >= 0.98f ||
+                                                bestMeasurementWfe == 0.0f || bestTimeDelayWfe == 0.0f );
+
+    if( suspiciousWinner && bestFPS != m_lastLoggedSuspiciousOptimumFps )
+    {
+        std::ostringstream oss;
+        oss << "strehlEstimator suspicious optimum scan" << " use_estimates=" << std::boolalpha << inputs.m_useEstimates
+            << " selected_mag=" << inputs.m_selectedMag << " selected_seeing=" << inputs.m_selectedSeeing
+            << " selected_wind=" << inputs.m_selectedWindSpeed << " fps_live=" << inputs.m_fps
+            << " emg=" << inputs.m_emg << " elevation=" << inputs.m_elevation << " npix=" << inputs.m_npix
+            << " winner_fps=" << bestFPS << " winner_strehl=" << bestStrehl << " winner_wfe_total=" << bestTotalWfe
+            << " winner_wfe_meas=" << bestMeasurementWfe << " winner_wfe_delay=" << bestTimeDelayWfe
+            << " winner_wfe_fit=" << bestFittingWfe << '\n';
+
+        for( const auto &point : scanCurve )
+        {
+            oss << "  fps=" << point.fps << " strehl=" << point.strehl << " wfe_total=" << point.wfeTotal
+                << " wfe_meas=" << point.wfeMeasurement << " wfe_delay=" << point.wfeTimeDelay
+                << " wfe_fit=" << point.wfeFitting << " d_opt=" << point.dOpt << " bin_opt=" << point.binOpt << '\n';
+        }
+
+        std::cerr << oss.str();
+        m_lastLoggedSuspiciousOptimumFps = bestFPS;
+    }
+    else if( !suspiciousWinner )
+    {
+        m_lastLoggedSuspiciousOptimumFps = -1.0f;
     }
 
     if( !m_indiDriver )
@@ -732,6 +793,8 @@ void strehlEstimator::updateOptimumLoopSpeed( const predictionInputs &inputs )
 
 void strehlEstimator::updatePredictionOutputs()
 {
+    std::lock_guard<std::mutex> predictionLock( m_predictionMutex );
+
     predictionInputs inputs = snapshotPredictionInputs();
 
     if( !finitePositiveValue( inputs.m_fps ) || !finitePositiveValue( inputs.m_emg ) ||

--- a/apps/strehlEstimator/strehlEstimator.hpp
+++ b/apps/strehlEstimator/strehlEstimator.hpp
@@ -173,8 +173,8 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Tracks whether the estimated seeing has been explicitly set by an operator.
     bool m_seeingEstimatedManual{ false };
 
-    /// Operator-entered wind speed in m/s used for planning calculations.
-    float m_windSpeedEstimated{ 10.0f };
+    /// Operator-selected wind speed in m/s used for planning calculations.
+    float m_windSpeed{ 9.4f };
 
     /// Selects whether predicted outputs use the live or estimated planning inputs.
     bool m_useEstimates{ false };
@@ -313,8 +313,8 @@ class strehlEstimator : public MagAOXApp<true>,
         /// Selected seeing used for prediction.
         float m_selectedSeeing{ 0.0f };
 
-        /// Operator-entered wind-speed estimate in m/s.
-        float m_windSpeedEstimated{ 0.0f };
+        /// Operator-selected wind speed in m/s.
+        float m_windSpeed{ 0.0f };
 
         /// Selected wind speed used for prediction.
         float m_selectedWindSpeed{ 0.0f };
@@ -334,6 +334,18 @@ class strehlEstimator : public MagAOXApp<true>,
 
     /// Return the selected wind speed for prediction calculations.
     float selectedWindSpeed() const;
+
+    /// Return the supported wind-speed selection element names.
+    static const std::vector<std::string> &windSpeedSelectionElements();
+
+    /// Return the supported wind-speed selection labels.
+    static const std::vector<std::string> &windSpeedSelectionLabels();
+
+    /// Convert a wind-speed selection element name into its configured speed in m/s.
+    static float windSpeedSelectionValue( const std::string &selection /**< [in] selected wind-speed element name */ );
+
+    /// Return the nearest supported wind-speed selection element name for a speed in m/s.
+    static std::string windSpeedSelectionName( float windSpeed /**< [in] wind speed in m/s */ );
 
     /// Convert seeing in arcseconds to Fried parameter `r0` in meters.
     static float seeingToR0( float seeing /**< [in] seeing in arcseconds */ );
@@ -404,7 +416,7 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Local writable star-magnitude property exposing `current` and `estimated`.
     pcf::IndiProperty m_indiP_mag;
 
-    /// Local writable wind-speed property exposing `current` and `estimated`.
+    /// Local writable wind-speed selection property exposing `slow`, `normal`, and `fast`.
     pcf::IndiProperty m_indiP_windSpeed;
 
     /// Local toggle selecting whether predicted outputs use estimated inputs.
@@ -440,7 +452,7 @@ class strehlEstimator : public MagAOXApp<true>,
     /// Callback for local seeing estimate writes.
     INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_seeing_magaox );
 
-    /// Callback for local wind-speed estimate writes.
+    /// Callback for local wind-speed selection writes.
     INDI_NEWCALLBACK_DECL( strehlEstimator, m_indiP_windSpeed );
 
     /// Callback for the `use_estimates` toggle.
@@ -462,7 +474,7 @@ void strehlEstimator::setupConfig()
     m_aosys.loadMagAOX();
     m_aosysScan.loadMagAOX();
 
-    m_windSpeedEstimated = m_aosys.atm.v_wind();
+    m_windSpeed = windSpeedSelectionValue( windSpeedSelectionName( m_aosys.atm.v_wind() ) );
 
     config.add( "loop.number",
                 "",
@@ -576,7 +588,53 @@ float strehlEstimator::selectedSeeing() const
 float strehlEstimator::selectedWindSpeed() const
 {
     std::lock_guard<std::mutex> lock( m_stateMutex );
-    return m_windSpeedEstimated;
+    return m_windSpeed;
+}
+
+const std::vector<std::string> &strehlEstimator::windSpeedSelectionElements()
+{
+    static const std::vector<std::string> names{ "slow", "normal", "fast" };
+    return names;
+}
+
+const std::vector<std::string> &strehlEstimator::windSpeedSelectionLabels()
+{
+    static const std::vector<std::string> labels{ "Slow (9.4 m/s)", "Normal (18.7 m/s)", "Fast (23.4 m/s)" };
+    return labels;
+}
+
+float strehlEstimator::windSpeedSelectionValue( const std::string &selection )
+{
+    if( selection == "fast" )
+    {
+        return 23.4f;
+    }
+
+    if( selection == "normal" )
+    {
+        return 18.7f;
+    }
+
+    return 9.4f;
+}
+
+std::string strehlEstimator::windSpeedSelectionName( float windSpeed )
+{
+    float slowDiff   = std::fabs( windSpeed - 9.4f );
+    float normalDiff = std::fabs( windSpeed - 18.7f );
+    float fastDiff   = std::fabs( windSpeed - 23.4f );
+
+    if( normalDiff < slowDiff && normalDiff <= fastDiff )
+    {
+        return "normal";
+    }
+
+    if( fastDiff < slowDiff && fastDiff < normalDiff )
+    {
+        return "fast";
+    }
+
+    return "slow";
 }
 
 strehlEstimator::predictionInputs strehlEstimator::snapshotPredictionInputs() const
@@ -586,32 +644,32 @@ strehlEstimator::predictionInputs strehlEstimator::snapshotPredictionInputs() co
     { // mutex scope
         std::lock_guard<std::mutex> lock( m_stateMutex );
 
-        inputs.m_fps                = m_fps;
-        inputs.m_emg                = m_emg;
-        inputs.m_qe                 = m_qe;
-        inputs.m_F0                 = m_F0;
-        inputs.m_lam0               = m_lam0;
-        inputs.m_elevation          = m_elevation;
-        inputs.m_npix               = m_npix;
-        inputs.m_mag                = m_mag;
-        inputs.m_magEstimated       = m_magEstimated;
-        inputs.m_seeing             = m_seeing;
-        inputs.m_seeingEstimated    = m_seeingEstimated;
-        inputs.m_windSpeedEstimated = m_windSpeedEstimated;
-        inputs.m_useEstimates       = m_useEstimates;
+        inputs.m_fps             = m_fps;
+        inputs.m_emg             = m_emg;
+        inputs.m_qe              = m_qe;
+        inputs.m_F0              = m_F0;
+        inputs.m_lam0            = m_lam0;
+        inputs.m_elevation       = m_elevation;
+        inputs.m_npix            = m_npix;
+        inputs.m_mag             = m_mag;
+        inputs.m_magEstimated    = m_magEstimated;
+        inputs.m_seeing          = m_seeing;
+        inputs.m_seeingEstimated = m_seeingEstimated;
+        inputs.m_windSpeed       = m_windSpeed;
+        inputs.m_useEstimates    = m_useEstimates;
     }
 
     if( inputs.m_useEstimates )
     {
         inputs.m_selectedMag       = inputs.m_magEstimated;
         inputs.m_selectedSeeing    = inputs.m_seeingEstimated;
-        inputs.m_selectedWindSpeed = inputs.m_windSpeedEstimated;
+        inputs.m_selectedWindSpeed = inputs.m_windSpeed;
     }
     else
     {
         inputs.m_selectedMag       = inputs.m_mag;
         inputs.m_selectedSeeing    = inputs.m_seeing;
-        inputs.m_selectedWindSpeed = inputs.m_windSpeedEstimated;
+        inputs.m_selectedWindSpeed = inputs.m_windSpeed;
     }
 
     return inputs;
@@ -661,7 +719,8 @@ float strehlEstimator::wfeNm( float variance, float lam0 )
 
 void strehlEstimator::updatePlanningProperties()
 {
-    predictionInputs inputs = snapshotPredictionInputs();
+    predictionInputs inputs        = snapshotPredictionInputs();
+    std::string      windSelection = windSpeedSelectionName( inputs.m_windSpeed );
 
     if( !m_indiDriver )
     {
@@ -673,8 +732,11 @@ void strehlEstimator::updatePlanningProperties()
         m_indiP_seeing_magaox["estimated"].set( inputs.m_seeingEstimated );
         m_indiP_seeing_magaox.setState( INDI_OK );
 
-        m_indiP_windSpeed["current"].set( inputs.m_windSpeedEstimated );
-        m_indiP_windSpeed["estimated"].set( inputs.m_windSpeedEstimated );
+        for( auto &&el : m_indiP_windSpeed.getElements() )
+        {
+            m_indiP_windSpeed[el.first].setSwitchState( el.first == windSelection ? pcf::IndiElement::On
+                                                                                  : pcf::IndiElement::Off );
+        }
         m_indiP_windSpeed.setState( INDI_OK );
 
         m_indiP_useEstimates["toggle"].setSwitchState( inputs.m_useEstimates ? pcf::IndiElement::On
@@ -687,8 +749,7 @@ void strehlEstimator::updatePlanningProperties()
     updatesIfChanged<float>( m_indiP_mag, { "current", "estimated" }, { inputs.m_mag, inputs.m_magEstimated } );
     updatesIfChanged<float>(
         m_indiP_seeing_magaox, { "current", "estimated" }, { inputs.m_seeing, inputs.m_seeingEstimated } );
-    updatesIfChanged<float>(
-        m_indiP_windSpeed, { "current", "estimated" }, { inputs.m_windSpeedEstimated, inputs.m_windSpeedEstimated } );
+    indi::updateSelectionSwitchIfChanged( m_indiP_windSpeed, windSelection, m_indiDriver, INDI_OK );
     updateSwitchIfChanged( m_indiP_useEstimates,
                            "toggle",
                            inputs.m_useEstimates ? pcf::IndiElement::On : pcf::IndiElement::Off,
@@ -913,9 +974,14 @@ int strehlEstimator::appStartup()
         return log<software_error, -1>( { __FILE__, __LINE__, "error from registerIndiPropertyNew" } );
     }
 
-    if( createCurrentEstimatedProperty( m_indiP_windSpeed, "wind_speed", "Wind Speed", "Error Budget" ) < 0 )
+    if( createStandardIndiSelectionSw( m_indiP_windSpeed,
+                                       "wind_speed",
+                                       windSpeedSelectionElements(),
+                                       windSpeedSelectionLabels(),
+                                       "Wind Speed",
+                                       "Error Budget" ) < 0 )
     {
-        return log<software_error, -1>( { __FILE__, __LINE__, "error from createCurrentEstimatedProperty" } );
+        return log<software_error, -1>( { __FILE__, __LINE__, "error from createStandardIndiSelectionSw" } );
     }
     if( registerIndiPropertyNew( m_indiP_windSpeed, INDI_NEWCALLBACK( m_indiP_windSpeed ) ) < 0 )
     {
@@ -1332,26 +1398,38 @@ INDI_NEWCALLBACK_DEFN( strehlEstimator, m_indiP_windSpeed )( const pcf::IndiProp
 {
     INDI_VALIDATE_CALLBACK_PROPS( m_indiP_windSpeed, ipRecv );
 
-    if( ipRecv.find( "estimated" ) )
+    std::string selection;
+    for( auto &&el : ipRecv.getElements() )
     {
-        float windSpeed = ipRecv["estimated"].get<float>();
-
-        bool changed = false;
-
-        { // mutex scope
-            std::lock_guard<std::mutex> lock( m_stateMutex );
-            if( finitePositiveValue( windSpeed ) && windSpeed != m_windSpeedEstimated )
-            {
-                m_windSpeedEstimated = windSpeed;
-                changed              = true;
-            }
-        }
-
-        if( changed )
+        if( el.second.getSwitchState() == pcf::IndiElement::On )
         {
-            updatePlanningProperties();
-            updatePredictionOutputs();
+            selection = el.first;
+            break;
         }
+    }
+
+    if( selection == "" )
+    {
+        return 0;
+    }
+
+    float windSpeed = windSpeedSelectionValue( selection );
+    bool  changed   = false;
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_stateMutex );
+        if( finitePositiveValue( windSpeed ) && windSpeed != m_windSpeed )
+        {
+            m_windSpeed = windSpeed;
+            changed     = true;
+        }
+    }
+
+    updatePlanningProperties();
+
+    if( changed )
+    {
+        updatePredictionOutputs();
     }
 
     return 0;

--- a/apps/strehlEstimator/tests/strehlEstimator_test.cpp
+++ b/apps/strehlEstimator/tests/strehlEstimator_test.cpp
@@ -453,6 +453,9 @@ TEST_CASE( "strehlEstimator freezes auto-tracked estimates while use_estimates i
     useEstimates["toggle"].setSwitchState( pcf::IndiElement::On );
     REQUIRE( app.newCallBack_m_indiP_useEstimates( useEstimates ) == 0 );
 
+    const float frozenPredictedStrehl = app.predictedStrehl();
+    const float frozenOptimumFPS      = app.optimumFPS();
+
     app.setPhotometry( 12000.0f, 196 );
 
     pcf::IndiProperty updatedSeeing = makeRemoteNumberProperty( "tcsi", "seeing" );
@@ -465,6 +468,8 @@ TEST_CASE( "strehlEstimator freezes auto-tracked estimates while use_estimates i
     REQUIRE( app.estimatedSeeing() == Approx( frozenSeeing ) );
     REQUIRE( app.selectedMagDirect() == Approx( frozenMag ) );
     REQUIRE( app.selectedSeeingDirect() == Approx( frozenSeeing ) );
+    REQUIRE( app.predictedStrehl() == Approx( frozenPredictedStrehl ) );
+    REQUIRE( app.optimumFPS() == Approx( frozenOptimumFPS ) );
     REQUIRE( app.liveMag() != Approx( frozenMag ) );
     REQUIRE( app.liveSeeing() != Approx( frozenSeeing ) );
 }

--- a/apps/strehlEstimator/tests/strehlEstimator_test.cpp
+++ b/apps/strehlEstimator/tests/strehlEstimator_test.cpp
@@ -225,7 +225,8 @@ class strehlEstimator_test : public strehlEstimator
     /// Evaluate the configured AO model at one FPS sample for test-side brute-force comparisons.
     float predictedStrehlAtFps( float fps, bool optimizeTau )
     {
-        configureAoSystem( m_aosysScan, fps, optimizeTau );
+        predictionInputs inputs = snapshotPredictionInputs();
+        configureAoSystem( m_aosysScan, inputs, fps, optimizeTau );
         return m_aosysScan.strehl();
     }
 };

--- a/apps/strehlEstimator/tests/strehlEstimator_test.cpp
+++ b/apps/strehlEstimator/tests/strehlEstimator_test.cpp
@@ -1,18 +1,9 @@
 /** \file strehlEstimator_test.cpp
  * \brief Catch2 tests for the strehlEstimator app.
- * \author Jared R. Males (jaredmales@gmail.com)
+ * \author OpenAI Codex
  *
  * \ingroup strehlEstimator_files
  */
-
-#include "../../../tests/testXWC.hpp"
-
-#include "../strehlEstimator.hpp"
-
-using namespace MagAOX::app;
-
-namespace libXWCTest
-{
 
 /** \defgroup strehlEstimator_unit_test strehlEstimator Unit Tests
  * \brief Unit tests for the strehlEstimator application.
@@ -20,30 +11,492 @@ namespace libXWCTest
  * \ingroup application_unit_test
  */
 
+#include "../strehlEstimator.hpp"
+
+#include "../../../tests/testMacrosINDI.hpp"
+#include "../../../tests/testXWC.hpp"
+
+#include <cmath>
+
+using namespace MagAOX::app;
+
+namespace libXWCTest
+{
+
 /// Namespace for `strehlEstimator` unit tests.
 /** \ingroup strehlEstimator_unit_test
  */
 namespace strehlEstimatorTest
 {
 
-/// Verify the placeholder strehlEstimator test harness instantiates the app cleanly.
+namespace
+{
+
+/// \cond DOXYGEN_SUPPRESS_TEST_HARNESS
+/// Test harness exposing the `strehlEstimator` internals needed by the unit tests.
+class strehlEstimator_test : public strehlEstimator
+{
+  public:
+    /// Construct a testable `strehlEstimator` instance with callback keys pre-seeded.
+    strehlEstimator_test( const std::string &device )
+    {
+        m_configName = device;
+
+        setupConfig();
+
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_fps, camwfs, fps );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_emg, camwfs, emgain );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_stage, stagebs, presetName );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_tcsi_seeing, tcsi, seeing );
+        XWCTEST_SETUP_INDI_ARB_PROP( m_indiP_tcsi_telpos, tcsi, telpos );
+
+        XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_mag, star_mag );
+        XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_seeing_magaox, seeing );
+        XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_windSpeed, wind_speed );
+        XWCTEST_SETUP_INDI_ARB_NEW_PROP( m_indiP_useEstimates, use_estimates );
+    }
+
+    /// Initialize the published INDI properties without starting the shmim-monitor threads.
+    int initializePublishedProperties()
+    {
+        if( createCurrentEstimatedProperty( m_indiP_mag, "star_mag", "Star Magnitude", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+
+        if( createCurrentEstimatedProperty( m_indiP_seeing_magaox, "seeing", "Seeing", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+
+        if( createCurrentEstimatedProperty( m_indiP_windSpeed, "wind_speed", "Wind Speed", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+
+        if( createStandardIndiToggleSw( m_indiP_useEstimates, "use_estimates", "Use Estimates", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+
+        if( createROIndiNumber( m_indiP_strehl, "strehl_optimal", "Strehl", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+        m_indiP_strehl.add( pcf::IndiElement( "pyramid", 0.0f ) );
+
+        if( createROIndiNumber( m_indiP_wfe, "wfe_predicted", "WFE", "Error Budget" ) < 0 )
+        {
+            return -1;
+        }
+        m_indiP_wfe.add( pcf::IndiElement( "total", 0.0f ) );
+        m_indiP_wfe.add( pcf::IndiElement( "measurement", 0.0f ) );
+        m_indiP_wfe.add( pcf::IndiElement( "time_delay", 0.0f ) );
+        m_indiP_wfe.add( pcf::IndiElement( "fitting", 0.0f ) );
+
+        if( createROIndiNumber( m_indiP_loopSpeedOptimum, "loop_speed_optimum", "Optimum Loop Speed", "Error Budget" ) <
+            0 )
+        {
+            return -1;
+        }
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "fps", 0.0f ) );
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "strehl", 0.0f ) );
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_total", 0.0f ) );
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_measurement", 0.0f ) );
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_time_delay", 0.0f ) );
+        m_indiP_loopSpeedOptimum.add( pcf::IndiElement( "wfe_fitting", 0.0f ) );
+
+        updatePlanningProperties();
+        updatePredictionOutputs();
+
+        return 0;
+    }
+
+    /// Recompute the public prediction properties immediately.
+    void refreshPredictions()
+    {
+        updatePredictionOutputs();
+    }
+
+    /// Seed the live photometry inputs and recalculate the live guide-star magnitude.
+    void setPhotometry( float counts, int npix )
+    {
+        m_counts = counts;
+        m_npix   = npix;
+        calcMag();
+    }
+
+    /// Return the current live guide-star magnitude.
+    float liveMag() const
+    {
+        return m_mag;
+    }
+
+    /// Return the estimated guide-star magnitude.
+    float estimatedMag() const
+    {
+        return m_magEstimated;
+    }
+
+    /// Return the current live seeing.
+    float liveSeeing() const
+    {
+        return m_seeing;
+    }
+
+    /// Return the estimated seeing.
+    float estimatedSeeing() const
+    {
+        return m_seeingEstimated;
+    }
+
+    /// Return the estimated wind speed.
+    float estimatedWindSpeed() const
+    {
+        return m_windSpeedEstimated;
+    }
+
+    /// Return whether estimate overrides are currently enabled.
+    bool useEstimates() const
+    {
+        return m_useEstimates;
+    }
+
+    /// Return the selected star magnitude used by the AO model.
+    float selectedMagDirect() const
+    {
+        return selectedStarMag();
+    }
+
+    /// Return the selected seeing used by the AO model.
+    float selectedSeeingDirect() const
+    {
+        return selectedSeeing();
+    }
+
+    /// Return the published star-magnitude property.
+    const pcf::IndiProperty &starMagProperty() const
+    {
+        return m_indiP_mag;
+    }
+
+    /// Return the published seeing property.
+    const pcf::IndiProperty &seeingProperty() const
+    {
+        return m_indiP_seeing_magaox;
+    }
+
+    /// Return the published wind-speed property.
+    const pcf::IndiProperty &windSpeedProperty() const
+    {
+        return m_indiP_windSpeed;
+    }
+
+    /// Return the published `use_estimates` toggle property.
+    const pcf::IndiProperty &useEstimatesProperty() const
+    {
+        return m_indiP_useEstimates;
+    }
+
+    /// Return the published optimum-loop-speed property.
+    const pcf::IndiProperty &optimumLoopSpeedProperty() const
+    {
+        return m_indiP_loopSpeedOptimum;
+    }
+
+    /// Return the published current-prediction Strehl.
+    float predictedStrehl() const
+    {
+        return m_indiP_strehl["pyramid"].get<float>();
+    }
+
+    /// Return the published optimum-loop-speed FPS.
+    float optimumFPS() const
+    {
+        return m_indiP_loopSpeedOptimum["fps"].get<float>();
+    }
+
+    /// Return the published optimum-loop-speed Strehl.
+    float optimumStrehl() const
+    {
+        return m_indiP_loopSpeedOptimum["strehl"].get<float>();
+    }
+
+    /// Evaluate the configured AO model at one FPS sample for test-side brute-force comparisons.
+    float predictedStrehlAtFps( float fps, bool optimizeTau )
+    {
+        configureAoSystem( m_aosysScan, fps, optimizeTau );
+        return m_aosysScan.strehl();
+    }
+};
+/// \endcond
+
+/// Build a number-property update payload for the local app.
+pcf::IndiProperty makeLocalNumberProperty( const std::string &device, const std::string &name )
+{
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
+    ip.setDevice( device );
+    ip.setName( name );
+    return ip;
+}
+
+/// Build a switch-property update payload for the local app.
+pcf::IndiProperty makeLocalSwitchProperty( const std::string &device, const std::string &name )
+{
+    pcf::IndiProperty ip( pcf::IndiProperty::Switch );
+    ip.setDevice( device );
+    ip.setName( name );
+    return ip;
+}
+
+/// Build a set-property payload from another device.
+pcf::IndiProperty makeRemoteNumberProperty( const std::string &device, const std::string &name )
+{
+    pcf::IndiProperty ip( pcf::IndiProperty::Number );
+    ip.setDevice( device );
+    ip.setName( name );
+    return ip;
+}
+
+} // namespace
+
+/// Verify the `strehlEstimator` callbacks reject mismatched property identities.
 /**
  * \ingroup strehlEstimator_unit_test
  */
-TEST_CASE( "strehlEstimator placeholder harness instantiates the app", "[strehlEstimator]" )
+TEST_CASE( "strehlEstimator callbacks validate the property identity", "[strehlEstimator][indi]" )
 {
     // clang-format off
     #ifdef STREHLESTIMATOR_TEST_DOXYGEN_REF
-    strehlEstimator();
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_fps( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_emg( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_stage( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_tcsi_seeing( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_tcsi_telpos( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_mag( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_seeing_magaox( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_windSpeed( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_useEstimates( std::declval<const pcf::IndiProperty &>() ) );
     #endif
     // clang-format on
 
-    SECTION( "default construction succeeds" )
-    {
-        strehlEstimator app;
+    XWCTEST_INDI_SET_CALLBACK( strehlEstimator, m_indiP_fps, camwfs, fps );
+    XWCTEST_INDI_SET_CALLBACK( strehlEstimator, m_indiP_emg, camwfs, emgain );
+    XWCTEST_INDI_SET_CALLBACK( strehlEstimator, m_indiP_stage, stagebs, presetName );
+    XWCTEST_INDI_SET_CALLBACK( strehlEstimator, m_indiP_tcsi_seeing, tcsi, seeing );
+    XWCTEST_INDI_SET_CALLBACK( strehlEstimator, m_indiP_tcsi_telpos, tcsi, telpos );
 
-        REQUIRE( true );
+    XWCTEST_INDI_ARBNEW_CALLBACK( strehlEstimator, newCallBack_m_indiP_mag, star_mag );
+    XWCTEST_INDI_ARBNEW_CALLBACK( strehlEstimator, newCallBack_m_indiP_seeing_magaox, seeing );
+    XWCTEST_INDI_ARBNEW_CALLBACK( strehlEstimator, newCallBack_m_indiP_windSpeed, wind_speed );
+    XWCTEST_INDI_ARBNEW_CALLBACK( strehlEstimator, newCallBack_m_indiP_useEstimates, use_estimates );
+}
+
+/// Verify published-property initialization creates the planning-input and optimum-speed properties with the expected
+/// elements.
+/**
+ * \ingroup strehlEstimator_unit_test
+ */
+TEST_CASE( "strehlEstimator startup publishes planning and optimum-speed properties", "[strehlEstimator]" )
+{
+    strehlEstimator_test app( "strehlEstimator_test" );
+
+    REQUIRE( app.initializePublishedProperties() == 0 );
+
+    REQUIRE( app.starMagProperty().find( "current" ) );
+    REQUIRE( app.starMagProperty().find( "estimated" ) );
+
+    REQUIRE( app.seeingProperty().find( "current" ) );
+    REQUIRE( app.seeingProperty().find( "estimated" ) );
+
+    REQUIRE( app.windSpeedProperty().find( "current" ) );
+    REQUIRE( app.windSpeedProperty().find( "estimated" ) );
+    REQUIRE( app.windSpeedProperty()["current"].get<float>() == Approx( app.estimatedWindSpeed() ) );
+
+    REQUIRE( app.useEstimatesProperty().find( "toggle" ) );
+    REQUIRE( app.useEstimatesProperty()["toggle"].getSwitchState() == pcf::IndiElement::Off );
+
+    REQUIRE( app.optimumLoopSpeedProperty().find( "fps" ) );
+    REQUIRE( app.optimumLoopSpeedProperty().find( "strehl" ) );
+    REQUIRE( app.optimumLoopSpeedProperty().find( "wfe_total" ) );
+    REQUIRE( app.optimumLoopSpeedProperty().find( "wfe_measurement" ) );
+    REQUIRE( app.optimumLoopSpeedProperty().find( "wfe_time_delay" ) );
+    REQUIRE( app.optimumLoopSpeedProperty().find( "wfe_fitting" ) );
+}
+
+/// Verify local planning-input writes only honor `estimated`, while live updates continue to drive `current`.
+/**
+ * \ingroup strehlEstimator_unit_test
+ */
+TEST_CASE( "strehlEstimator ignores writes to current and accepts writes to estimated", "[strehlEstimator]" )
+{
+    // clang-format off
+    #ifdef STREHLESTIMATOR_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( strehlEstimator::calcMag() );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_mag( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_seeing_magaox( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_windSpeed( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_tcsi_seeing( std::declval<const pcf::IndiProperty &>() ) );
+    #endif
+    // clang-format on
+
+    strehlEstimator_test app( "right" );
+
+    REQUIRE( app.initializePublishedProperties() == 0 );
+
+    app.setPhotometry( 25000.0f, 144 );
+    REQUIRE( app.estimatedMag() == Approx( app.liveMag() ) );
+
+    SECTION( "star magnitude current writes are ignored" )
+    {
+        pcf::IndiProperty ip = makeLocalNumberProperty( "right", "star_mag" );
+        ip.add( pcf::IndiElement( "current" ) );
+        ip["current"].set( app.liveMag() + 2.0f );
+
+        REQUIRE( app.newCallBack_m_indiP_mag( ip ) == 0 );
+        REQUIRE( app.estimatedMag() == Approx( app.liveMag() ) );
     }
+
+    SECTION( "star magnitude estimated writes are accepted" )
+    {
+        pcf::IndiProperty ip = makeLocalNumberProperty( "right", "star_mag" );
+        ip.add( pcf::IndiElement( "estimated" ) );
+        ip["estimated"].set( app.liveMag() + 2.0f );
+
+        REQUIRE( app.newCallBack_m_indiP_mag( ip ) == 0 );
+        REQUIRE( app.estimatedMag() == Approx( app.liveMag() + 2.0f ) );
+    }
+
+    SECTION( "live TCS seeing updates the current value" )
+    {
+        pcf::IndiProperty ip = makeRemoteNumberProperty( "tcsi", "seeing" );
+        ip.add( pcf::IndiElement( "dimm_fwhm_corr" ) );
+        ip["dimm_fwhm_corr"].set( 0.83f );
+
+        REQUIRE( app.setCallBack_m_indiP_tcsi_seeing( ip ) == 0 );
+        REQUIRE( app.liveSeeing() == Approx( 0.83f ) );
+        REQUIRE( app.estimatedSeeing() == Approx( 0.83f ) );
+    }
+
+    SECTION( "local seeing current writes are ignored and estimated writes are accepted" )
+    {
+        pcf::IndiProperty live = makeRemoteNumberProperty( "tcsi", "seeing" );
+        live.add( pcf::IndiElement( "dimm_fwhm_corr" ) );
+        live["dimm_fwhm_corr"].set( 0.76f );
+        REQUIRE( app.setCallBack_m_indiP_tcsi_seeing( live ) == 0 );
+
+        pcf::IndiProperty currentWrite = makeLocalNumberProperty( "right", "seeing" );
+        currentWrite.add( pcf::IndiElement( "current" ) );
+        currentWrite["current"].set( 0.40f );
+        REQUIRE( app.newCallBack_m_indiP_seeing_magaox( currentWrite ) == 0 );
+        REQUIRE( app.estimatedSeeing() == Approx( 0.76f ) );
+
+        pcf::IndiProperty estimatedWrite = makeLocalNumberProperty( "right", "seeing" );
+        estimatedWrite.add( pcf::IndiElement( "estimated" ) );
+        estimatedWrite["estimated"].set( 1.15f );
+        REQUIRE( app.newCallBack_m_indiP_seeing_magaox( estimatedWrite ) == 0 );
+        REQUIRE( app.estimatedSeeing() == Approx( 1.15f ) );
+    }
+
+    SECTION( "wind current writes are ignored and estimated writes update both elements" )
+    {
+        const float initialWind = app.windSpeedProperty()["current"].get<float>();
+
+        pcf::IndiProperty currentWrite = makeLocalNumberProperty( "right", "wind_speed" );
+        currentWrite.add( pcf::IndiElement( "current" ) );
+        currentWrite["current"].set( initialWind + 5.0f );
+        REQUIRE( app.newCallBack_m_indiP_windSpeed( currentWrite ) == 0 );
+        REQUIRE( app.estimatedWindSpeed() == Approx( initialWind ) );
+
+        pcf::IndiProperty estimatedWrite = makeLocalNumberProperty( "right", "wind_speed" );
+        estimatedWrite.add( pcf::IndiElement( "estimated" ) );
+        estimatedWrite["estimated"].set( initialWind + 7.0f );
+        REQUIRE( app.newCallBack_m_indiP_windSpeed( estimatedWrite ) == 0 );
+        REQUIRE( app.estimatedWindSpeed() == Approx( initialWind + 7.0f ) );
+        REQUIRE( app.windSpeedProperty()["current"].get<float>() == Approx( initialWind + 7.0f ) );
+        REQUIRE( app.windSpeedProperty()["estimated"].get<float>() == Approx( initialWind + 7.0f ) );
+    }
+}
+
+/// Verify estimate selection changes the published predictions and the optimum-loop-speed summary matches the fixed FPS
+/// grid.
+/**
+ * \ingroup strehlEstimator_unit_test
+ */
+TEST_CASE( "strehlEstimator uses estimates when requested and scans the fixed loop-speed grid", "[strehlEstimator]" )
+{
+    // clang-format off
+    #ifdef STREHLESTIMATOR_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( strehlEstimator::updatePredictionOutputs() );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::updateOptimumLoopSpeed() );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_useEstimates( std::declval<const pcf::IndiProperty &>() ) );
+    #endif
+    // clang-format on
+
+    strehlEstimator_test app( "right" );
+
+    REQUIRE( app.initializePublishedProperties() == 0 );
+
+    app.setPhotometry( 30000.0f, 196 );
+
+    pcf::IndiProperty liveSeeing = makeRemoteNumberProperty( "tcsi", "seeing" );
+    liveSeeing.add( pcf::IndiElement( "dimm_fwhm_corr" ) );
+    liveSeeing["dimm_fwhm_corr"].set( 0.55f );
+    REQUIRE( app.setCallBack_m_indiP_tcsi_seeing( liveSeeing ) == 0 );
+
+    pcf::IndiProperty liveElevation = makeRemoteNumberProperty( "tcsi", "telpos" );
+    liveElevation.add( pcf::IndiElement( "el" ) );
+    liveElevation["el"].set( 72.0f );
+    REQUIRE( app.setCallBack_m_indiP_tcsi_telpos( liveElevation ) == 0 );
+
+    const float liveSelectedMag     = app.selectedMagDirect();
+    const float liveSelectedSeeing  = app.selectedSeeingDirect();
+    const float livePredictedStrehl = app.predictedStrehl();
+
+    pcf::IndiProperty magEstimate = makeLocalNumberProperty( "right", "star_mag" );
+    magEstimate.add( pcf::IndiElement( "estimated" ) );
+    magEstimate["estimated"].set( liveSelectedMag + 4.0f );
+    REQUIRE( app.newCallBack_m_indiP_mag( magEstimate ) == 0 );
+
+    pcf::IndiProperty seeingEstimate = makeLocalNumberProperty( "right", "seeing" );
+    seeingEstimate.add( pcf::IndiElement( "estimated" ) );
+    seeingEstimate["estimated"].set( 1.10f );
+    REQUIRE( app.newCallBack_m_indiP_seeing_magaox( seeingEstimate ) == 0 );
+
+    pcf::IndiProperty windEstimate = makeLocalNumberProperty( "right", "wind_speed" );
+    windEstimate.add( pcf::IndiElement( "estimated" ) );
+    windEstimate["estimated"].set( 18.0f );
+    REQUIRE( app.newCallBack_m_indiP_windSpeed( windEstimate ) == 0 );
+
+    pcf::IndiProperty useEstimates = makeLocalSwitchProperty( "right", "use_estimates" );
+    useEstimates.add( pcf::IndiElement( "toggle" ) );
+    useEstimates["toggle"].setSwitchState( pcf::IndiElement::On );
+    REQUIRE( app.newCallBack_m_indiP_useEstimates( useEstimates ) == 0 );
+
+    REQUIRE( app.useEstimates() == true );
+    REQUIRE( app.selectedMagDirect() == Approx( app.estimatedMag() ) );
+    REQUIRE( app.selectedSeeingDirect() == Approx( app.estimatedSeeing() ) );
+    REQUIRE( app.selectedMagDirect() != Approx( liveSelectedMag ) );
+    REQUIRE( app.selectedSeeingDirect() != Approx( liveSelectedSeeing ) );
+    REQUIRE( app.predictedStrehl() != Approx( livePredictedStrehl ) );
+
+    float bruteForceBestFps    = 0.0f;
+    float bruteForceBestStrehl = -1.0f;
+    for( int fps = 100; fps <= 3000; fps += 100 )
+    {
+        float strehl = app.predictedStrehlAtFps( static_cast<float>( fps ), false );
+        if( bruteForceBestFps == 0.0f || strehl > bruteForceBestStrehl )
+        {
+            bruteForceBestFps    = static_cast<float>( fps );
+            bruteForceBestStrehl = strehl;
+        }
+    }
+
+    REQUIRE( app.optimumFPS() >= 100.0f );
+    REQUIRE( app.optimumFPS() <= 3000.0f );
+    REQUIRE( std::fmod( app.optimumFPS(), 100.0f ) == Approx( 0.0f ).margin( 1.0e-4 ) );
+    REQUIRE( app.optimumFPS() == Approx( bruteForceBestFps ) );
+    REQUIRE( app.optimumStrehl() == Approx( bruteForceBestStrehl ) );
 }
 
 } // namespace strehlEstimatorTest

--- a/apps/strehlEstimator/tests/strehlEstimator_test.cpp
+++ b/apps/strehlEstimator/tests/strehlEstimator_test.cpp
@@ -69,7 +69,12 @@ class strehlEstimator_test : public strehlEstimator
             return -1;
         }
 
-        if( createCurrentEstimatedProperty( m_indiP_windSpeed, "wind_speed", "Wind Speed", "Error Budget" ) < 0 )
+        if( createStandardIndiSelectionSw( m_indiP_windSpeed,
+                                           "wind_speed",
+                                           windSpeedSelectionElements(),
+                                           windSpeedSelectionLabels(),
+                                           "Wind Speed",
+                                           "Error Budget" ) < 0 )
         {
             return -1;
         }
@@ -150,10 +155,16 @@ class strehlEstimator_test : public strehlEstimator
         return m_seeingEstimated;
     }
 
-    /// Return the estimated wind speed.
-    float estimatedWindSpeed() const
+    /// Return the selected wind speed value in m/s.
+    float windSpeed() const
     {
-        return m_windSpeedEstimated;
+        return m_windSpeed;
+    }
+
+    /// Return the selected wind-speed switch element name.
+    std::string windSpeedSelection() const
+    {
+        return windSpeedSelectionName( m_windSpeed );
     }
 
     /// Return whether estimate overrides are currently enabled.
@@ -310,9 +321,10 @@ TEST_CASE( "strehlEstimator startup publishes planning and optimum-speed propert
     REQUIRE( app.seeingProperty().find( "current" ) );
     REQUIRE( app.seeingProperty().find( "estimated" ) );
 
-    REQUIRE( app.windSpeedProperty().find( "current" ) );
-    REQUIRE( app.windSpeedProperty().find( "estimated" ) );
-    REQUIRE( app.windSpeedProperty()["current"].get<float>() == Approx( app.estimatedWindSpeed() ) );
+    REQUIRE( app.windSpeedProperty().find( "slow" ) );
+    REQUIRE( app.windSpeedProperty().find( "normal" ) );
+    REQUIRE( app.windSpeedProperty().find( "fast" ) );
+    REQUIRE( app.windSpeedProperty()[app.windSpeedSelection()].getSwitchState() == pcf::IndiElement::On );
 
     REQUIRE( app.useEstimatesProperty().find( "toggle" ) );
     REQUIRE( app.useEstimatesProperty()["toggle"].getSwitchState() == pcf::IndiElement::Off );
@@ -325,11 +337,12 @@ TEST_CASE( "strehlEstimator startup publishes planning and optimum-speed propert
     REQUIRE( app.optimumLoopSpeedProperty().find( "wfe_fitting" ) );
 }
 
-/// Verify local planning-input writes only honor `estimated`, while live updates continue to drive `current`.
+/// Verify local star-magnitude and seeing writes only honor `estimated`, while the wind-speed selector updates the
+/// planning wind state.
 /**
  * \ingroup strehlEstimator_unit_test
  */
-TEST_CASE( "strehlEstimator ignores writes to current and accepts writes to estimated", "[strehlEstimator]" )
+TEST_CASE( "strehlEstimator planning inputs honor estimated writes and wind-speed selections", "[strehlEstimator]" )
 {
     // clang-format off
     #ifdef STREHLESTIMATOR_TEST_DOXYGEN_REF
@@ -399,23 +412,21 @@ TEST_CASE( "strehlEstimator ignores writes to current and accepts writes to esti
         REQUIRE( app.estimatedSeeing() == Approx( 1.15f ) );
     }
 
-    SECTION( "wind current writes are ignored and estimated writes update both elements" )
+    SECTION( "wind-speed selection writes update the planning wind speed" )
     {
-        const float initialWind = app.windSpeedProperty()["current"].get<float>();
+        pcf::IndiProperty normal = makeLocalSwitchProperty( "right", "wind_speed" );
+        normal.add( pcf::IndiElement( "normal" ) );
+        normal["normal"].setSwitchState( pcf::IndiElement::On );
+        REQUIRE( app.newCallBack_m_indiP_windSpeed( normal ) == 0 );
+        REQUIRE( app.windSpeed() == Approx( 18.7f ) );
+        REQUIRE( app.windSpeedProperty()["normal"].getSwitchState() == pcf::IndiElement::On );
 
-        pcf::IndiProperty currentWrite = makeLocalNumberProperty( "right", "wind_speed" );
-        currentWrite.add( pcf::IndiElement( "current" ) );
-        currentWrite["current"].set( initialWind + 5.0f );
-        REQUIRE( app.newCallBack_m_indiP_windSpeed( currentWrite ) == 0 );
-        REQUIRE( app.estimatedWindSpeed() == Approx( initialWind ) );
-
-        pcf::IndiProperty estimatedWrite = makeLocalNumberProperty( "right", "wind_speed" );
-        estimatedWrite.add( pcf::IndiElement( "estimated" ) );
-        estimatedWrite["estimated"].set( initialWind + 7.0f );
-        REQUIRE( app.newCallBack_m_indiP_windSpeed( estimatedWrite ) == 0 );
-        REQUIRE( app.estimatedWindSpeed() == Approx( initialWind + 7.0f ) );
-        REQUIRE( app.windSpeedProperty()["current"].get<float>() == Approx( initialWind + 7.0f ) );
-        REQUIRE( app.windSpeedProperty()["estimated"].get<float>() == Approx( initialWind + 7.0f ) );
+        pcf::IndiProperty fast = makeLocalSwitchProperty( "right", "wind_speed" );
+        fast.add( pcf::IndiElement( "fast" ) );
+        fast["fast"].setSwitchState( pcf::IndiElement::On );
+        REQUIRE( app.newCallBack_m_indiP_windSpeed( fast ) == 0 );
+        REQUIRE( app.windSpeed() == Approx( 23.4f ) );
+        REQUIRE( app.windSpeedProperty()["fast"].getSwitchState() == pcf::IndiElement::On );
     }
 }
 
@@ -519,10 +530,10 @@ TEST_CASE( "strehlEstimator uses estimates when requested and scans the fixed lo
     seeingEstimate["estimated"].set( 1.10f );
     REQUIRE( app.newCallBack_m_indiP_seeing_magaox( seeingEstimate ) == 0 );
 
-    pcf::IndiProperty windEstimate = makeLocalNumberProperty( "right", "wind_speed" );
-    windEstimate.add( pcf::IndiElement( "estimated" ) );
-    windEstimate["estimated"].set( 18.0f );
-    REQUIRE( app.newCallBack_m_indiP_windSpeed( windEstimate ) == 0 );
+    pcf::IndiProperty windSelection = makeLocalSwitchProperty( "right", "wind_speed" );
+    windSelection.add( pcf::IndiElement( "normal" ) );
+    windSelection["normal"].setSwitchState( pcf::IndiElement::On );
+    REQUIRE( app.newCallBack_m_indiP_windSpeed( windSelection ) == 0 );
 
     pcf::IndiProperty useEstimates = makeLocalSwitchProperty( "right", "use_estimates" );
     useEstimates.add( pcf::IndiElement( "toggle" ) );

--- a/apps/strehlEstimator/tests/strehlEstimator_test.cpp
+++ b/apps/strehlEstimator/tests/strehlEstimator_test.cpp
@@ -423,6 +423,56 @@ TEST_CASE( "strehlEstimator ignores writes to current and accepts writes to esti
 /**
  * \ingroup strehlEstimator_unit_test
  */
+TEST_CASE( "strehlEstimator freezes auto-tracked estimates while use_estimates is enabled", "[strehlEstimator]" )
+{
+    // clang-format off
+    #ifdef STREHLESTIMATOR_TEST_DOXYGEN_REF
+    XWCTEST_DOXYGEN_REF( strehlEstimator::calcMag() );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::setCallBack_m_indiP_tcsi_seeing( std::declval<const pcf::IndiProperty &>() ) );
+    XWCTEST_DOXYGEN_REF( strehlEstimator::newCallBack_m_indiP_useEstimates( std::declval<const pcf::IndiProperty &>() ) );
+    #endif
+    // clang-format on
+
+    strehlEstimator_test app( "right" );
+
+    REQUIRE( app.initializePublishedProperties() == 0 );
+
+    app.setPhotometry( 30000.0f, 196 );
+
+    pcf::IndiProperty initialSeeing = makeRemoteNumberProperty( "tcsi", "seeing" );
+    initialSeeing.add( pcf::IndiElement( "dimm_fwhm_corr" ) );
+    initialSeeing["dimm_fwhm_corr"].set( 0.55f );
+    REQUIRE( app.setCallBack_m_indiP_tcsi_seeing( initialSeeing ) == 0 );
+
+    const float frozenMag    = app.estimatedMag();
+    const float frozenSeeing = app.estimatedSeeing();
+
+    pcf::IndiProperty useEstimates = makeLocalSwitchProperty( "right", "use_estimates" );
+    useEstimates.add( pcf::IndiElement( "toggle" ) );
+    useEstimates["toggle"].setSwitchState( pcf::IndiElement::On );
+    REQUIRE( app.newCallBack_m_indiP_useEstimates( useEstimates ) == 0 );
+
+    app.setPhotometry( 12000.0f, 196 );
+
+    pcf::IndiProperty updatedSeeing = makeRemoteNumberProperty( "tcsi", "seeing" );
+    updatedSeeing.add( pcf::IndiElement( "dimm_fwhm_corr" ) );
+    updatedSeeing["dimm_fwhm_corr"].set( 0.92f );
+    REQUIRE( app.setCallBack_m_indiP_tcsi_seeing( updatedSeeing ) == 0 );
+
+    REQUIRE( app.useEstimates() == true );
+    REQUIRE( app.estimatedMag() == Approx( frozenMag ) );
+    REQUIRE( app.estimatedSeeing() == Approx( frozenSeeing ) );
+    REQUIRE( app.selectedMagDirect() == Approx( frozenMag ) );
+    REQUIRE( app.selectedSeeingDirect() == Approx( frozenSeeing ) );
+    REQUIRE( app.liveMag() != Approx( frozenMag ) );
+    REQUIRE( app.liveSeeing() != Approx( frozenSeeing ) );
+}
+
+/// Verify estimate selection changes the published predictions and the optimum-loop-speed summary matches the fixed FPS
+/// grid.
+/**
+ * \ingroup strehlEstimator_unit_test
+ */
 TEST_CASE( "strehlEstimator uses estimates when requested and scans the fixed loop-speed grid", "[strehlEstimator]" )
 {
     // clang-format off


### PR DESCRIPTION
This work was performed by Codex (GPT-5) in response to strehlEstimator_optimum_speed.md.

## Summary

This PR extends `strehlEstimator` with a planning-oriented optimum loop-speed tool and stabilizes its online behavior.

Changes included here:
- Adds planning inputs for `star_mag` and `seeing` with `current` and `estimated` elements.
- Adds a `use_estimates` toggle to switch the prediction path between live inputs and planning inputs.
- Adds a new `loop_speed_optimum` summary property computed on a fixed 100 Hz grid from 100 Hz to 3000 Hz.
- Ignores attempted writes to `current` for the writable planning properties.
- Replaces numeric `wind_speed` editing with a one-of-many switch:
  - `slow` = `9.4 m/s`
  - `normal` = `18.7 m/s`
  - `fast` = `23.4 m/s`
- Stabilizes the prediction path by snapshotting inputs, serializing AO-model updates, and avoiding no-op recalculations when the effective AO inputs are unchanged.
- Adds targeted debug logging for suspicious optimum-speed scans to help diagnose pathological model behavior online.

## User-Facing Behavior

Operators can now:
- View live and estimated star magnitude.
- View live and estimated seeing.
- Select whether predictions use live inputs or estimated inputs.
- Select wind speed from `slow`, `normal`, or `fast`.
- View the predicted optimum loop speed and associated Strehl/WFE summary.

When `use_estimates` is enabled:
- estimated star magnitude and seeing no longer auto-follow live values
- live photometry and live seeing updates do not perturb the prediction outputs when the effective selected AO inputs are unchanged

## Testing

Verified with:
- `make -B -f Makefile.one t=../apps/strehlEstimator/tests/strehlEstimator_test.cpp`
- `../apps/strehlEstimator/tests/strehlEstimator_test`

Current test result:
- `103 assertions in 5 test cases`

## Notes
- The suspicious optimum-scan debug dump remains enabled for follow-up online verification if needed.
