### PR TITLE
Remove stale mzmq signal recovery hooks

### DIFF
--- a/apps/mzmqClient/mzmqClient.hpp
+++ b/apps/mzmqClient/mzmqClient.hpp
@@ -75,30 +75,6 @@ class mzmqClient : public MagAOXApp<>, public milkzmq::milkzmqClient
   protected:
     std::vector<std::string> m_shMemImNames;
 
-    /** \name SIGSEGV & SIGBUS signal handling
-     * These signals occur as a result of a ImageStreamIO source server resetting (e.g. changing frame sizes).
-     * When they occur a restart of the framegrabber and framewriter thread main loops is triggered.
-     *
-     * @{
-     */
-    bool m_restart{ false };
-
-    static mzmqClient *m_selfClient; ///< Static pointer to this (set in constructor).  Used for getting out of the
-                                     ///< static SIGSEGV handler.
-
-    /// Sets the handler for SIGSEGV and SIGBUS
-    /** These are caused by ImageStreamIO server resets.
-     */
-    int setSigSegvHandler();
-
-    /// The handler called when SIGSEGV or SIGBUS is received, which will be due to ImageStreamIO server resets.  Just a
-    /// wrapper for handlerSigSegv.
-    static void _handlerSigSegv( int signum, siginfo_t *siginf, void *ucont );
-
-    /// Handles SIGSEGV and SIGBUS.  Sets m_restart to true.
-    void handlerSigSegv( int signum, siginfo_t *siginf, void *ucont );
-    ///@}
-
     /** \name milkzmq Status and Error Handling
      * Implementation of status updates, warnings, and errors from milkzmq using logs.
      *
@@ -122,13 +98,9 @@ class mzmqClient : public MagAOXApp<>, public milkzmq::milkzmqClient
     ///@}
 };
 
-// Set self pointer to null so app starts up uninitialized.
-mzmqClient *mzmqClient::m_selfClient = nullptr;
-
 inline mzmqClient::mzmqClient() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
     m_powerMgtEnabled = false;
-    m_selfClient      = this;
 
     return;
 }
@@ -182,16 +154,8 @@ inline void mzmqClient::loadConfig()
     std::cerr << "m_imagePort = " << m_imagePort << "\n";
 }
 
-#include <sys/syscall.h>
-
 inline int mzmqClient::appStartup()
 {
-    if( setSigSegvHandler() < 0 )
-    {
-        log<software_error>( { __FILE__, __LINE__ } );
-        return -1;
-    }
-
     for( size_t n = 0; n < m_shMemImNames.size(); ++n )
     {
         shMemImName( m_shMemImNames[n] );
@@ -245,59 +209,6 @@ inline int mzmqClient::appShutdown()
     }
 
     return 0;
-}
-
-inline int mzmqClient::setSigSegvHandler()
-{
-    struct sigaction act;
-    sigset_t         set;
-
-    act.sa_sigaction = &mzmqClient::_handlerSigSegv;
-    act.sa_flags     = SA_SIGINFO;
-    sigemptyset( &set );
-    act.sa_mask = set;
-
-    errno = 0;
-    if( sigaction( SIGSEGV, &act, 0 ) < 0 )
-    {
-        std::string logss = "Setting handler for SIGSEGV failed. Errno says: ";
-        logss += strerror( errno );
-
-        log<software_error>( { __FILE__, __LINE__, errno, 0, logss } );
-
-        return -1;
-    }
-
-    errno = 0;
-    if( sigaction( SIGBUS, &act, 0 ) < 0 )
-    {
-        std::string logss = "Setting handler for SIGBUS failed. Errno says: ";
-        logss += strerror( errno );
-
-        log<software_error>( { __FILE__, __LINE__, errno, 0, logss } );
-
-        return -1;
-    }
-
-    log<text_log>( "Installed SIGSEGV/SIGBUS signal handler.", logPrio::LOG_DEBUG );
-
-    return 0;
-}
-
-inline void mzmqClient::_handlerSigSegv( int signum, siginfo_t *siginf, void *ucont )
-{
-    m_selfClient->handlerSigSegv( signum, siginf, ucont );
-}
-
-inline void mzmqClient::handlerSigSegv( int signum, siginfo_t *siginf, void *ucont )
-{
-    static_cast<void>( signum );
-    static_cast<void>( siginf );
-    static_cast<void>( ucont );
-
-    m_restart = true;
-
-    return;
 }
 
 inline void mzmqClient::reportInfo( const std::string &msg )

--- a/apps/mzmqServer/mzmqServer.hpp
+++ b/apps/mzmqServer/mzmqServer.hpp
@@ -39,7 +39,6 @@ namespace app
 
 /// MagAO-X application to control writing ImageStreamIO streams to a zeroMQ channel
 /** \todo document this better
- * \todo implement thread-kills for shutdown. Maybe switch to USR1, with library wide empty handler, so it isn't logged.
  * \ingroup mzmqServer
  *
  */
@@ -75,28 +74,6 @@ class mzmqServer : public MagAOXApp<>, public milkzmq::milkzmqServer
     bool                     m_compress{ false };
     std::vector<std::string> m_shMemImNames;
 
-    /** \name SIGSEGV & SIGBUS signal handling
-     * These signals occur as a result of a ImageStreamIO source server resetting (e.g. changing frame sizes).
-     * When they occur a restart of the framegrabber and framewriter thread main loops is triggered.
-     *
-     * @{
-     */
-    static mzmqServer *m_selfWriter; ///< Static pointer to this (set in constructor).  Used for getting out of the
-                                     ///< static SIGSEGV handler.
-
-    /// Sets the handler for SIGSEGV and SIGBUS
-    /** These are caused by ImageStreamIO server resets.
-     */
-    int setSigSegvHandler();
-
-    /// The handler called when SIGSEGV or SIGBUS is received, which will be due to ImageStreamIO server resets.  Just a
-    /// wrapper for handlerSigSegv.
-    static void _handlerSigSegv( int signum, siginfo_t *siginf, void *ucont );
-
-    /// Handles SIGSEGV and SIGBUS.  Sets m_restart to true.
-    void handlerSigSegv( int signum, siginfo_t *siginf, void *ucont );
-    ///@}
-
     /** \name milkzmq Status and Error Handling
      * Implementation of status updates, warnings, and errors from milkzmq using logs.
      *
@@ -120,13 +97,9 @@ class mzmqServer : public MagAOXApp<>, public milkzmq::milkzmqServer
     ///@}
 };
 
-// Set self pointer to null so app starts up uninitialized.
-mzmqServer *mzmqServer::m_selfWriter = nullptr;
-
 inline mzmqServer::mzmqServer() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
     m_powerMgtEnabled = false;
-    m_selfWriter      = this;
 
     return;
 }
@@ -181,18 +154,6 @@ inline void mzmqServer::loadConfig()
 
 inline int mzmqServer::appStartup()
 {
-
-    // Now set up the framegrabber and writer threads.
-    //  - need SIGSEGV and SIGBUS handling for ImageStreamIO restarts
-    //  - initialize the semaphore
-    //  - start the threads
-
-    if( setSigSegvHandler() < 0 )
-    {
-        log<software_error>( { __FILE__, __LINE__ } );
-        return -1;
-    }
-
     if( m_compress )
         defaultCompression();
 
@@ -271,59 +232,6 @@ inline int mzmqServer::appShutdown()
     }
 
     return 0;
-}
-
-inline int mzmqServer::setSigSegvHandler()
-{
-    struct sigaction act;
-    sigset_t         set;
-
-    act.sa_sigaction = &mzmqServer::_handlerSigSegv;
-    act.sa_flags     = SA_SIGINFO;
-    sigemptyset( &set );
-    act.sa_mask = set;
-
-    errno = 0;
-    if( sigaction( SIGSEGV, &act, 0 ) < 0 )
-    {
-        std::string logss = "Setting handler for SIGSEGV failed. Errno says: ";
-        logss += strerror( errno );
-
-        log<software_error>( { __FILE__, __LINE__, errno, 0, logss } );
-
-        return -1;
-    }
-
-    errno = 0;
-    if( sigaction( SIGBUS, &act, 0 ) < 0 )
-    {
-        std::string logss = "Setting handler for SIGBUS failed. Errno says: ";
-        logss += strerror( errno );
-
-        log<software_error>( { __FILE__, __LINE__, errno, 0, logss } );
-
-        return -1;
-    }
-
-    log<text_log>( "Installed SIGSEGV/SIGBUS signal handler.", logPrio::LOG_DEBUG );
-
-    return 0;
-}
-
-inline void mzmqServer::_handlerSigSegv( int signum, siginfo_t *siginf, void *ucont )
-{
-    m_selfWriter->handlerSigSegv( signum, siginf, ucont );
-}
-
-inline void mzmqServer::handlerSigSegv( int signum, siginfo_t *siginf, void *ucont )
-{
-    static_cast<void>( signum );
-    static_cast<void>( siginf );
-    static_cast<void>( ucont );
-
-    milkzmqServer::requestRestart();
-
-    return;
 }
 
 inline void mzmqServer::reportInfo( const std::string &msg )


### PR DESCRIPTION
This work was performed by GPT-5 Codex in response to the prompt: "The mzmqServer is prone to segfaults when streams are resized. It seems most common when the source of the streams is an mzmqClient. You can find the source for milkzmq at ../milkzmq/, changes to that are in scope. mzmqClient has also shown some occasional instability but not as common/pronounced as in mzmqServer. Please analyze these apps for possible causes of segfaults and other crashes."

## Summary
Remove the legacy SIGSEGV/SIGBUS recovery scaffolding from the MagAO-X `mzmqServer` and `mzmqClient` wrappers.

## Why
ImageStreamIO resize behavior has changed, and the old signal-recovery path was no longer a reliable or useful recovery mechanism. The wrappers now defer crash/lifetime handling to the underlying `milkzmq` fixes and keep shutdown behavior simpler and more predictable.

## Testing
- Initial resize and reconnect tests on hardware looked good.

