### PR TITLE
Fix clobbered camera defaults

### DIFF
--- a/apps/baslerCtrl/baslerCtrl.hpp
+++ b/apps/baslerCtrl/baslerCtrl.hpp
@@ -1019,12 +1019,6 @@ inline float baslerCtrl::fps()
 
 int baslerCtrl::powerOnDefaults()
 {
-    m_nextROI.x     = m_default_x;
-    m_nextROI.y     = m_default_y;
-    m_nextROI.w     = m_default_w;
-    m_nextROI.h     = m_default_h;
-    m_nextROI.bin_x = m_default_bin_x;
-    m_nextROI.bin_y = m_default_bin_y;
 
     return 0;
 }

--- a/apps/baslerCtrl/baslerCtrl.hpp
+++ b/apps/baslerCtrl/baslerCtrl.hpp
@@ -1019,12 +1019,12 @@ inline float baslerCtrl::fps()
 
 int baslerCtrl::powerOnDefaults()
 {
-    /*m_nextROI.x     = m_default_x;
+    m_nextROI.x     = m_default_x;
     m_nextROI.y     = m_default_y;
     m_nextROI.w     = m_default_w;
     m_nextROI.h     = m_default_h;
     m_nextROI.bin_x = m_default_bin_x;
-    m_nextROI.bin_y = m_default_bin_y;*/
+    m_nextROI.bin_y = m_default_bin_y;
 
     return 0;
 }

--- a/libMagAOX/app/dev/stdCamera.hpp
+++ b/libMagAOX/app/dev/stdCamera.hpp
@@ -1828,16 +1828,12 @@ int stdCamera<derivedT>::loadConfig( mx::app::appConfigurator &config )
         config( m_default_bin_y, "camera.default_bin_y" );
 
         // If default is not setup properly, it defaults to full
-        if( m_default_x == 0 || m_default_y == 0 || m_default_w == 0 || m_default_h == 0 || m_default_bin_x < 1 ||
-            m_default_bin_y < 1 )
-        {
-            m_default_x     = m_full_x;
-            m_default_y     = m_full_y;
-            m_default_w     = m_full_w;
-            m_default_h     = m_full_h;
-            m_default_bin_x = m_default_bin_x;
-            m_default_bin_y = m_default_bin_y;
-        }
+        if( m_default_x == 0 ) m_default_x = m_full_x;
+        if( m_default_y == 0 ) m_default_y = m_full_y;
+        if( m_default_w == 0 ) m_default_w = m_full_w;
+        if( m_default_h == 0 ) m_default_h = m_full_h;
+        if( m_default_bin_x < 1 ) m_default_bin_x = m_full_bin_x;
+        if( m_default_bin_y < 1 ) m_default_bin_y = m_full_bin_y;
 
         // now always start with current and next set to default
 


### PR DESCRIPTION
Basically, for cameras which only set one or two of the default ROI values, the behavior was that the defaults were ignored.

I discovered this when working with the basler cameras when the `default_w` config value seemed to be ignored. The catch was this little poison-pill inside stdCamera:

https://github.com/magao-x/MagAOX/blob/042dfa079c663810781d01d4d8c9c656ee82fbe6/libMagAOX/app/dev/stdCamera.hpp#L1831-L1840

So, if ANY of the default values are "invalid", it will overwrite ALL default values to the full values. What this means is that if I only set `default_w` and `default_h`, those were being overwritten because `default_x` and `default_y` by DEFAULT are set to 0. So, either every camera config has to _fully_ specify the default ROI, or we adjust the code to check each default individually. This PR implements the latter.

After implementing this fix, the basler cameras correctly started with `default_w` set in the config file. 