### PR TITLE
Jrmales/streamwriter hang restart fix

### DIFF
--- a/apps/observerCtrl/observerCtrl.hpp
+++ b/apps/observerCtrl/observerCtrl.hpp
@@ -58,10 +58,15 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
      *@{
      */
 
-    std::vector<std::string> m_streamWriters; ///< The configured stream writers available for observation control.
+    std::vector<std::string> m_streamWriters; ///< The configured stream writers available for user selection.
+
+    std::vector<std::string> m_defStreamWriters; ///< The configured stream writers always managed for observations.
 
     /// Tracks the remote `writing` properties for configured stream writers.
     std::map<std::string, pcf::IndiProperty> m_indiP_streamWriterWriting;
+
+    /// Tracks whether each configured stream writer is user-selectable in INDI.
+    std::map<std::string, bool> m_streamWriterSelectable;
 
     /// Reverse lookup from remote stream writer device name to configured writer name.
     std::map<std::string, std::string> m_streamWriterDevices;
@@ -157,11 +162,12 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     std::string
     streamWriterDeviceName( const std::string &writerName /**< [in] the configured stream writer name */ ) const;
 
-    /// Return whether a stream writer is selected for observation control.
+    /// Return whether a stream writer is enabled for observation control.
     bool streamWriterSelected( const std::string &writerName /**< [in] the configured stream writer name */ ) const;
 
     /// Register one configured stream writer for remote writing-state tracking.
-    int registerStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */ );
+    int registerStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */,
+                              bool userSelectable /**< [in] true if the writer should appear in the INDI selector */ );
 
     /// Determine whether observerCtrl should start a stream writer for a new observation.
     bool beginObservationStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */ );
@@ -243,7 +249,7 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     pcf::IndiProperty m_indiP_obsStart;    ///< String timestamp indicating the start for target/observation
     pcf::IndiProperty m_indiP_obsTime;     ///< Number tracking the elapsed time
     pcf::IndiProperty m_indiP_obsAngle;    ///< Number tracking the change in angle
-    pcf::IndiProperty m_indiP_sws;         ///< Selection to switch which stream writers are enabled
+    pcf::IndiProperty m_indiP_sws;         ///< Selection to switch which user-managed stream writers are enabled
     pcf::IndiProperty m_indiP_userlog;     ///< Text to enter a user log
 
     pcf::IndiProperty m_indiP_resetTarget; ///< Reset the target statistics
@@ -330,13 +336,30 @@ inline std::string observerCtrl::streamWriterDeviceName( const std::string &writ
 
 inline bool observerCtrl::streamWriterSelected( const std::string &writerName ) const
 {
+    auto streamWriterIt = m_streamWriterSelectable.find( writerName );
+    if( streamWriterIt == m_streamWriterSelectable.end() )
+    {
+        return false;
+    }
+
+    if( !streamWriterIt->second )
+    {
+        return true;
+    }
+
     return m_indiP_sws.find( writerName ) && m_indiP_sws[writerName].getSwitchState() == pcf::IndiElement::On;
 }
 
-inline int observerCtrl::registerStreamWriter( const std::string &writerName )
+inline int observerCtrl::registerStreamWriter( const std::string &writerName, bool userSelectable )
 {
     const std::string deviceName = streamWriterDeviceName( writerName );
 
+    if( m_streamWriterSelectable.count( writerName ) > 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "duplicate configured stream writer " + writerName } );
+    }
+
+    m_streamWriterSelectable[writerName]        = userSelectable;
     m_streamWriterDevices[deviceName]           = writerName;
     m_streamWriterWriting[writerName]           = false;
     m_streamWriterWritingKnown[writerName]      = false;
@@ -397,12 +420,22 @@ void observerCtrl::setupConfig()
     config.add( "stream.writers",
                 "",
                 "stream.writers",
-                argType::Required,
+                argType::Optional,
                 "stream",
                 "writers",
                 false,
                 "string",
-                "The device names of the stream writers to control." );
+                "The device names of the stream writers available for user selection." );
+
+    config.add( "stream.defWriters",
+                "",
+                "stream.defWriters",
+                argType::Optional,
+                "stream",
+                "defWriters",
+                false,
+                "string",
+                "The device names of the stream writers always controlled for each observation." );
 
     dev::telemeter<observerCtrl>::setupConfig( config );
 }
@@ -410,6 +443,7 @@ void observerCtrl::setupConfig()
 int observerCtrl::loadConfigImpl( mx::app::appConfigurator &_config )
 {
     _config( m_streamWriters, "stream.writers" );
+    _config( m_defStreamWriters, "stream.defWriters" );
 
     std::vector<std::string> sections;
 
@@ -585,7 +619,15 @@ int observerCtrl::appStartup()
     {
         m_indiP_sws.add( pcf::IndiElement( m_streamWriters[n], pcf::IndiElement::Off ) );
 
-        if( registerStreamWriter( m_streamWriters[n] ) < 0 )
+        if( registerStreamWriter( m_streamWriters[n], true ) < 0 )
+        {
+            return log<software_error, -1>( { __FILE__, __LINE__ } );
+        }
+    }
+
+    for( size_t n = 0; n < m_defStreamWriters.size(); ++n )
+    {
+        if( registerStreamWriter( m_defStreamWriters[n], false ) < 0 )
         {
             return log<software_error, -1>( { __FILE__, __LINE__ } );
         }
@@ -735,6 +777,17 @@ void observerCtrl::startObserving()
         }
     }
 
+    for( size_t n = 0; n < m_defStreamWriters.size(); ++n )
+    {
+        if( beginObservationStreamWriter( m_defStreamWriters[n] ) )
+        {
+            if( commandStreamWriter( m_defStreamWriters[n], pcf::IndiElement::On ) < 0 )
+            {
+                log<software_error>( { __FILE__, __LINE__, "failed to start stream writer " + m_defStreamWriters[n] } );
+            }
+        }
+    }
+
     mx::sys::sleep( 1 );
 
     m_obsStartTime      = std::chrono::steady_clock::now();
@@ -766,6 +819,17 @@ void observerCtrl::stopObserving()
             if( commandStreamWriter( m_streamWriters[n], pcf::IndiElement::Off ) < 0 )
             {
                 log<software_error>( { __FILE__, __LINE__, "failed to stop stream writer " + m_streamWriters[n] } );
+            }
+        }
+    }
+
+    for( size_t n = 0; n < m_defStreamWriters.size(); ++n )
+    {
+        if( endObservationStreamWriter( m_defStreamWriters[n] ) )
+        {
+            if( commandStreamWriter( m_defStreamWriters[n], pcf::IndiElement::Off ) < 0 )
+            {
+                log<software_error>( { __FILE__, __LINE__, "failed to stop stream writer " + m_defStreamWriters[n] } );
             }
         }
     }

--- a/apps/observerCtrl/observerCtrl.hpp
+++ b/apps/observerCtrl/observerCtrl.hpp
@@ -48,14 +48,32 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     typedef std::chrono::time_point<std::chrono::steady_clock> timePointT;
     typedef std::string                                        timeStampT;
     typedef std::chrono::duration<double>                      durationT;
-    std::string timeStampAsISO8601( const std::chrono::time_point<std::chrono::system_clock> &tp );
+
+    /// Format a system-clock time point as an ISO 8601 UTC timestamp.
+    std::string timeStampAsISO8601(
+        const std::chrono::time_point<std::chrono::system_clock> &tp /**< [in] the time point to format */ );
 
   protected:
     /** \name Configurable Parameters
      *@{
      */
 
-    std::vector<std::string> m_streamWriters; ///< The stream writers to stop and start
+    std::vector<std::string> m_streamWriters; ///< The configured stream writers available for observation control.
+
+    /// Tracks the remote `writing` properties for configured stream writers.
+    std::map<std::string, pcf::IndiProperty> m_indiP_streamWriterWriting;
+
+    /// Reverse lookup from remote stream writer device name to configured writer name.
+    std::map<std::string, std::string> m_streamWriterDevices;
+
+    /// Tracks the last known remote writing state for each configured stream writer.
+    std::map<std::string, bool> m_streamWriterWriting;
+
+    /// Tracks whether a remote writing state has been received for each configured stream writer.
+    std::map<std::string, bool> m_streamWriterWritingKnown;
+
+    /// Tracks whether observerCtrl started each stream writer for the current observation.
+    std::map<std::string, bool> m_streamWriterStartedByObserver;
 
     std::string m_tcsDev{ "tcsi" };
     std::string m_catalogProp{ "catalog" };
@@ -97,12 +115,12 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
 
     bool m_observing{ false }; ///< Flag indicating whether or not we are in an observation
 
-    std::string m_target;
+    std::string m_target; ///< The current target name shown to the observer.
 
-    std::string m_catObj;
+    std::string m_catObj; ///< The latest catalog object name reported by the TCS.
 
-    std::string m_catRA;
-    std::string m_catDec;
+    std::string m_catRA;  ///< The latest catalog right ascension reported by the TCS.
+    std::string m_catDec; ///< The latest catalog declination reported by the TCS.
 
     bool m_loop{ false }; ///< Flag tracking loop state.  true is loop closed.
 
@@ -132,8 +150,28 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     /// The parallactic angle at the start of observing the current target
     double m_tgtStartParang{ 0 };
 
-    /// The current parallactic angle
-    double m_parang;
+    /// The current parallactic angle.
+    double m_parang{ 0 };
+
+    /// Return the INDI device name used for a configured stream writer.
+    std::string
+    streamWriterDeviceName( const std::string &writerName /**< [in] the configured stream writer name */ ) const;
+
+    /// Return whether a stream writer is selected for observation control.
+    bool streamWriterSelected( const std::string &writerName /**< [in] the configured stream writer name */ ) const;
+
+    /// Register one configured stream writer for remote writing-state tracking.
+    int registerStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */ );
+
+    /// Determine whether observerCtrl should start a stream writer for a new observation.
+    bool beginObservationStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */ );
+
+    /// Determine whether observerCtrl should stop a stream writer when an observation ends.
+    bool endObservationStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */ );
+
+    /// Send a writing toggle command to a configured stream writer.
+    int commandStreamWriter( const std::string &writerName /**< [in] the configured stream writer name */,
+                             pcf::IndiElement::SwitchStateType state /**< [in] the requested writing switch state */ );
 
     /// The current target time.  Only updated while observing.
     durationT m_tgtTime;
@@ -150,6 +188,7 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     {
     }
 
+    /// Set up the observerCtrl configuration parameters.
     virtual void setupConfig();
 
     /// Implementation of loadConfig logic, separated for testing.
@@ -159,6 +198,7 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
                                                                     from which to load values*/
     );
 
+    /// Load the observerCtrl configuration.
     virtual void loadConfig();
 
     /// Startup function
@@ -180,8 +220,10 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
      */
     virtual int appShutdown();
 
+    /// Start the current observation and any stream writers owned by observerCtrl.
     void startObserving();
 
+    /// Stop the current observation and any stream writers owned by observerCtrl.
     void stopObserving();
 
     ///\name INDI
@@ -247,6 +289,15 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
 
     INDI_SETCALLBACK_DECL( observerCtrl, m_indiP_loop );
 
+    /// Handle remote stream writer `writing` property updates.
+    int
+    setCallBack_streamWriterWriting( const pcf::IndiProperty &ipRecv /**< [in] the remote writing property update */ );
+
+    /// Static wrapper for remote stream writer `writing` property updates.
+    static int st_setCallBack_streamWriterWriting(
+        void                    *app /**< [in] the application instance */,
+        const pcf::IndiProperty &ipRecv /**< [in] the remote writing property update */ );
+
     ///@}
 
     /** \name Telemeter Interface
@@ -262,9 +313,83 @@ class observerCtrl : public MagAOXApp<true>, public dev::telemeter<observerCtrl>
     ///@}
 };
 
+inline int observerCtrl::st_setCallBack_streamWriterWriting( void *app, const pcf::IndiProperty &ipRecv )
+{
+    return static_cast<observerCtrl *>( app )->setCallBack_streamWriterWriting( ipRecv );
+}
+
 observerCtrl::observerCtrl() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIFIED )
 {
     return;
+}
+
+inline std::string observerCtrl::streamWriterDeviceName( const std::string &writerName ) const
+{
+    return writerName + "-sw";
+}
+
+inline bool observerCtrl::streamWriterSelected( const std::string &writerName ) const
+{
+    return m_indiP_sws.find( writerName ) && m_indiP_sws[writerName].getSwitchState() == pcf::IndiElement::On;
+}
+
+inline int observerCtrl::registerStreamWriter( const std::string &writerName )
+{
+    const std::string deviceName = streamWriterDeviceName( writerName );
+
+    m_streamWriterDevices[deviceName]           = writerName;
+    m_streamWriterWriting[writerName]           = false;
+    m_streamWriterWritingKnown[writerName]      = false;
+    m_streamWriterStartedByObserver[writerName] = false;
+
+    if( registerIndiPropertySet(
+            m_indiP_streamWriterWriting[writerName], deviceName, "writing", st_setCallBack_streamWriterWriting ) < 0 )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "failed to register stream writer property for " + writerName } );
+    }
+
+    return 0;
+}
+
+inline bool observerCtrl::beginObservationStreamWriter( const std::string &writerName )
+{
+    if( !streamWriterSelected( writerName ) )
+    {
+        m_streamWriterStartedByObserver[writerName] = false;
+        return false;
+    }
+
+    bool shouldStart = true;
+    if( m_streamWriterWritingKnown[writerName] && m_streamWriterWriting[writerName] )
+    {
+        shouldStart = false;
+    }
+
+    m_streamWriterStartedByObserver[writerName] =
+        shouldStart && m_streamWriterWritingKnown[writerName] && !m_streamWriterWriting[writerName];
+
+    return shouldStart;
+}
+
+inline bool observerCtrl::endObservationStreamWriter( const std::string &writerName )
+{
+    bool shouldStop                             = m_streamWriterStartedByObserver[writerName];
+    m_streamWriterStartedByObserver[writerName] = false;
+
+    return shouldStop;
+}
+
+inline int observerCtrl::commandStreamWriter( const std::string &writerName, pcf::IndiElement::SwitchStateType state )
+{
+    pcf::IndiProperty ip( pcf::IndiProperty::Switch );
+
+    ip.setDevice( streamWriterDeviceName( writerName ) );
+    ip.setName( "writing" );
+    ip.add( pcf::IndiElement( "toggle" ) );
+    ip["toggle"].setSwitchState( state );
+
+    return sendNewProperty( ip );
 }
 
 void observerCtrl::setupConfig()
@@ -459,6 +584,11 @@ int observerCtrl::appStartup()
     for( size_t n = 0; n < m_streamWriters.size(); ++n )
     {
         m_indiP_sws.add( pcf::IndiElement( m_streamWriters[n], pcf::IndiElement::Off ) );
+
+        if( registerStreamWriter( m_streamWriters[n] ) < 0 )
+        {
+            return log<software_error, -1>( { __FILE__, __LINE__ } );
+        }
     }
 
     REG_INDI_NEWPROP_NOSETUP( m_indiP_sws );
@@ -596,16 +726,12 @@ void observerCtrl::startObserving()
 {
     for( size_t n = 0; n < m_streamWriters.size(); ++n )
     {
-        if( m_indiP_sws[m_streamWriters[n]].getSwitchState() == pcf::IndiElement::On )
+        if( beginObservationStreamWriter( m_streamWriters[n] ) )
         {
-            pcf::IndiProperty ip( pcf::IndiProperty::Switch );
-
-            ip.setDevice( m_streamWriters[n] + "-sw" );
-            ip.setName( "writing" );
-            ip.add( pcf::IndiElement( "toggle" ) );
-            ip["toggle"].setSwitchState( pcf::IndiElement::On );
-
-            sendNewProperty( ip );
+            if( commandStreamWriter( m_streamWriters[n], pcf::IndiElement::On ) < 0 )
+            {
+                log<software_error>( { __FILE__, __LINE__, "failed to start stream writer " + m_streamWriters[n] } );
+            }
         }
     }
 
@@ -635,18 +761,38 @@ void observerCtrl::stopObserving()
 
     for( size_t n = 0; n < m_streamWriters.size(); ++n )
     {
-        if( m_indiP_sws[m_streamWriters[n]].getSwitchState() == pcf::IndiElement::On )
+        if( endObservationStreamWriter( m_streamWriters[n] ) )
         {
-            pcf::IndiProperty ip( pcf::IndiProperty::Switch );
-
-            ip.setDevice( m_streamWriters[n] + "-sw" );
-            ip.setName( "writing" );
-            ip.add( pcf::IndiElement( "toggle" ) );
-            ip["toggle"].setSwitchState( pcf::IndiElement::Off );
-
-            sendNewProperty( ip );
+            if( commandStreamWriter( m_streamWriters[n], pcf::IndiElement::Off ) < 0 )
+            {
+                log<software_error>( { __FILE__, __LINE__, "failed to stop stream writer " + m_streamWriters[n] } );
+            }
         }
     }
+}
+
+int observerCtrl::setCallBack_streamWriterWriting( const pcf::IndiProperty &ipRecv )
+{
+    if( !ipRecv.hasValidDevice() || !ipRecv.find( "toggle" ) )
+    {
+        return 0;
+    }
+
+    auto streamWriterIt = m_streamWriterDevices.find( ipRecv.getDevice() );
+    if( streamWriterIt == m_streamWriterDevices.end() )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "received writing update for unknown stream writer " + ipRecv.getDevice() } );
+    }
+
+    { // mutex scope
+        std::lock_guard<std::mutex> lock( m_indiMutex );
+
+        m_streamWriterWriting[streamWriterIt->second]      = ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On;
+        m_streamWriterWritingKnown[streamWriterIt->second] = true;
+    } // mutex scope
+
+    return 0;
 }
 
 INDI_NEWCALLBACK_DEFN( observerCtrl, m_indiP_observers )( const pcf::IndiProperty &ipRecv )
@@ -1017,15 +1163,15 @@ INDI_SETCALLBACK_DEFN( observerCtrl, m_indiP_catalog )( const pcf::IndiProperty 
 
     if( object != m_catObj )
     {
-        m_catObj    = object;
-        //m_target    = object;
-        //m_newTarget = true;
+        m_catObj = object;
+        // m_target    = object;
+        // m_newTarget = true;
 
         // Always log change in name (different from RA and DEC)
         log<text_log>( "TCS target updated to " + m_catObj, logPrio::LOG_NOTICE );
 
-        //std::unique_lock<std::mutex> lock( m_indiMutex );
-        //updatesIfChanged<std::string>( m_indiP_target, { "current", "target" }, { m_target, m_target } );
+        // std::unique_lock<std::mutex> lock( m_indiMutex );
+        // updatesIfChanged<std::string>( m_indiP_target, { "current", "target" }, { m_target, m_target } );
     }
 
     return 0;
@@ -1042,8 +1188,8 @@ INDI_SETCALLBACK_DEFN( observerCtrl, m_indiP_catdata )( const pcf::IndiProperty 
 
         if( ra != m_catRA )
         {
-            m_catRA  = ra;
-            //m_target = m_catObj;
+            m_catRA = ra;
+            // m_target = m_catObj;
 
             if( !m_newTarget ) // Only log if not already new
             {
@@ -1063,7 +1209,7 @@ INDI_SETCALLBACK_DEFN( observerCtrl, m_indiP_catdata )( const pcf::IndiProperty 
         if( dec != m_catDec )
         {
             m_catDec = dec;
-            //m_target = m_catObj;
+            // m_target = m_catObj;
 
             if( !m_newTarget ) // Only log if not already new
             {
@@ -1108,7 +1254,7 @@ INDI_SETCALLBACK_DEFN( observerCtrl, m_indiP_labMode )( const pcf::IndiProperty 
         }
         else
         {
-            m_labMode        = false;
+            m_labMode = false;
         }
     }
 
@@ -1124,8 +1270,8 @@ INDI_SETCALLBACK_DEFN( observerCtrl, m_indiP_loop )( const pcf::IndiProperty &ip
     {
         if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On )
         {
-            //Now that we're manually synch-ing the target name, we don't need loop closed logic
-            //i.e. the target block starts when the observation starts after setting the name.
+            // Now that we're manually synch-ing the target name, we don't need loop closed logic
+            // i.e. the target block starts when the observation starts after setting the name.
             /*if( m_newTarget == true && !m_loop )
             {
                 m_newTargetBlock = true;

--- a/apps/observerCtrl/tests/observerCtrl_test.cpp
+++ b/apps/observerCtrl/tests/observerCtrl_test.cpp
@@ -41,9 +41,11 @@ class observerCtrl_test : public observerCtrl
         XWCTEST_SETUP_INDI_NEW_PROP( sws );
     }
 
-    void configureStreamWriters( const std::vector<std::string> &writers )
+    void configureStreamWriters( const std::vector<std::string> &writers,
+                                 const std::vector<std::string> &defWriters = std::vector<std::string>() )
     {
-        m_streamWriters = writers;
+        m_streamWriters    = writers;
+        m_defStreamWriters = defWriters;
 
         m_indiP_sws = pcf::IndiProperty( pcf::IndiProperty::Switch );
         m_indiP_sws.setDevice( m_configName );
@@ -53,6 +55,7 @@ class observerCtrl_test : public observerCtrl
         m_indiP_sws.setRule( pcf::IndiProperty::AnyOfMany );
 
         m_indiP_streamWriterWriting.clear();
+        m_streamWriterSelectable.clear();
         m_streamWriterDevices.clear();
         m_streamWriterWriting.clear();
         m_streamWriterWritingKnown.clear();
@@ -62,7 +65,12 @@ class observerCtrl_test : public observerCtrl
         for( const auto &writer : writers )
         {
             m_indiP_sws.add( pcf::IndiElement( writer, pcf::IndiElement::Off ) );
-            REQUIRE( registerStreamWriter( writer ) == 0 );
+            REQUIRE( registerStreamWriter( writer, true ) == 0 );
+        }
+
+        for( const auto &writer : defWriters )
+        {
+            REQUIRE( registerStreamWriter( writer, false ) == 0 );
         }
     }
 
@@ -101,6 +109,11 @@ class observerCtrl_test : public observerCtrl
     bool writerWriting( const std::string &writerName ) const
     {
         return m_streamWriterWriting.at( writerName );
+    }
+
+    bool writerExposed( const std::string &writerName ) const
+    {
+        return m_indiP_sws.find( writerName );
     }
 };
 /// \endcond
@@ -181,6 +194,23 @@ TEST_CASE( "observerCtrl only stops stream writers it started", "[observerCtrl]"
     REQUIRE_FALSE( app.endWriter( "camwfs" ) );
 }
 
+/// Verify observerCtrl always manages configured default writers without exposing them in INDI.
+/**
+ * \ingroup observerCtrl_unit_test
+ */
+TEST_CASE( "observerCtrl default stream writers are managed but not selectable", "[observerCtrl]" )
+{
+    observerCtrl_test app( "observerCtrl_test" );
+    app.configureStreamWriters( { "camsci1" }, { "camlowfs" } );
+
+    REQUIRE( app.writerExposed( "camsci1" ) );
+    REQUIRE_FALSE( app.writerExposed( "camlowfs" ) );
+
+    REQUIRE( app.setWriterWritingState( "camlowfs", pcf::IndiElement::Off ) == 0 );
+    REQUIRE( app.beginWriter( "camlowfs" ) );
+    REQUIRE( app.endWriter( "camlowfs" ) );
+}
+
 /// Verify observerCtrl does not claim ownership when a writer state has not been received yet.
 /**
  * \ingroup observerCtrl_unit_test
@@ -188,9 +218,7 @@ TEST_CASE( "observerCtrl only stops stream writers it started", "[observerCtrl]"
 TEST_CASE( "observerCtrl does not stop writers with unknown initial state", "[observerCtrl]" )
 {
     observerCtrl_test app( "observerCtrl_test" );
-    app.configureStreamWriters( { "camlowfs" } );
-
-    app.setWriterSelected( "camlowfs", pcf::IndiElement::On );
+    app.configureStreamWriters( {}, { "camlowfs" } );
 
     REQUIRE( app.beginWriter( "camlowfs" ) );
     REQUIRE_FALSE( app.endWriter( "camlowfs" ) );

--- a/apps/observerCtrl/tests/observerCtrl_test.cpp
+++ b/apps/observerCtrl/tests/observerCtrl_test.cpp
@@ -31,7 +31,7 @@ namespace observerCtrlTest
 class observerCtrl_test : public observerCtrl
 {
   public:
-    observerCtrl_test( const std::string device )
+    observerCtrl_test( const std::string &device )
     {
         m_configName = device;
 
@@ -39,6 +39,68 @@ class observerCtrl_test : public observerCtrl
         XWCTEST_SETUP_INDI_NEW_PROP( obsName );
         XWCTEST_SETUP_INDI_NEW_PROP( observing );
         XWCTEST_SETUP_INDI_NEW_PROP( sws );
+    }
+
+    void configureStreamWriters( const std::vector<std::string> &writers )
+    {
+        m_streamWriters = writers;
+
+        m_indiP_sws = pcf::IndiProperty( pcf::IndiProperty::Switch );
+        m_indiP_sws.setDevice( m_configName );
+        m_indiP_sws.setName( "writers" );
+        m_indiP_sws.setPerm( pcf::IndiProperty::ReadWrite );
+        m_indiP_sws.setState( pcf::IndiProperty::Idle );
+        m_indiP_sws.setRule( pcf::IndiProperty::AnyOfMany );
+
+        m_indiP_streamWriterWriting.clear();
+        m_streamWriterDevices.clear();
+        m_streamWriterWriting.clear();
+        m_streamWriterWritingKnown.clear();
+        m_streamWriterStartedByObserver.clear();
+        m_indiSetCallBacks.clear();
+
+        for( const auto &writer : writers )
+        {
+            m_indiP_sws.add( pcf::IndiElement( writer, pcf::IndiElement::Off ) );
+            REQUIRE( registerStreamWriter( writer ) == 0 );
+        }
+    }
+
+    void setWriterSelected( const std::string &writerName, pcf::IndiElement::SwitchStateType state )
+    {
+        m_indiP_sws[writerName].setSwitchState( state );
+    }
+
+    int setWriterWritingState( const std::string &writerName, pcf::IndiElement::SwitchStateType state )
+    {
+        pcf::IndiProperty ip( pcf::IndiProperty::Switch );
+
+        ip.setDevice( streamWriterDeviceName( writerName ) );
+        ip.setName( "writing" );
+        ip.add( pcf::IndiElement( "toggle" ) );
+        ip["toggle"].setSwitchState( state );
+
+        return setCallBack_streamWriterWriting( ip );
+    }
+
+    bool beginWriter( const std::string &writerName )
+    {
+        return beginObservationStreamWriter( writerName );
+    }
+
+    bool endWriter( const std::string &writerName )
+    {
+        return endObservationStreamWriter( writerName );
+    }
+
+    bool writerWritingKnown( const std::string &writerName ) const
+    {
+        return m_streamWriterWritingKnown.at( writerName );
+    }
+
+    bool writerWriting( const std::string &writerName ) const
+    {
+        return m_streamWriterWriting.at( writerName );
     }
 };
 /// \endcond
@@ -62,6 +124,76 @@ TEST_CASE( "observerCtrl INDI callbacks validate device and property names", "[o
     XWCTEST_INDI_NEW_CALLBACK( observerCtrl, obsName );
     XWCTEST_INDI_NEW_CALLBACK( observerCtrl, observing );
     XWCTEST_INDI_NEW_CALLBACK( observerCtrl, sws );
+}
+
+/// Verify observerCtrl tracks remote stream writer writing state updates.
+/**
+ * \ingroup observerCtrl_unit_test
+ */
+TEST_CASE( "observerCtrl tracks remote stream writer writing state", "[observerCtrl]" )
+{
+    // clang-format off
+    #ifdef OBSERVERCTRL_TEST_DOXYGEN_REF
+    observerCtrl::setCallBack_streamWriterWriting( pcf::IndiProperty() );
+    #endif
+    // clang-format on
+
+    observerCtrl_test app( "observerCtrl_test" );
+    app.configureStreamWriters( { "camwfs" } );
+
+    REQUIRE_FALSE( app.writerWritingKnown( "camwfs" ) );
+
+    REQUIRE( app.setWriterWritingState( "camwfs", pcf::IndiElement::On ) == 0 );
+    REQUIRE( app.writerWritingKnown( "camwfs" ) );
+    REQUIRE( app.writerWriting( "camwfs" ) );
+
+    REQUIRE( app.setWriterWritingState( "camwfs", pcf::IndiElement::Off ) == 0 );
+    REQUIRE_FALSE( app.writerWriting( "camwfs" ) );
+}
+
+/// Verify observerCtrl only stops stream writers it started for the current observation.
+/**
+ * \ingroup observerCtrl_unit_test
+ */
+TEST_CASE( "observerCtrl only stops stream writers it started", "[observerCtrl]" )
+{
+    // clang-format off
+    #ifdef OBSERVERCTRL_TEST_DOXYGEN_REF
+    observerCtrl::beginObservationStreamWriter( std::string() );
+    observerCtrl::endObservationStreamWriter( std::string() );
+    #endif
+    // clang-format on
+
+    observerCtrl_test app( "observerCtrl_test" );
+    app.configureStreamWriters( { "camsci1", "camwfs" } );
+
+    app.setWriterSelected( "camsci1", pcf::IndiElement::On );
+    app.setWriterSelected( "camwfs", pcf::IndiElement::On );
+
+    REQUIRE( app.setWriterWritingState( "camsci1", pcf::IndiElement::On ) == 0 );
+    REQUIRE( app.setWriterWritingState( "camwfs", pcf::IndiElement::Off ) == 0 );
+
+    REQUIRE_FALSE( app.beginWriter( "camsci1" ) );
+    REQUIRE( app.beginWriter( "camwfs" ) );
+
+    REQUIRE_FALSE( app.endWriter( "camsci1" ) );
+    REQUIRE( app.endWriter( "camwfs" ) );
+    REQUIRE_FALSE( app.endWriter( "camwfs" ) );
+}
+
+/// Verify observerCtrl does not claim ownership when a writer state has not been received yet.
+/**
+ * \ingroup observerCtrl_unit_test
+ */
+TEST_CASE( "observerCtrl does not stop writers with unknown initial state", "[observerCtrl]" )
+{
+    observerCtrl_test app( "observerCtrl_test" );
+    app.configureStreamWriters( { "camlowfs" } );
+
+    app.setWriterSelected( "camlowfs", pcf::IndiElement::On );
+
+    REQUIRE( app.beginWriter( "camlowfs" ) );
+    REQUIRE_FALSE( app.endWriter( "camlowfs" ) );
 }
 
 } // namespace observerCtrlTest

--- a/apps/streamWriter/streamWriter.hpp
+++ b/apps/streamWriter/streamWriter.hpp
@@ -1250,17 +1250,16 @@ bool streamWriter::waitForWriteCompletion( uint64_t saveStopFrameNo )
 
         if( now >= deadline )
         {
-            log<software_critical>( { __FILE__,
-                                      __LINE__,
-                                      "timed out waiting " + std::to_string( m_writeCompletionTimeout ) +
-                                          " sec for the writer thread to finish frame " +
-                                          std::to_string( saveStopFrameNo ) } );
+            log<text_log>( "timed out waiting " + std::to_string( m_writeCompletionTimeout ) +
+                               " sec for the writer thread to finish frame " + std::to_string( saveStopFrameNo ),
+                           logPrio::LOG_NOTICE );
             return false;
         }
 
         if( now >= nextLog )
         {
-            std::cerr << __FILE__ << " " << __LINE__ << " WAITING TO FINISH WRITING " << saveStopFrameNo << "\n";
+            log<text_log>( "still waiting for the writer thread to finish frame " + std::to_string( saveStopFrameNo ),
+                           logPrio::LOG_DEBUG );
             nextLog = now + std::chrono::seconds( 1 );
         }
 

--- a/apps/streamWriter/streamWriter.hpp
+++ b/apps/streamWriter/streamWriter.hpp
@@ -147,6 +147,9 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
     double m_writeCompletionTimeout{
         5.0 }; ///< Seconds to wait for the writer thread to finish a queued flush during restart cleanup.
 
+    bool m_resumeAfterReconnect{
+        false }; ///< Tracks whether reconnect cleanup should resume writing immediately on the replacement stream.
+
     uint64_t m_currChunkStart{ 0 }; ///< The circular buffer starting position of the current to-be-written chunk.
     uint64_t m_nextChunkStart{ 0 }; ///< The circular buffer starting position of the next to-be-written chunk.
 
@@ -879,9 +882,10 @@ int streamWriter::appLogic()
 
 int streamWriter::appShutdown()
 {
-    m_writing           = NOT_WRITING;
-    m_writePending      = false;
-    m_stopWriteDeadline = 0;
+    m_writing              = NOT_WRITING;
+    m_writePending         = false;
+    m_resumeAfterReconnect = false;
+    m_stopWriteDeadline    = 0;
     updateINDI();
 
     try
@@ -1617,13 +1621,14 @@ void streamWriter::fgThreadExec()
                     m_nextChunkStart     = ( m_currImage / m_writeChunkLength ) * m_writeChunkLength;
                     m_currChunkStartTime = m_currImageTime;
 
-                    if( !restartWriting ) // We only log if this is really a start
+                    if( !restartWriting && !m_resumeAfterReconnect ) // We only log if this is really a start
                     {
                         log<saving_start>( { 1, new_cnt0 } );
                     }
-                    else // on a restart after a timeout we don't log
+                    else // on a restart after a timeout or reconnect we don't log
                     {
-                        restartWriting = false;
+                        restartWriting         = false;
+                        m_resumeAfterReconnect = false;
                     }
 
                     m_writing = WRITING;
@@ -1838,6 +1843,14 @@ void streamWriter::fgThreadExec()
             }
         }
 
+        const bool resumeAfterReconnect = ( m_writing == WRITING );
+
+        if( m_writePending && !waitForWriteCompletion( last_cnt0 ) )
+        {
+            m_shutdown = 1;
+            return;
+        }
+
         ///\todo might still be writing here, so must check
         // If semaphore times-out or errors, we first cleanup any writing that needs to be done
         if( m_writing == WRITING || m_writing == STOP_WRITING )
@@ -1849,8 +1862,9 @@ void streamWriter::fgThreadExec()
                 m_currSaveStop        = m_currImage;
                 m_currSaveStopFrameNo = last_cnt0;
 
-                m_writing           = STOP_WRITING;
-                m_stopWriteDeadline = 0;
+                m_writing              = STOP_WRITING;
+                m_stopWriteDeadline    = 0;
+                m_resumeAfterReconnect = resumeAfterReconnect;
 
                 std::cerr << __FILE__ << " " << __LINE__ << " WRITING ON RESTART " << last_cnt0 << "\n";
                 // Now tell the writer to get going
@@ -1862,9 +1876,16 @@ void streamWriter::fgThreadExec()
                     return;
                 }
             }
+            else if( resumeAfterReconnect )
+            {
+                m_writing              = START_WRITING;
+                m_stopWriteDeadline    = 0;
+                m_resumeAfterReconnect = true;
+            }
             else
             {
-                m_writing = NOT_WRITING;
+                m_writing              = NOT_WRITING;
+                m_resumeAfterReconnect = false;
             }
 
             if( !waitForWriteCompletion( last_cnt0 ) )
@@ -1872,12 +1893,6 @@ void streamWriter::fgThreadExec()
                 m_shutdown = 1;
                 return;
             }
-        }
-
-        if( m_writePending && !waitForWriteCompletion( last_cnt0 ) )
-        {
-            m_shutdown = 1;
-            return;
         }
 
         release_circbufs();
@@ -2015,9 +2030,16 @@ int streamWriter::doEncode()
 
         if( m_writing == STOP_WRITING )
         {
-            m_writing           = NOT_WRITING;
+            if( m_resumeAfterReconnect )
+            {
+                m_writing = START_WRITING;
+            }
+            else
+            {
+                m_writing = NOT_WRITING;
+                log<saving_stop>( { 0, saveStopFrameNo } );
+            }
             m_stopWriteDeadline = 0;
-            log<saving_stop>( { 0, saveStopFrameNo } );
         }
 
         recordSavingState( true );
@@ -2195,9 +2217,16 @@ int streamWriter::doEncode()
 
     if( m_writing == STOP_WRITING )
     {
-        m_writing           = NOT_WRITING;
+        if( m_resumeAfterReconnect )
+        {
+            m_writing = START_WRITING;
+        }
+        else
+        {
+            m_writing = NOT_WRITING;
+            log<saving_stop>( { 0, saveStopFrameNo } );
+        }
         m_stopWriteDeadline = 0;
-        log<saving_stop>( { 0, saveStopFrameNo } );
     }
 
     recordSavingState( true );
@@ -2220,14 +2249,16 @@ INDI_NEWCALLBACK_DEFN( streamWriter, m_indiP_writing )
     if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off &&
         ( m_writing == WRITING || m_writing == START_WRITING ) )
     {
-        m_writing           = STOP_WRITING;
-        m_stopWriteDeadline = mx::sys::get_curr_time() + m_writeStopTimeout;
+        m_writing              = STOP_WRITING;
+        m_resumeAfterReconnect = false;
+        m_stopWriteDeadline    = mx::sys::get_curr_time() + m_writeStopTimeout;
     }
 
     if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_writing == NOT_WRITING )
     {
-        m_writing           = START_WRITING;
-        m_stopWriteDeadline = 0;
+        m_writing              = START_WRITING;
+        m_resumeAfterReconnect = false;
+        m_stopWriteDeadline    = 0;
     }
 
     return 0;

--- a/apps/streamWriter/streamWriter.hpp
+++ b/apps/streamWriter/streamWriter.hpp
@@ -81,7 +81,7 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
     double m_maxChunkTime{ 10 }; ///< The maximum time before writing regardless of number of frames.
 
     double m_writeStopTimeout{
-        5.0 }; ///< Seconds to wait for the writer thread to finish a queued flush during restart cleanup.
+        1.0 }; ///< Seconds to wait after a stop-writing command before flushing the pending data without a new frame.
 
     std::string m_shmimName; ///< The name of the shared memory buffer.
 
@@ -138,6 +138,12 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
 
     std::atomic<bool> m_writePending{
         false }; ///< Whether the writer thread still owns a queued save window and may touch the circular buffers.
+
+    double m_stopWriteDeadline{ 0.0 }; ///< Absolute time after which a stop-writing request should flush without a
+                                       ///< new frame.
+
+    double m_writeCompletionTimeout{
+        5.0 }; ///< Seconds to wait for the writer thread to finish a queued flush during restart cleanup.
 
     uint64_t m_currChunkStart{ 0 }; ///< The circular buffer starting position of the current to-be-written chunk.
     uint64_t m_nextChunkStart{ 0 }; ///< The circular buffer starting position of the next to-be-written chunk.
@@ -428,8 +434,8 @@ void streamWriter::setupConfig()
                 "stopTimeout",
                 false,
                 "float",
-                "The max time in seconds to wait for the writer thread to finish a queued flush during restart "
-                "cleanup before treating it as hung." );
+                "The max time in seconds to wait after a stop-writing command for the next frame before flushing the "
+                "pending data and returning to the idle state." );
 
     config.add( "writer.threadPrio",
                 "",
@@ -552,6 +558,10 @@ void streamWriter::loadConfig()
     config( m_maxWriteChunkLength, "writer.maxWriteChunkLength" );
     config( m_maxChunkTime, "writer.maxChunkTime" );
     config( m_writeStopTimeout, "writer.stopTimeout" );
+    if( m_writeStopTimeout < 0 )
+    {
+        m_writeStopTimeout = 0;
+    }
     config( m_swThreadPrio, "writer.threadPrio" );
     config( m_swCpuset, "writer.cpuset" );
     config( m_compress, "writer.compress" );
@@ -851,8 +861,9 @@ int streamWriter::appLogic()
 
 int streamWriter::appShutdown()
 {
-    m_writing      = NOT_WRITING;
-    m_writePending = false;
+    m_writing           = NOT_WRITING;
+    m_writePending      = false;
+    m_stopWriteDeadline = 0;
     updateINDI();
 
     try
@@ -1211,7 +1222,7 @@ void streamWriter::release_circbufs()
 
 bool streamWriter::waitForWriteCompletion( uint64_t saveStopFrameNo )
 {
-    const auto timeout  = std::chrono::duration<double>( m_writeStopTimeout );
+    const auto timeout  = std::chrono::duration<double>( m_writeCompletionTimeout );
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     auto       nextLog  = std::chrono::steady_clock::now();
 
@@ -1223,7 +1234,7 @@ bool streamWriter::waitForWriteCompletion( uint64_t saveStopFrameNo )
         {
             log<software_critical>( { __FILE__,
                                       __LINE__,
-                                      "timed out waiting " + std::to_string( m_writeStopTimeout ) +
+                                      "timed out waiting " + std::to_string( m_writeCompletionTimeout ) +
                                           " sec for the writer thread to finish frame " +
                                           std::to_string( saveStopFrameNo ) } );
             return false;
@@ -1577,7 +1588,8 @@ void streamWriter::fgThreadExec()
 
                 if( m_shutdown && m_writing == WRITING )
                 {
-                    m_writing = STOP_WRITING;
+                    m_writing           = STOP_WRITING;
+                    m_stopWriteDeadline = 0;
                 }
 
                 switch( m_writing )
@@ -1675,7 +1687,8 @@ void streamWriter::fgThreadExec()
                     // clang-format on
 
                     // Now tell the writer to get going
-                    m_writePending = true;
+                    m_writePending      = true;
+                    m_stopWriteDeadline = 0;
                     if( sem_post( &m_swSemaphore ) < 0 )
                     {
                         m_writePending = false;
@@ -1732,24 +1745,29 @@ void streamWriter::fgThreadExec()
                     }
                     break;
                 case STOP_WRITING:
-                    // If we timed-out while STOP_WRITING is set, we trigger a write.
-                    m_currSaveStart       = m_currChunkStart;
-                    m_currSaveStop        = m_currImage;
-                    m_currSaveStopFrameNo = last_cnt0;
+                    if( mx::sys::get_curr_time() >= m_stopWriteDeadline )
+                    {
+                        // If the stop timer expires before the next frame arrives, flush the current chunk and
+                        // settle back to the idle state exactly as we would on the next frame.
+                        m_currSaveStart       = m_currChunkStart;
+                        m_currSaveStop        = m_currImage;
+                        m_currSaveStopFrameNo = last_cnt0;
 
 #ifdef SW_DEBUG
-                    std::cerr << __FILE__ << " " << __LINE__ << " TIMEOUT STOP_WRITING\n";
+                        std::cerr << __FILE__ << " " << __LINE__ << " TIMEOUT STOP_WRITING\n";
 #endif
 
-                    // Now tell the writer to get going
-                    m_writePending = true;
-                    if( sem_post( &m_swSemaphore ) < 0 )
-                    {
-                        m_writePending = false;
-                        log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
-                        return;
+                        // Now tell the writer to get going
+                        m_writePending      = true;
+                        m_stopWriteDeadline = 0;
+                        if( sem_post( &m_swSemaphore ) < 0 )
+                        {
+                            m_writePending = false;
+                            log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
+                            return;
+                        }
+                        restartWriting = false;
                     }
-                    restartWriting = false;
                     break;
                 default:
                     break;
@@ -1814,7 +1832,8 @@ void streamWriter::fgThreadExec()
                 m_currSaveStop        = m_currImage;
                 m_currSaveStopFrameNo = last_cnt0;
 
-                m_writing = STOP_WRITING;
+                m_writing           = STOP_WRITING;
+                m_stopWriteDeadline = 0;
 
                 std::cerr << __FILE__ << " " << __LINE__ << " WRITING ON RESTART " << last_cnt0 << "\n";
                 // Now tell the writer to get going
@@ -1979,7 +1998,8 @@ int streamWriter::doEncode()
 
         if( m_writing == STOP_WRITING )
         {
-            m_writing = NOT_WRITING;
+            m_writing           = NOT_WRITING;
+            m_stopWriteDeadline = 0;
             log<saving_stop>( { 0, saveStopFrameNo } );
         }
 
@@ -2158,7 +2178,8 @@ int streamWriter::doEncode()
 
     if( m_writing == STOP_WRITING )
     {
-        m_writing = NOT_WRITING;
+        m_writing           = NOT_WRITING;
+        m_stopWriteDeadline = 0;
         log<saving_stop>( { 0, saveStopFrameNo } );
     }
 
@@ -2182,12 +2203,14 @@ INDI_NEWCALLBACK_DEFN( streamWriter, m_indiP_writing )
     if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::Off &&
         ( m_writing == WRITING || m_writing == START_WRITING ) )
     {
-        m_writing = STOP_WRITING;
+        m_writing           = STOP_WRITING;
+        m_stopWriteDeadline = mx::sys::get_curr_time() + m_writeStopTimeout;
     }
 
     if( ipRecv["toggle"].getSwitchState() == pcf::IndiElement::On && m_writing == NOT_WRITING )
     {
-        m_writing = START_WRITING;
+        m_writing           = START_WRITING;
+        m_stopWriteDeadline = 0;
     }
 
     return 0;

--- a/apps/streamWriter/streamWriter.hpp
+++ b/apps/streamWriter/streamWriter.hpp
@@ -83,6 +83,8 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
     double m_writeStopTimeout{
         1.0 }; ///< Seconds to wait after a stop-writing command before flushing the pending data without a new frame.
 
+    bool m_startWriting{ false }; ///< Whether writing should be armed automatically at application startup.
+
     std::string m_shmimName; ///< The name of the shared memory buffer.
 
     std::string m_outName; ///< The name to use for outputting files,  Default is m_shmimName.
@@ -437,6 +439,16 @@ void streamWriter::setupConfig()
                 "The max time in seconds to wait after a stop-writing command for the next frame before flushing the "
                 "pending data and returning to the idle state." );
 
+    config.add( "writer.startWriting",
+                "",
+                "writer.startWriting",
+                argType::Required,
+                "writer",
+                "startWriting",
+                false,
+                "bool",
+                "Flag controlling whether writing is armed automatically at application startup. Default is false." );
+
     config.add( "writer.threadPrio",
                 "",
                 "writer.threadPrio",
@@ -562,6 +574,7 @@ void streamWriter::loadConfig()
     {
         m_writeStopTimeout = 0;
     }
+    config( m_startWriting, "writer.startWriting" );
     config( m_swThreadPrio, "writer.threadPrio" );
     config( m_swCpuset, "writer.cpuset" );
     config( m_compress, "writer.compress" );
@@ -716,6 +729,11 @@ int streamWriter::appStartup()
     if( initialize_xrif() < 0 )
     {
         log<software_critical, -1>( { __FILE__, __LINE__ } );
+    }
+
+    if( m_startWriting )
+    {
+        m_writing = START_WRITING;
     }
 
     if( threadStart( m_fgThread,
@@ -2219,9 +2237,9 @@ INDI_NEWCALLBACK_DEFN( streamWriter, m_indiP_writing )
 void streamWriter::updateINDI()
 {
     // Only update this if not changing
-    if( m_writing == NOT_WRITING || m_writing == WRITING )
+    if( m_writing == NOT_WRITING || m_writing == WRITING || m_writing == START_WRITING )
     {
-        if( m_xrif && m_writing == WRITING )
+        if( m_xrif && ( m_writing == WRITING || m_writing == START_WRITING ) )
         {
             indi::updateSwitchIfChanged( m_indiP_writing, "toggle", pcf::IndiElement::On, m_indiDriver, INDI_OK );
             indi::updateIfChanged( m_indiP_xrifStats, "ratio", m_xrif->compression_ratio, m_indiDriver, INDI_BUSY );

--- a/apps/streamWriter/streamWriter.hpp
+++ b/apps/streamWriter/streamWriter.hpp
@@ -10,7 +10,9 @@
 #define streamWriter_hpp
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
+#include <thread>
 
 #include <ImageStreamIO/ImageStruct.h>
 #include <ImageStreamIO/ImageStreamIO.h>
@@ -78,6 +80,9 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
 
     double m_maxChunkTime{ 10 }; ///< The maximum time before writing regardless of number of frames.
 
+    double m_writeStopTimeout{
+        5.0 }; ///< Seconds to wait for the writer thread to finish a queued flush during restart cleanup.
+
     std::string m_shmimName; ///< The name of the shared memory buffer.
 
     std::string m_outName; ///< The name to use for outputting files,  Default is m_shmimName.
@@ -130,6 +135,9 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
     // Writer book-keeping:
     int m_writing{ NOT_WRITING }; /**< Controls whether or not images are being written,
                    and sequences start and stop of writing.*/
+
+    std::atomic<bool> m_writePending{
+        false }; ///< Whether the writer thread still owns a queued save window and may touch the circular buffers.
 
     uint64_t m_currChunkStart{ 0 }; ///< The circular buffer starting position of the current to-be-written chunk.
     uint64_t m_nextChunkStart{ 0 }; ///< The circular buffer starting position of the next to-be-written chunk.
@@ -256,6 +264,13 @@ class streamWriter : public MagAOXApp<>, public dev::telemeter<streamWriter>
      */
     int allocate_xrif();
 
+    /// Release the circular buffers owned by the framegrabber thread.
+    void release_circbufs();
+
+    /// Wait for the writer thread to finish any queued save work before buffer teardown.
+    bool waitForWriteCompletion( uint64_t saveStopFrameNo /**< [in] The last frame number associated with the
+                                                               queued save for timeout logging. */ );
+
     /// Thread starter, called by fgThreadStart on thread construction.  Calls fgThreadExec.
     static void fgThreadStart( streamWriter *s /**< [in] a pointer to an streamWriter instance (normally this) */ );
 
@@ -333,6 +348,8 @@ streamWriter::streamWriter() : MagAOXApp( MAGAOX_CURRENT_SHA1, MAGAOX_REPO_MODIF
 
 streamWriter::~streamWriter() noexcept
 {
+    release_circbufs();
+
     if( m_xrif )
         xrif_delete( m_xrif );
 
@@ -402,6 +419,17 @@ void streamWriter::setupConfig()
                 false,
                 "float",
                 "The max length in seconds of the chunks to write to disk. Default is 60 sec." );
+
+    config.add( "writer.stopTimeout",
+                "",
+                "writer.stopTimeout",
+                argType::Required,
+                "writer",
+                "stopTimeout",
+                false,
+                "float",
+                "The max time in seconds to wait for the writer thread to finish a queued flush during restart "
+                "cleanup before treating it as hung." );
 
     config.add( "writer.threadPrio",
                 "",
@@ -523,6 +551,7 @@ void streamWriter::loadConfig()
     config( m_maxCircBuffSize, "writer.maxCircBuffSize" );
     config( m_maxWriteChunkLength, "writer.maxWriteChunkLength" );
     config( m_maxChunkTime, "writer.maxChunkTime" );
+    config( m_writeStopTimeout, "writer.stopTimeout" );
     config( m_swThreadPrio, "writer.threadPrio" );
     config( m_swCpuset, "writer.cpuset" );
     config( m_compress, "writer.compress" );
@@ -822,7 +851,8 @@ int streamWriter::appLogic()
 
 int streamWriter::appShutdown()
 {
-    m_writing = NOT_WRITING;
+    m_writing      = NOT_WRITING;
+    m_writePending = false;
     updateINDI();
 
     try
@@ -846,6 +876,8 @@ int streamWriter::appShutdown()
     catch( ... )
     {
     }
+
+    release_circbufs();
 
     if( m_xrif )
     {
@@ -1160,6 +1192,53 @@ int streamWriter::allocate_xrif()
     }
 
     return 0;
+}
+
+void streamWriter::release_circbufs()
+{
+    if( m_rawImageCircBuff )
+    {
+        free( m_rawImageCircBuff );
+        m_rawImageCircBuff = nullptr;
+    }
+
+    if( m_timingCircBuff )
+    {
+        free( m_timingCircBuff );
+        m_timingCircBuff = nullptr;
+    }
+}
+
+bool streamWriter::waitForWriteCompletion( uint64_t saveStopFrameNo )
+{
+    const auto timeout  = std::chrono::duration<double>( m_writeStopTimeout );
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    auto       nextLog  = std::chrono::steady_clock::now();
+
+    while( m_writePending )
+    {
+        const auto now = std::chrono::steady_clock::now();
+
+        if( now >= deadline )
+        {
+            log<software_critical>( { __FILE__,
+                                      __LINE__,
+                                      "timed out waiting " + std::to_string( m_writeStopTimeout ) +
+                                          " sec for the writer thread to finish frame " +
+                                          std::to_string( saveStopFrameNo ) } );
+            return false;
+        }
+
+        if( now >= nextLog )
+        {
+            std::cerr << __FILE__ << " " << __LINE__ << " WAITING TO FINISH WRITING " << saveStopFrameNo << "\n";
+            nextLog = now + std::chrono::seconds( 1 );
+        }
+
+        std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+    }
+
+    return true;
 }
 
 void streamWriter::fgThreadStart( streamWriter *o )
@@ -1537,8 +1616,10 @@ void streamWriter::fgThreadExec()
 #endif
 
                         // Now tell the writer to get going
+                        m_writePending = true;
                         if( sem_post( &m_swSemaphore ) < 0 )
                         {
+                            m_writePending = false;
                             log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                             return;
                         }
@@ -1569,8 +1650,10 @@ void streamWriter::fgThreadExec()
                         // clang-format on
 
                         // Now tell the writer to get going
+                        m_writePending = true;
                         if( sem_post( &m_swSemaphore ) < 0 )
                         {
+                            m_writePending = false;
                             log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                             return;
                         }
@@ -1592,8 +1675,10 @@ void streamWriter::fgThreadExec()
                     // clang-format on
 
                     // Now tell the writer to get going
+                    m_writePending = true;
                     if( sem_post( &m_swSemaphore ) < 0 )
                     {
+                        m_writePending = false;
                         log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                         return;
                     }
@@ -1634,8 +1719,10 @@ void streamWriter::fgThreadExec()
 #endif
 
                         // Now tell the writer to get going
+                        m_writePending = true;
                         if( sem_post( &m_swSemaphore ) < 0 )
                         {
+                            m_writePending = false;
                             log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                             return;
                         }
@@ -1655,8 +1742,10 @@ void streamWriter::fgThreadExec()
 #endif
 
                     // Now tell the writer to get going
+                    m_writePending = true;
                     if( sem_post( &m_swSemaphore ) < 0 )
                     {
+                        m_writePending = false;
                         log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                         return;
                     }
@@ -1729,8 +1818,10 @@ void streamWriter::fgThreadExec()
 
                 std::cerr << __FILE__ << " " << __LINE__ << " WRITING ON RESTART " << last_cnt0 << "\n";
                 // Now tell the writer to get going
+                m_writePending = true;
                 if( sem_post( &m_swSemaphore ) < 0 )
                 {
+                    m_writePending = false;
                     log<software_critical>( { __FILE__, __LINE__, errno, 0, "Error posting to semaphore" } );
                     return;
                 }
@@ -1740,24 +1831,20 @@ void streamWriter::fgThreadExec()
                 m_writing = NOT_WRITING;
             }
 
-            while( m_writing != NOT_WRITING )
+            if( !waitForWriteCompletion( last_cnt0 ) )
             {
-                std::cerr << __FILE__ << " " << __LINE__ << " WAITING TO FINISH WRITING " << last_cnt0 << "\n";
-                sleep( 1 );
+                m_shutdown = 1;
+                return;
             }
         }
 
-        if( m_rawImageCircBuff )
+        if( m_writePending && !waitForWriteCompletion( last_cnt0 ) )
         {
-            free( m_rawImageCircBuff );
-            m_rawImageCircBuff = 0;
+            m_shutdown = 1;
+            return;
         }
 
-        if( m_timingCircBuff )
-        {
-            free( m_timingCircBuff );
-            m_timingCircBuff = 0;
-        }
+        release_circbufs();
 
         if( opened )
         {
@@ -1866,6 +1953,7 @@ int streamWriter::doEncode()
 {
     if( m_writing == NOT_WRITING )
     {
+        m_writePending = false;
         return 0;
     }
 
@@ -1897,6 +1985,7 @@ int streamWriter::doEncode()
 
         recordSavingState( true );
 
+        m_writePending = false;
         return 0;
     }
     // Configure xrif and copy image data -- this does no allocations
@@ -1980,6 +2069,7 @@ int streamWriter::doEncode()
         std::string msg = "error from file::fileTimeRePath: ";
         msg += mx::errorMessage( errc );
         msg += " (" + std::string( mx::errorName( errc ) ) + ")";
+        m_writePending = false;
         return log<software_error, -1>( { __FILE__, __LINE__, msg } );
     }
 
@@ -1995,12 +2085,14 @@ int streamWriter::doEncode()
         msg += e.what();
         msg += " code: ";
         msg += e.code().value();
+        m_writePending = false;
         return log<software_critical, -1>( { __FILE__, __LINE__, msg } );
     }
     catch( const std::exception &e )
     {
         std::string msg = "exception from std::create_directories. ";
         msg += e.what();
+        m_writePending = false;
         return log<software_critical, -1>( { __FILE__, __LINE__, msg } );
     }
 
@@ -2009,6 +2101,7 @@ int streamWriter::doEncode()
     if( fp_xrif == NULL )
     {
         // This is it.  If we can't write data to disk need to fix.
+        m_writePending = false;
         return log<software_critical, -1>( { __FILE__, __LINE__, errno, 0, "failed to open file for writing" } );
     }
 
@@ -2071,6 +2164,7 @@ int streamWriter::doEncode()
 
     recordSavingState( true );
 
+    m_writePending = false;
     return 0;
 
 } // doEncode

--- a/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
+++ b/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
@@ -73,7 +73,7 @@ struct streamWriterConfig
     double                     m_maxCircBuffSize{ 16.0 };                 ///< Configured circular-buffer size in MB.
     size_t                     m_maxWriteChunkLength{ 4 };                ///< Configured write-chunk length.
     double                     m_maxChunkTime{ 0.5 };                     ///< Configured max chunk time in seconds.
-    double                     m_writeStopTimeout{ 5.0 };                 ///< Configured restart-cleanup wait timeout.
+    double                     m_writeStopTimeout{ 1.0 };                 ///< Configured stop-writing flush timeout.
     int                        m_writerThreadPrio{ 0 };                   ///< Configured writer thread priority.
     std::string                m_writerCpuset;                            ///< Optional writer cpuset.
     bool                       m_compress{ true };                        ///< Whether XRIF compression is enabled.
@@ -592,7 +592,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         REQUIRE( app.m_maxCircBuffSize == Approx( 16.0 ) );
         REQUIRE( app.m_maxWriteChunkLength == 4 );
         REQUIRE( app.m_maxChunkTime == Approx( 0.5 ) );
-        REQUIRE( app.m_writeStopTimeout == Approx( 5.0 ) );
+        REQUIRE( app.m_writeStopTimeout == Approx( 1.0 ) );
         REQUIRE( app.m_shmimName == "streamWriter_test_stream" );
         REQUIRE( app.m_outName == app.m_shmimName );
         REQUIRE( app.m_rawimageDir == ( root / expectedRawRel ).string() );
@@ -895,6 +895,7 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         cfg.m_maxCircBuffLength   = 8;
         cfg.m_maxWriteChunkLength = 2;
         cfg.m_maxChunkTime        = 0.2;
+        cfg.m_writeStopTimeout    = 0.05;
         cfg.m_semWaitNSec         = 1000000;
         cfg.m_savePath =
             ( std::filesystem::path( "/tmp/streamWriter_lifecycle_test" ) / "fg_writing" / "raw" ).string();
@@ -931,7 +932,8 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         REQUIRE( waitFor( [&app]() { return app.m_currImage == 3; } ) );
         REQUIRE( app.m_writing == WRITING );
 
-        app.m_writing = STOP_WRITING;
+        app.m_writing           = STOP_WRITING;
+        app.m_stopWriteDeadline = mx::sys::get_curr_time() + cfg.m_writeStopTimeout;
         source.publishFrame( 3, 4, 40, offsetTimespec( stopAtime, 1000000 ), offsetTimespec( stopWtime, 1000000 ) );
         REQUIRE( waitFor( [&app]() { return app.writerSemaphoreValue() > 0; } ) );
         REQUIRE( app.m_currSaveStart == 2 );
@@ -946,7 +948,10 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         REQUIRE( waitFor( [&app]() { return app.m_currImage == 5; } ) );
         REQUIRE( app.m_writing == WRITING );
 
-        app.m_writing = STOP_WRITING;
+        app.m_writing           = STOP_WRITING;
+        app.m_stopWriteDeadline = mx::sys::get_curr_time() + cfg.m_writeStopTimeout;
+        std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
+        REQUIRE( app.writerSemaphoreValue() == 0 );
         REQUIRE( waitFor( [&app]() { return app.writerSemaphoreValue() > 0; } ) );
         REQUIRE( app.m_currSaveStart == 4 );
         REQUIRE( app.m_currSaveStop == 5 );
@@ -1111,6 +1116,7 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         loadConfig( app, "fg_cube_restart_timeout", cfg );
         REQUIRE( app.initializeFgHarness() == 0 );
         fgScope.markActive( true );
+        app.m_writeCompletionTimeout = 0.1;
 
         app.startFgHarnessThread();
 

--- a/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
+++ b/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
@@ -69,17 +69,18 @@ std::string ensureMilkShmDir()
 /// Configuration values used to build a deterministic streamWriter test config.
 struct streamWriterConfig
 {
-    size_t                     m_maxCircBuffLength{ 8 };                  ///< Configured circular-buffer length.
-    double                     m_maxCircBuffSize{ 16.0 };                 ///< Configured circular-buffer size in MB.
-    size_t                     m_maxWriteChunkLength{ 4 };                ///< Configured write-chunk length.
-    double                     m_maxChunkTime{ 0.5 };                     ///< Configured max chunk time in seconds.
-    double                     m_writeStopTimeout{ 1.0 };                 ///< Configured stop-writing flush timeout.
-    int                        m_writerThreadPrio{ 0 };                   ///< Configured writer thread priority.
-    std::string                m_writerCpuset;                            ///< Optional writer cpuset.
-    bool                       m_compress{ true };                        ///< Whether XRIF compression is enabled.
-    int                        m_lz4accel{ XRIF_LZ4_ACCEL_MIN };          ///< Configured LZ4 acceleration.
-    std::optional<std::string> m_outName;                                 ///< Optional explicit output name.
-    std::optional<std::string> m_savePath;                                ///< Optional explicit save directory.
+    size_t                     m_maxCircBuffLength{ 8 };         ///< Configured circular-buffer length.
+    double                     m_maxCircBuffSize{ 16.0 };        ///< Configured circular-buffer size in MB.
+    size_t                     m_maxWriteChunkLength{ 4 };       ///< Configured write-chunk length.
+    double                     m_maxChunkTime{ 0.5 };            ///< Configured max chunk time in seconds.
+    double                     m_writeStopTimeout{ 1.0 };        ///< Configured stop-writing flush timeout.
+    bool                       m_startWriting{ false };          ///< Whether writing should start armed at startup.
+    int                        m_writerThreadPrio{ 0 };          ///< Configured writer thread priority.
+    std::string                m_writerCpuset;                   ///< Optional writer cpuset.
+    bool                       m_compress{ true };               ///< Whether XRIF compression is enabled.
+    int                        m_lz4accel{ XRIF_LZ4_ACCEL_MIN }; ///< Configured LZ4 acceleration.
+    std::optional<std::string> m_outName;                        ///< Optional explicit output name.
+    std::optional<std::string> m_savePath;                       ///< Optional explicit save directory.
     std::string                m_shmimName{ "streamWriter_test_stream" }; ///< Shared-memory stream name.
     int                        m_semaphoreNumber{ 5 };                    ///< Shared-memory semaphore index.
     unsigned                   m_semWaitNSec{ 1000000 };                  ///< Semaphore timeout in nanoseconds.
@@ -399,6 +400,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                        "writer",
                                        "writer",
                                        "writer",
+                                       "writer",
                                        "framegrabber",
                                        "framegrabber",
                                        "framegrabber",
@@ -411,6 +413,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                    "maxWriteChunkLength",
                                    "maxChunkTime",
                                    "stopTimeout",
+                                   "startWriting",
                                    "threadPrio",
                                    "compress",
                                    "lz4accel",
@@ -426,6 +429,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                      std::to_string( cfg.m_maxWriteChunkLength ),
                                      std::to_string( cfg.m_maxChunkTime ),
                                      std::to_string( cfg.m_writeStopTimeout ),
+                                     cfg.m_startWriting ? "1" : "0",
                                      std::to_string( cfg.m_writerThreadPrio ),
                                      cfg.m_compress ? "1" : "0",
                                      std::to_string( cfg.m_lz4accel ),
@@ -593,6 +597,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         REQUIRE( app.m_maxWriteChunkLength == 4 );
         REQUIRE( app.m_maxChunkTime == Approx( 0.5 ) );
         REQUIRE( app.m_writeStopTimeout == Approx( 1.0 ) );
+        REQUIRE( app.m_startWriting == false );
         REQUIRE( app.m_shmimName == "streamWriter_test_stream" );
         REQUIRE( app.m_outName == app.m_shmimName );
         REQUIRE( app.m_rawimageDir == ( root / expectedRawRel ).string() );
@@ -614,6 +619,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         cfg.m_savePath = ( std::filesystem::path( "/tmp/streamWriter_lifecycle_test_override" ) / "science" ).string();
         cfg.m_compress = false;
         cfg.m_lz4accel = XRIF_LZ4_ACCEL_MAX + 17;
+        cfg.m_startWriting           = true;
         cfg.m_writeStopTimeout       = 0.25;
         cfg.m_writerThreadPrio       = 3;
         cfg.m_framegrabberThreadPrio = 2;
@@ -624,6 +630,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         REQUIRE( app.m_rawimageDir == *cfg.m_savePath );
         REQUIRE( app.m_compress == false );
         REQUIRE( app.m_lz4accel == XRIF_LZ4_ACCEL_MAX );
+        REQUIRE( app.m_startWriting == true );
         REQUIRE( app.m_writeStopTimeout == Approx( 0.25 ) );
         REQUIRE( app.m_swThreadPrio == 3 );
         REQUIRE( app.m_fgThreadPrio == 2 );
@@ -708,6 +715,28 @@ TEST_CASE( "streamWriter lifecycle handles startup validation and nominal shutdo
         REQUIRE( app.m_fgThread.joinable() == false );
         REQUIRE( app.m_swThread.joinable() == false );
         REQUIRE( app.m_writing == NOT_WRITING );
+    }
+
+    SECTION( "appStartup arms writing immediately when configured to start writing" )
+    {
+        streamWriterLifecycleTest app;
+        startupScope              startup( app );
+        streamWriterConfig        cfg;
+
+        cfg.m_startWriting = true;
+        cfg.m_savePath =
+            ( std::filesystem::path( "/tmp/streamWriter_lifecycle_test" ) / "startup_start_writing" / "raw" ).string();
+
+        loadConfig( app, "startup_start_writing", cfg );
+
+        const int startupRv = app.appStartup();
+        startup.markStarted( startupRv == 0 );
+
+        REQUIRE( startupRv == 0 );
+        REQUIRE( app.m_writing == START_WRITING );
+
+        REQUIRE( app.appLogic() == 0 );
+        REQUIRE( app.state() == stateCodes::OPERATING );
     }
 }
 

--- a/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
+++ b/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
@@ -73,6 +73,7 @@ struct streamWriterConfig
     double                     m_maxCircBuffSize{ 16.0 };                 ///< Configured circular-buffer size in MB.
     size_t                     m_maxWriteChunkLength{ 4 };                ///< Configured write-chunk length.
     double                     m_maxChunkTime{ 0.5 };                     ///< Configured max chunk time in seconds.
+    double                     m_writeStopTimeout{ 5.0 };                 ///< Configured restart-cleanup wait timeout.
     int                        m_writerThreadPrio{ 0 };                   ///< Configured writer thread priority.
     std::string                m_writerCpuset;                            ///< Optional writer cpuset.
     bool                       m_compress{ true };                        ///< Whether XRIF compression is enabled.
@@ -248,14 +249,17 @@ class streamWriterLifecycleTest : public streamWriter
     /// Stop the direct `fgThreadExec()` harness and release any resources it owns.
     void stopFgHarness()
     {
-        m_writing  = NOT_WRITING;
-        m_restart  = false;
-        m_shutdown = 1;
+        m_writing      = NOT_WRITING;
+        m_writePending = false;
+        m_restart      = false;
+        m_shutdown     = 1;
 
         if( m_fgThread.joinable() )
         {
             m_fgThread.join();
         }
+
+        release_circbufs();
 
         if( m_swSemaphoreInitialized )
         {
@@ -394,6 +398,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                        "writer",
                                        "writer",
                                        "writer",
+                                       "writer",
                                        "framegrabber",
                                        "framegrabber",
                                        "framegrabber",
@@ -405,6 +410,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                    "maxCircBuffSize",
                                    "maxWriteChunkLength",
                                    "maxChunkTime",
+                                   "stopTimeout",
                                    "threadPrio",
                                    "compress",
                                    "lz4accel",
@@ -419,6 +425,7 @@ std::filesystem::path loadConfig( streamWriterLifecycleTest &app,
                                      std::to_string( cfg.m_maxCircBuffSize ),
                                      std::to_string( cfg.m_maxWriteChunkLength ),
                                      std::to_string( cfg.m_maxChunkTime ),
+                                     std::to_string( cfg.m_writeStopTimeout ),
                                      std::to_string( cfg.m_writerThreadPrio ),
                                      cfg.m_compress ? "1" : "0",
                                      std::to_string( cfg.m_lz4accel ),
@@ -585,6 +592,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         REQUIRE( app.m_maxCircBuffSize == Approx( 16.0 ) );
         REQUIRE( app.m_maxWriteChunkLength == 4 );
         REQUIRE( app.m_maxChunkTime == Approx( 0.5 ) );
+        REQUIRE( app.m_writeStopTimeout == Approx( 5.0 ) );
         REQUIRE( app.m_shmimName == "streamWriter_test_stream" );
         REQUIRE( app.m_outName == app.m_shmimName );
         REQUIRE( app.m_rawimageDir == ( root / expectedRawRel ).string() );
@@ -606,6 +614,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         cfg.m_savePath = ( std::filesystem::path( "/tmp/streamWriter_lifecycle_test_override" ) / "science" ).string();
         cfg.m_compress = false;
         cfg.m_lz4accel = XRIF_LZ4_ACCEL_MAX + 17;
+        cfg.m_writeStopTimeout       = 0.25;
         cfg.m_writerThreadPrio       = 3;
         cfg.m_framegrabberThreadPrio = 2;
 
@@ -615,6 +624,7 @@ TEST_CASE( "streamWriter configuration loads defaults and overrides", "[streamWr
         REQUIRE( app.m_rawimageDir == *cfg.m_savePath );
         REQUIRE( app.m_compress == false );
         REQUIRE( app.m_lz4accel == XRIF_LZ4_ACCEL_MAX );
+        REQUIRE( app.m_writeStopTimeout == Approx( 0.25 ) );
         REQUIRE( app.m_swThreadPrio == 3 );
         REQUIRE( app.m_fgThreadPrio == 2 );
     }
@@ -1057,7 +1067,8 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
                                                          static_cast<uint64_t>( nextWtime.tv_sec ),
                                                          static_cast<uint64_t>( nextWtime.tv_nsec ) } );
 
-        app.m_writing = NOT_WRITING;
+        app.m_writing      = NOT_WRITING;
+        app.m_writePending = false;
         REQUIRE( app.drainWriterSemaphore() >= 1 );
 
         REQUIRE( waitFor( [&app]() { return app.m_width == 3 && app.m_height == 1 && app.m_writing == NOT_WRITING; },
@@ -1074,6 +1085,56 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         REQUIRE( rawFrameWord( app, 0, 2 ) == 502 );
         REQUIRE( timingWord( app, 0, 0 ) == 101 );
         REQUIRE( app.writerSemaphoreValue() == 0 );
+
+        app.stopFgHarness();
+        fgScope.disarm();
+    }
+
+    SECTION( "restart cleanup times out instead of hanging when no writer thread drains the queued flush" )
+    {
+        streamWriterLifecycleTest   app;
+        fgHarnessScope              fgScope( app );
+        streamWriterConfig          cfg;
+        std::unique_ptr<tempStream> source;
+
+        cfg.m_shmimName           = uniqueShmimName( "cube_restart_timeout" );
+        cfg.m_maxCircBuffLength   = 8;
+        cfg.m_maxWriteChunkLength = 4;
+        cfg.m_maxChunkTime        = 10.0;
+        cfg.m_writeStopTimeout    = 0.1;
+        cfg.m_semWaitNSec         = 1000000;
+        cfg.m_savePath =
+            ( std::filesystem::path( "/tmp/streamWriter_lifecycle_test" ) / "fg_restart_timeout" / "raw" ).string();
+
+        source = std::make_unique<tempStream>( cfg.m_shmimName, 2, 2, 8 );
+
+        loadConfig( app, "fg_cube_restart_timeout", cfg );
+        REQUIRE( app.initializeFgHarness() == 0 );
+        fgScope.markActive( true );
+
+        app.startFgHarnessThread();
+
+        REQUIRE( waitFor( [&app]()
+                          { return app.m_rawImageCircBuff != nullptr && app.m_width == 2 && app.m_height == 2; } ) );
+
+        const timespec baseAtime = currentRealtime();
+        const timespec baseWtime = offsetTimespec( baseAtime, 1000 );
+
+        app.m_writing = START_WRITING;
+        source->publishFrame( 0, 1, 100, baseAtime, baseWtime );
+        REQUIRE( waitFor( [&app]() { return app.m_currImage == 1; } ) );
+        source->publishFrame( 1, 2, 200, offsetTimespec( baseAtime, 1000000 ), offsetTimespec( baseWtime, 1000000 ) );
+        REQUIRE( waitFor( [&app]() { return app.m_currImage == 2; } ) );
+        REQUIRE( app.m_writing == WRITING );
+        REQUIRE( app.writerSemaphoreValue() == 0 );
+
+        source.reset();
+        source = std::make_unique<tempStream>( cfg.m_shmimName, 3, 1, 8 );
+
+        REQUIRE( waitFor( [&app]() { return app.m_shutdown != 0; }, 3000 ) );
+        REQUIRE( app.m_writing == STOP_WRITING );
+        REQUIRE( app.m_writePending == true );
+        REQUIRE( app.writerSemaphoreValue() > 0 );
 
         app.stopFgHarness();
         fgScope.disarm();

--- a/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
+++ b/apps/streamWriter/tests/streamWriter_lifecycle_test.cpp
@@ -1037,7 +1037,7 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         fgScope.disarm();
     }
 
-    SECTION( "replaced shmims flush the pending chunk and reconnect in the idle state" )
+    SECTION( "replaced shmims flush the pending chunk and reconnect ready to keep writing" )
     {
         streamWriterLifecycleTest   app;
         fgHarnessScope              fgScope( app );
@@ -1101,11 +1101,12 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
                                                          static_cast<uint64_t>( nextWtime.tv_sec ),
                                                          static_cast<uint64_t>( nextWtime.tv_nsec ) } );
 
-        app.m_writing      = NOT_WRITING;
-        app.m_writePending = false;
+        app.m_writing              = START_WRITING;
+        app.m_resumeAfterReconnect = true;
+        app.m_writePending         = false;
         REQUIRE( app.drainWriterSemaphore() >= 1 );
 
-        REQUIRE( waitFor( [&app]() { return app.m_width == 3 && app.m_height == 1 && app.m_writing == NOT_WRITING; },
+        REQUIRE( waitFor( [&app]() { return app.m_width == 3 && app.m_height == 1 && app.m_writing == START_WRITING; },
                           3000 ) );
         REQUIRE( app.writerSemaphoreValue() == 0 );
 
@@ -1114,7 +1115,7 @@ TEST_CASE( "streamWriter fgThreadExec ingests stream data and manages write sche
         source->publishFrame( 0, 101, 500, reconnectedAtime, reconnectedWtime );
 
         REQUIRE( waitFor( [&app]() { return app.m_currImage == 1; } ) );
-        REQUIRE( app.m_writing == NOT_WRITING );
+        REQUIRE( app.m_writing == WRITING );
         REQUIRE( rawFrameWord( app, 0, 0 ) == 500 );
         REQUIRE( rawFrameWord( app, 0, 2 ) == 502 );
         REQUIRE( timingWord( app, 0, 0 ) == 101 );


### PR DESCRIPTION
fixes hangs on sw writer toggles when image isn't updating, and now handles image resize events while writing.  adds "startWriting" config to allow startup in default writing state.