### PR TITLE
dmSpeckle: runtime arbcube reload, mode switch, and file INDI properties

### DIFF
--- a/agents/plans/2026-06/dmSpeckle-runtime-arbcube-reload.md
+++ b/agents/plans/2026-06/dmSpeckle-runtime-arbcube-reload.md
@@ -1,0 +1,197 @@
+# dmSpeckle runtime arbcube reload + mode switching
+
+## Problem to solve
+
+`apps/dmSpeckle/dmSpeckle.hpp` currently supports two operating modes — `sparkle`
+and `arbcube` — selected only via `modulator.opMode` in the config file. In
+`arbcube` mode it reads a FITS cube from `modulator.fileName` (an absolute path
+in config) on each modulation start. Operators want to:
+
+1. change the cube filename at runtime via INDI, with the usual
+   `current` / `target` convention;
+2. trigger a synchronous reload of the new cube via an INDI request switch and
+   get feedback (OK / Alert) on whether the load succeeded;
+3. switch between `sparkle` and `arbcube` modes at runtime via an INDI
+   multi-element selection switch.
+
+The runtime-supplied `file.target` is treated as an opaque filesystem path —
+any unreadable, missing, or malformed file surfaces as a logged
+`software_error` on load attempt rather than being pre-validated. Earlier
+design iterations restricted the value to a leaf filename plus a configured
+prefix path; that constraint was dropped per user direction (2026-06-15) in
+favor of letting operators point at any path.
+
+## Plan
+
+### Goals
+- Add a `<device>.file` text property with `current` and `target` elements
+  holding the full filesystem path to the arbcube FITS file. `current`
+  reflects what was last accepted by the callback (i.e. last commanded
+  value), not the result of the most recent load.
+- Add a `<device>.load_file` request switch (`request` element) that triggers
+  a reload of the file named in `current`, with the load's success / failure
+  reflected in the state of `<device>.file` (`Ok` or `Alert`).
+- Add a `<device>.mode` selection switch with elements `sparkle` and
+  `arbcube`, one-of-many, that swaps `m_opMode` at runtime.
+- The runtime-supplied path is not validated; any I/O or dimension errors
+  surface when the load is attempted.
+
+### Files touched
+- `apps/dmSpeckle/dmSpeckle.hpp` — primary implementation.
+- This plan file under `## Plan`.
+
+`dmSpeckle.cpp` is the existing 11-line main and stays unchanged.
+`apps/dmSpeckle/tests/dmSpeckle_test.cpp` keeps its existing placeholder test
+only; no new unit tests since the sanitizer helper was removed.
+
+### Configuration changes
+- `modulator.opMode` — unchanged, still selects initial mode at startup
+  (`sparkle` default, `arbcube` opt-in).
+- `modulator.fileName` — unchanged, still seeds `m_fileName` at startup;
+  remains a full filesystem path. Help text reworded to reflect that the
+  value is also settable at runtime via the new `file` property.
+
+### New / changed member state
+- INDI properties:
+  - `pcf::IndiProperty m_indiP_file;`
+  - `pcf::IndiProperty m_indiP_loadFile;`
+  - `pcf::IndiProperty m_indiP_mode;`
+- Flags:
+  - `bool m_reloadFile{ false };` — set true by the `load_file.request`
+    callback. The modulator thread checks this flag at the top of each
+    outer-loop iteration, performs the load, updates INDI state of
+    `m_indiP_file` to `Ok` on success / `Alert` on failure, then clears the
+    flag.
+- `std::mutex m_shapesMutex;` — guards `m_shapes` while a load is rewriting
+  it. The modulator hot inner loop does not take this mutex; instead, the
+  `load_file.request` callback sets `m_restartSp = true` so the inner loop
+  exits, then `loadArbcubeFile` holds the mutex during the rewrite.
+
+### `appStartup` changes
+- Register every INDI property unconditionally, regardless of initial
+  `m_opMode`. This includes the previously sparkle-only `separation`,
+  `angle`, and `cross`, plus the new `mode`, `file`, and `load_file`. Users
+  can adjust any of these in either mode; values take effect when the
+  modulator next runs and (if applicable) generates speckles for the
+  configured mode.
+- Order: trigger group, sparkle group, amp, frequency, trigger, dwell,
+  single, modulating, zero, then the new `mode`, `file`, `load_file`.
+- New property setup:
+  - `m_indiP_file` via `createStandardIndiText(... "file", ...)` and
+    `registerIndiPropertyNew`. Seed `current` and `target` from
+    `m_fileName`.
+  - `m_indiP_loadFile` via `createStandardIndiRequestSw(... "load_file", ...)`.
+  - `m_indiP_mode` via `createStandardIndiSelectionSw(... "mode",
+    {"sparkle", "arbcube"}, ...)`. Set the correct element to `On` based on
+    initial `m_opMode`.
+
+### `generateSpeckles` refactor
+- Extract the arbcube branch into a private helper:
+  `int loadArbcubeFile()` that
+  - rejects an empty `m_fileName`,
+  - locks `m_shapesMutex`,
+  - reads `m_fileName` directly into `m_shapes`,
+  - applies the dimension check (now diagnostic, includes expected vs.
+    loaded WxH and the path),
+  - scales by `m_amp`,
+  - returns 0 / -1. Severity downgraded from `software_critical` to
+    `software_error` so a bad runtime file does not crash the app.
+- `generateSpeckles()` arbcube branch becomes a call to `loadArbcubeFile()`
+  whose return value is checked. After the if/else, the existing trailing
+  `updateIfChanged` calls run for both modes (delay / amp / frequency /
+  dwell / single).
+- `generateSpeckles()` is no longer the only path that loads the cube; see
+  `modThreadExec` changes below.
+
+### `modThreadExec` changes
+- Outer-loop structure becomes:
+  1. If `m_reloadFile`: clear flag, call `loadArbcubeFile()` unconditionally
+     (even in sparkle mode — acts as a validation check; the loaded data may
+     be overwritten when sparkle next regenerates patterns). Push INDI state
+     `Ok` / `Alert` to `m_indiP_file` based on the load result.
+  2. If `!m_modulating`: sleep 500 ms and continue.
+  3. Else: existing modulating branch. `generateSpeckles()` is still called
+     once per modulating restart; in arbcube mode that re-invokes
+     `loadArbcubeFile()` which is wasted work after a recent top-of-loop
+     load, but the cost is negligible and avoids extra state-tracking.
+- The reload request always works regardless of current mode, so the user
+  can validate the file before pressing modulate, or while in sparkle mode.
+
+### Callback semantics
+- `m_indiP_file` callback:
+  - `INDI_VALIDATE_CALLBACK_PROPS`.
+  - If `target` is present, under `m_indiMutex` set `m_fileName = target`,
+    push both `target` and `current` to `target` via `updateIfChanged`.
+  - This callback does *not* trigger a load. `load_file.request` is the
+    trigger. The new path is also not validated by the callback; any
+    problems surface from the next `loadArbcubeFile()` attempt.
+- `m_indiP_loadFile` callback:
+  - `INDI_VALIDATE_CALLBACK_PROPS`.
+  - If `request` element is `On`:
+    - Under `m_indiMutex`, set `m_reloadFile = true` and
+      `m_restartSp = true`. Push state `Busy` to `m_indiP_file`. The
+      modulator thread will pick up the flag, run the load, and update
+      `m_indiP_file` state to `Ok` / `Alert` accordingly.
+- `m_indiP_mode` callback:
+  - `INDI_VALIDATE_CALLBACK_PROPS`.
+  - Determine which of `sparkle` / `arbcube` is being requested `On`.
+  - Under `m_indiMutex`, update `m_opMode` accordingly, mirror the switch
+    state back with `updateSelectionSwitchIfChanged`, and set
+    `m_restartSp = true` so the modulator thread re-generates speckles on
+    next iteration.
+
+### Telemetry
+- `recordDmSpeck` currently captures sparkle-specific parameters. Out of
+  scope to extend the telemetry schema in this change. We will add a TODO
+  comment noting that `m_opMode`, `m_fileName`, and the path are not yet in
+  the telemetry record.
+
+### Tests
+- `tests/dmSpeckle_test.cpp` keeps its existing placeholder test only. The
+  sanitizer helper was removed, so the previously planned filename-validator
+  unit tests are dropped along with it. No INDI callback unit tests added;
+  this app does not have an existing INDI callback test harness and adding
+  one is out of scope.
+
+### Documentation pass
+- Update file-level doc block to mention runtime cube reload.
+- Add `///` doc on the new members, the new helper, and the new callbacks.
+- Do an `AGENTS.md` rule-15 "changed file documentation pass" sweep on the
+  whole file.
+
+### Branch + commits
+- Create feature branch `jlong/dmSpeckle-runtime-arbcube-reload` from `dev`.
+- Commit ordering (per `AGENTS.md` rule 19):
+  1. Functional change in `dmSpeckle.hpp` and minimal test additions.
+  2. Plan file under `agents/plans/2026-06/` (this file).
+  3. Final `clang-format -i` pass over touched files if needed.
+
+## Assumptions
+- The modulator thread is the only writer to `m_shapes` other than
+  `loadArbcubeFile()`. Both call sites take `m_shapesMutex`; the hot inner
+  loop does not, and is kept consistent through the existing `m_restartSp`
+  rendezvous.
+- All INDI properties — including sparkle-only `separation` / `angle` /
+  `cross` and arbcube-only `file` / `load_file` — are registered
+  unconditionally so users can stage values for the other mode and have
+  them take effect on mode switch. Per-user direction (2026-06-15).
+- Runtime-supplied paths are trusted (`m_indiDriver` access is already
+  authenticated upstream); validation is deferred to the `mx::fits::fitsFile`
+  read itself. If hardening is ever needed, the natural place to add it is
+  back in `loadArbcubeFile` rather than in the callback.
+
+## Followups / edge cases
+- Telemetry schema does not yet record `m_opMode` or filename; add fields in
+  a separate change.
+- In arbcube mode while modulating, a `load_file.request` causes both the
+  top-of-loop eager reload AND the per-modulating-restart reload inside
+  `generateSpeckles()`. Wasted I/O but functionally correct; can be
+  optimized later with a cache invalidation flag if it ever shows up in
+  profiling.
+- The current `/tmp/specks.fits` debug write in `generateSpeckles()` is
+  preserved. Could become an INDI-toggleable debug option later.
+- Build is not exercised in this branch; the user will compile on the
+  instrument. Reviewer should sanity-check that `calibDir()` returns a
+  populated string at `loadConfigImpl` time (it does — `setDefaults()` runs
+  earlier in the `mx::app::application` lifecycle, same pattern used by
+  `libMagAOX/app/dev/dm.hpp`).

--- a/apps/dmSpeckle/dmSpeckle.hpp
+++ b/apps/dmSpeckle/dmSpeckle.hpp
@@ -7,6 +7,8 @@
 #ifndef dmSpeckle_hpp
 #define dmSpeckle_hpp
 
+#include <mutex>
+
 #include <mx/improc/eigenCube.hpp>
 #include <mx/ioutils/fits/fitsFile.hpp>
 #include <mx/improc/eigenImage.hpp>
@@ -87,13 +89,17 @@ class dmSpeckle : public MagAOXApp<true>, public dev::telemeter<dmSpeckle>
 
     int m_single{ -1 }; ///< if >= 0 a single frame is non-zero.
 
-    int m_opMode{ SPARKLE };
+    int m_opMode{ SPARKLE }; ///< Operating mode, SPARKLE or ARBCUBE.
 
-    std::string m_fileName;
+    std::string m_fileName; ///< Full filesystem path to the arbcube FITS file, settable at runtime via INDI.
 
     ///@}
 
     mx::improc::eigenCube<realT> m_shapes;
+
+    std::mutex m_shapesMutex; ///< Guards m_shapes during reload. Held only by callers that resize/repopulate the cube.
+
+    bool m_reloadFile{ false }; ///< Set by the load_file.request callback; consumed by the modulator thread.
 
     IMAGE    m_imageStream;
     uint32_t m_width{ 0 };  ///< The width of the image
@@ -150,6 +156,24 @@ class dmSpeckle : public MagAOXApp<true>, public dev::telemeter<dmSpeckle>
     virtual int appShutdown();
 
   protected:
+    /// Read m_fileName into m_shapes and scale by m_amp.
+    /** Reads the FITS cube at m_fileName into m_shapes under m_shapesMutex.
+     *  Any I/O or dimension errors are logged and returned; m_fileName is
+     *  treated as an opaque filesystem path and not otherwise validated.
+     *
+     *  \returns 0 on success
+     *  \returns -1 on error
+     */
+    int loadArbcubeFile();
+
+    /// Populate m_shapes for the current operating mode.
+    /** In SPARKLE mode, computes Fourier-mode speckle patterns from
+     *  m_separation / m_angle / m_amp. In ARBCUBE mode, delegates to
+     *  loadArbcubeFile().
+     *
+     *  \returns 0 on success
+     *  \returns -1 on error
+     */
     int generateSpeckles();
 
     /** \name Modulator Thread
@@ -192,6 +216,9 @@ class dmSpeckle : public MagAOXApp<true>, public dev::telemeter<dmSpeckle>
     pcf::IndiProperty m_indiP_single;
     pcf::IndiProperty m_indiP_modulating;
     pcf::IndiProperty m_indiP_zero;
+    pcf::IndiProperty m_indiP_mode;     ///< Selection switch toggling SPARKLE / ARBCUBE.
+    pcf::IndiProperty m_indiP_file;     ///< Text property with current/target arbcube leaf filenames.
+    pcf::IndiProperty m_indiP_loadFile; ///< Request switch that triggers an arbcube reload.
 
   public:
     INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_trigger );
@@ -205,6 +232,9 @@ class dmSpeckle : public MagAOXApp<true>, public dev::telemeter<dmSpeckle>
     INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_single );
     INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_modulating );
     INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_zero );
+    INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_mode );
+    INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_file );
+    INDI_NEWCALLBACK_DECL( dmSpeckle, m_indiP_loadFile );
 
     /** \name Telemeter Interface
      *
@@ -374,7 +404,8 @@ void dmSpeckle::setupConfig()
                 "fileName",
                 false,
                 "string",
-                "File name containing the FITS cube to modulate the DM with.  Only valid if opMode==arbcube." );
+                "Full filesystem path to the FITS cube to modulate the DM with.  "
+                "Only used if opMode==arbcube; can be changed at runtime via the file INDI property." );
 }
 
 int dmSpeckle::loadConfigImpl( mx::app::appConfigurator &_config )
@@ -405,10 +436,12 @@ int dmSpeckle::loadConfigImpl( mx::app::appConfigurator &_config )
     {
         m_opMode = SPARKLE;
     }
-        _config(m_fileName, "modulator.fileName");
-        _config( m_separation, "dm.separation" );
-        _config( m_angle, "dm.angle" );
-        _config( m_angleOffset, "dm.angleOffset" );
+
+    _config( m_fileName, "modulator.fileName" );
+
+    _config( m_separation, "dm.separation" );
+    _config( m_angle, "dm.angle" );
+    _config( m_angleOffset, "dm.angleOffset" );
 
 
     _config( m_amp, "dm.amp" );
@@ -447,32 +480,31 @@ int dmSpeckle::appStartup()
     m_indiP_delay["target"]  = m_triggerDelay;
     registerIndiPropertyNew( m_indiP_delay, INDI_NEWCALLBACK( m_indiP_delay ) );
 
-    if( m_opMode == SPARKLE )
+    // The sparkle-specific properties are always registered so users can set them while in
+    // arbcube mode; they take effect when mode switches back to sparkle.
+    createStandardIndiNumber<float>( m_indiP_separation, "separation", 0, 0, 100, "%f" );
+    m_indiP_separation["current"] = m_separation;
+    m_indiP_separation["target"]  = m_separation;
+    registerIndiPropertyNew( m_indiP_separation, INDI_NEWCALLBACK( m_indiP_separation ) );
+
+    createStandardIndiNumber<float>( m_indiP_angle, "angle", 0, 0, 100, "%f" );
+    m_indiP_angle["current"] = m_angle;
+    m_indiP_angle["target"]  = m_angle;
+    registerIndiPropertyNew( m_indiP_angle, INDI_NEWCALLBACK( m_indiP_angle ) );
+
+    createStandardIndiToggleSw( m_indiP_cross, "cross" );
+    if( registerIndiPropertyNew( m_indiP_cross, INDI_NEWCALLBACK( m_indiP_cross ) ) < 0 )
     {
-        createStandardIndiNumber<float>( m_indiP_separation, "separation", 0, 0, 100, "%f" );
-        m_indiP_separation["current"] = m_separation;
-        m_indiP_separation["target"]  = m_separation;
-        registerIndiPropertyNew( m_indiP_separation, INDI_NEWCALLBACK( m_indiP_separation ) );
-
-        createStandardIndiNumber<float>( m_indiP_angle, "angle", 0, 0, 100, "%f" );
-        m_indiP_angle["current"] = m_angle;
-        m_indiP_angle["target"]  = m_angle;
-        registerIndiPropertyNew( m_indiP_angle, INDI_NEWCALLBACK( m_indiP_angle ) );
-
-        createStandardIndiToggleSw( m_indiP_cross, "cross" );
-        if( registerIndiPropertyNew( m_indiP_cross, INDI_NEWCALLBACK( m_indiP_cross ) ) < 0 )
-        {
-            log<software_error>( { __FILE__, __LINE__ } );
-            return -1;
-        }
-        if( m_cross )
-        {
-            m_indiP_cross["toggle"] = pcf::IndiElement::On;
-        }
-        else
-        {
-            m_indiP_cross["toggle"] = pcf::IndiElement::Off;
-        }
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+    if( m_cross )
+    {
+        m_indiP_cross["toggle"] = pcf::IndiElement::On;
+    }
+    else
+    {
+        m_indiP_cross["toggle"] = pcf::IndiElement::Off;
     }
 
     createStandardIndiNumber<float>( m_indiP_amp, "amp", -1, 0, 1, "%f" );
@@ -519,6 +551,39 @@ int dmSpeckle::appStartup()
 
     createStandardIndiRequestSw( m_indiP_zero, "zero" );
     if( registerIndiPropertyNew( m_indiP_zero, INDI_NEWCALLBACK( m_indiP_zero ) ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+
+    if( createStandardIndiSelectionSw( m_indiP_mode, "mode", { "sparkle", "arbcube" } ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+    m_indiP_mode["sparkle"] = ( m_opMode == SPARKLE ) ? pcf::IndiElement::On : pcf::IndiElement::Off;
+    m_indiP_mode["arbcube"] = ( m_opMode == ARBCUBE ) ? pcf::IndiElement::On : pcf::IndiElement::Off;
+    if( registerIndiPropertyNew( m_indiP_mode, INDI_NEWCALLBACK( m_indiP_mode ) ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+
+    if( createStandardIndiText( m_indiP_file, "file" ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+    m_indiP_file["current"] = m_fileName;
+    m_indiP_file["target"]  = m_fileName;
+    if( registerIndiPropertyNew( m_indiP_file, INDI_NEWCALLBACK( m_indiP_file ) ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__ } );
+        return -1;
+    }
+
+    createStandardIndiRequestSw( m_indiP_loadFile, "load_file" );
+    if( registerIndiPropertyNew( m_indiP_loadFile, INDI_NEWCALLBACK( m_indiP_loadFile ) ) < 0 )
     {
         log<software_error>( { __FILE__, __LINE__ } );
         return -1;
@@ -634,25 +699,49 @@ int dmSpeckle::appShutdown()
     return 0;
 }
 
+int dmSpeckle::loadArbcubeFile()
+{
+    if( m_fileName.empty() )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "arbcube file name is empty; nothing to load" } );
+    }
+
+    std::lock_guard<std::mutex> shapesLock( m_shapesMutex ); //mutex scope
+
+    mx::fits::fitsFile<float> ff;
+    mx::error_t               errc = ff.read( m_shapes, m_fileName );
+    if( errc != mx::error_t::noerror )
+    {
+        return log<software_error, -1>(
+            { __FILE__, __LINE__, "could not read arbcube FITS file: " + m_fileName } );
+    }
+
+    if( m_shapes.rows() != m_width || m_shapes.cols() != m_height )
+    {
+        return log<software_error, -1>( { __FILE__,
+                                          __LINE__,
+                                          "arbcube dimensions do not match DM channel size: expected " +
+                                              std::to_string( m_width ) + "x" + std::to_string( m_height ) +
+                                              ", loaded " + std::to_string( m_shapes.rows() ) + "x" +
+                                              std::to_string( m_shapes.cols() ) + " from " + m_fileName } );
+    }
+
+    for( int p = 0; p < m_shapes.planes(); ++p )
+    {
+        m_shapes.image( p ) *= (float)m_amp;
+    }
+
+    return 0;
+}
+
 int dmSpeckle::generateSpeckles()
 {
     if( m_opMode == ARBCUBE )
     {
-        mx::fits::fitsFile<float> ff;
-        mx::error_t errc = ff.read( m_shapes, m_fileName ) ;
-        if( errc != mx::error_t::noerror )
+        if( loadArbcubeFile() < 0 )
         {
-            return log<software_critical, -1>( { __FILE__, __LINE__, "no file with that name" } );
-        }
-
-        if( m_shapes.rows() != m_width || m_shapes.cols() != m_height )
-        {
-            return log<software_critical, -1>( { __FILE__, __LINE__, "shape cube is not the right size" } );
-        }
-
-        for(int p =0; p < m_shapes.planes(); ++p)
-        {
-            m_shapes.image(p) *= (float) m_amp;
+            return -1;
         }
     }
     else
@@ -732,6 +821,23 @@ inline void dmSpeckle::modThreadExec()
 
     while( m_shutdown == 0 )
     {
+        // Handle any pending file reload. If we are currently modulating the load_file.request
+        // callback also sets m_restartSp = true so the inner loop has already exited; m_shapes
+        // is therefore safe to rewrite here.
+        if( m_reloadFile && !m_shutdown )
+        {
+            m_reloadFile = false;
+            int rv       = loadArbcubeFile();
+            pcf::IndiProperty::PropertyStateType newState =
+                ( rv < 0 ) ? pcf::IndiProperty::Alert : pcf::IndiProperty::Ok;
+            if( m_indiDriver )
+            {
+                m_indiP_file.setState( newState );
+                m_indiP_file.setTimeStamp( pcf::TimeStamp() );
+                m_indiDriver->sendSetProperty( m_indiP_file );
+            }
+        }
+
         if( !m_modulating && !m_shutdown ) // If we aren't modulating we sleep for 1/2 a second
         {
             mx::sys::milliSleep( 500 );
@@ -740,7 +846,7 @@ inline void dmSpeckle::modThreadExec()
         if( m_modulating && !m_shutdown )
         {
             m_restartSp = false;
-            if(generateSpeckles() < 0)
+            if( generateSpeckles() < 0 )
             {
                 m_modulating = false;
                 continue;
@@ -1282,6 +1388,81 @@ INDI_NEWCALLBACK_DEFN( dmSpeckle, m_indiP_zero )
         log<text_log>( "zeroed" );
     }
 
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( dmSpeckle, m_indiP_mode )
+( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_mode, ipRecv );
+
+    int newMode = m_opMode;
+    if( ipRecv.find( "sparkle" ) && ipRecv["sparkle"].getSwitchState() == pcf::IndiElement::On )
+    {
+        newMode = SPARKLE;
+    }
+    else if( ipRecv.find( "arbcube" ) && ipRecv["arbcube"].getSwitchState() == pcf::IndiElement::On )
+    {
+        newMode = ARBCUBE;
+    }
+    else
+    {
+        return 0;
+    }
+
+    std::unique_lock<std::mutex> lock( m_indiMutex );
+
+    if( newMode != m_opMode )
+    {
+        m_opMode = newMode;
+        log<text_log>( newMode == ARBCUBE ? "mode set to arbcube" : "mode set to sparkle", logPrio::LOG_NOTICE );
+        m_restartSp = true;
+    }
+
+    indi::updateSelectionSwitchIfChanged(
+        m_indiP_mode, newMode == SPARKLE ? "sparkle" : "arbcube", m_indiDriver, pcf::IndiProperty::Ok );
+
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( dmSpeckle, m_indiP_file )
+( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_file, ipRecv );
+
+    if( !ipRecv.find( "target" ) )
+        return 0;
+
+    std::string target = ipRecv["target"].get<std::string>();
+
+    std::unique_lock<std::mutex> lock( m_indiMutex );
+    m_fileName = target;
+    updateIfChanged( m_indiP_file, "target", m_fileName );
+    updateIfChanged( m_indiP_file, "current", m_fileName );
+    return 0;
+}
+
+INDI_NEWCALLBACK_DEFN( dmSpeckle, m_indiP_loadFile )
+( const pcf::IndiProperty &ipRecv )
+{
+    INDI_VALIDATE_CALLBACK_PROPS( m_indiP_loadFile, ipRecv );
+
+    if( !ipRecv.find( "request" ) )
+        return 0;
+
+    if( ipRecv["request"].getSwitchState() != pcf::IndiElement::On )
+        return 0;
+
+    std::unique_lock<std::mutex> lock( m_indiMutex );
+
+    m_reloadFile = true;
+    m_restartSp  = true;
+    if( m_indiDriver )
+    {
+        m_indiP_file.setState( pcf::IndiProperty::Busy );
+        m_indiP_file.setTimeStamp( pcf::TimeStamp() );
+        m_indiDriver->sendSetProperty( m_indiP_file );
+    }
     return 0;
 }
 


### PR DESCRIPTION
This work was performed by Claude Opus 4.7 in response to the prompt: "currently @apps/dmSpeckle/dmSpeckle.hpp supports loading an arbcube, a FITS cube from disk that contains frames to be written to an output shmim (shared memory image from MILK). I want to be able to change the cube filename at runtime and trigger a reload, using INDI property messages. There should be a `<devicename>.file.current` / `<devicename>.file.target` text property pair, using the convention of current for the current state and target for the user commanded state. There should be `<devicename>.load_file.request`, a switch that triggers a load of the file named in `current`. There should be a config item for the prefix where it looks for FITS files. For simplicity, disallow slashes in the commanded `file.current` name, and just prepend the configed path. Finally, a `mode` multi-element switch that can switch between sparkle and arbcube modes." Two follow-up directions during implementation: (a) register every INDI property unconditionally so values can be staged across mode switches; (b) drop the leaf-filename restriction and the configured-prefix path — accept a full UNIX path and let load errors surface in logs.

## Summary
- Add `mode` (selection switch: sparkle / arbcube), `file` (text current/target, full path), and `load_file` (request switch) INDI properties to `dmSpeckle`. All three are registered regardless of current mode.
- Extract the arbcube FITS read into `loadArbcubeFile()` under a new `m_shapesMutex`; the dimension mismatch error now reports expected vs loaded WxH and the file path. Severity downgraded from `software_critical` to `software_error` so a bad runtime file does not crash the app.
- `modThreadExec` outer loop processes a new `m_reloadFile` flag at the top of each iteration so reloads work whether or not the modulator is running.
- Sparkle-only `separation`, `angle`, and `cross` are now also registered unconditionally so operators can stage values across mode switches.
- Plan committed alongside under `agents/plans/2026-06/dmSpeckle-runtime-arbcube-reload.md`.

## Test plan
- [x] Build on instrument (local build skipped per request).
- [x] Start `dmSpeckle` in sparkle mode; confirm `dm.mode.sparkle = On`, `dm.file.current/target` and `dm.load_file` properties are visible.
- [x] Toggle `dm.mode.arbcube = On`, confirm `m_opMode` switches and modulator restarts cleanly.
- [x] Set `dm.file.target = /path/to/cube.fits`; confirm `current` mirrors the target.
- [ ] Send `dm.load_file.request = On` while not modulating; observe `dm.file` state transition Busy → Ok and a log line on success, or → Alert with a diagnostic on failure (bad path, dimension mismatch).
- [ ] Repeat `load_file.request` while modulating; confirm the modulator interrupts cleanly via `m_restartSp`, reloads, and resumes.
- [ ] Confirm an arbcube whose dimensions do not match the DM channel size produces an error log of the form `arbcube dimensions do not match DM channel size: expected WxH, loaded AxB from /path`.