### PR TITLE
Add shmimDelta timing utility and DM trigger delta stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,7 @@ utils_to_build = \
 	logdump \
 	logsurgeon \
 	cursesINDI \
+	shmimDelta \
 	xrif2fits \
 	xrif2shmim
 

--- a/doc/config/Doxyfile.libMagAOX
+++ b/doc/config/Doxyfile.libMagAOX
@@ -822,6 +822,7 @@ INPUT                  = libMagAOX \
                          flatlogs/include/flatlogs/ \
                          apps/ \
                          utils/logdump/ \
+                         utils/shmimDelta/ \
                          utils/xrif2shmim/ \
                          tests \
                          tests/groups.dox

--- a/libMagAOX/app/dev/dm.hpp
+++ b/libMagAOX/app/dev/dm.hpp
@@ -12,6 +12,7 @@
 #include <mx/improc/eigenImage.hpp>
 #include <mx/improc/milkImage.hpp>
 #include <mx/ioutils/fits/fitsFile.hpp>
+#include <mx/sigproc/circularBuffer.hpp>
 
 #include "shmimMonitor.hpp"
 
@@ -772,29 +773,59 @@ class dm
 
     typedef int32_t cbIndexT;
 
+    /// Timing markers for total command processing, saturation posting, and saturation update intervals.
     double m_t0{ 0 }, m_tf{ 0 }, m_tsat0{ 0 }, m_tsatf{ 0 };
+
+    /// Timing markers set by derived DM command implementations for actuator processing phases.
     double m_tact0{ 0 }, m_tact1{ 0 }, m_tact2{ 0 }, m_tact3{ 0 }, m_tact4{ 0 };
+
+    /// Timing markers for delta-channel update processing.
     double m_tdelta0 {0}, m_tdeltaf {0};
 
+    /// Previous trigger semaphore arrival time, used to compute frame-to-frame spacing.
+    double m_t0Last{ 0 };
+
+    /// Circular buffer of total processImage latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_piTimes;
 
+    /// Circular buffer of saturation semaphore post latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_satSem;
 
+    /// Circular buffer of actuator processing latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_actProc;
 
+    /// Circular buffer of actuator command latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_actCom;
 
+    /// Circular buffer of saturation map update latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_satUp;
 
+    /// Circular buffer of delta-channel update latency samples.
     mx::sigproc::circularBufferIndex<double, cbIndexT> m_deltaUp;
 
+    /// Circular buffer of trigger semaphore frame-to-frame arrival deltas.
+    mx::sigproc::circularBufferIndex<double, cbIndexT> m_triggerDelta;
 
+    /// Storage for reporting total processImage latency samples.
     std::vector<double> m_piTimesD;
+
+    /// Storage for reporting saturation semaphore post latency samples.
     std::vector<double> m_satSemD;
+
+    /// Storage for reporting actuator processing latency samples.
     std::vector<double> m_actProcD;
+
+    /// Storage for reporting actuator command latency samples.
     std::vector<double> m_actComD;
+
+    /// Storage for reporting saturation map update latency samples.
     std::vector<double> m_satUpD;
+
+    /// Storage for reporting delta-channel update latency samples.
     std::vector<double> m_deltaUpD;
+
+    /// Storage for reporting trigger semaphore frame-to-frame arrival deltas.
+    std::vector<double> m_triggerDeltaD;
 
     // clang-format off
     #endif // clang-format on
@@ -1571,9 +1602,12 @@ int dm<derivedT, realT>::appLogic()
 #ifdef XWC_DMTIMINGS
     static uint64_t lastMono = 0;
 
-    if( m_piTimes.size() >= m_piTimes.maxEntries() && m_piTimes.maxEntries() > 0 && m_piTimes.mono() != lastMono )
+    if( m_piTimes.size() >= m_piTimes.maxEntries() && m_piTimes.maxEntries() > 0 &&
+        m_triggerDelta.size() >= m_triggerDelta.maxEntries() && m_triggerDelta.maxEntries() > 0 &&
+        m_piTimes.mono() != lastMono )
     {
-        cbIndexT refEntry = m_piTimes.earliest();
+        cbIndexT refEntry             = m_piTimes.earliest();
+        cbIndexT triggerDeltaRefEntry = m_triggerDelta.earliest();
 
         m_piTimesD.resize( m_piTimes.maxEntries() );
         m_satSemD.resize( m_satSem.maxEntries() );
@@ -1581,6 +1615,7 @@ int dm<derivedT, realT>::appLogic()
         m_actComD.resize( m_actCom.maxEntries() );
         m_satUpD.resize( m_satUp.maxEntries() );
         m_deltaUpD.resize( m_deltaUp.maxEntries() );
+        m_triggerDeltaD.resize( m_triggerDelta.maxEntries() );
 
         for( size_t n = 0; n < m_piTimesD.size(); ++n )
         {
@@ -1592,6 +1627,11 @@ int dm<derivedT, realT>::appLogic()
             m_deltaUpD[n] = m_deltaUp.at( refEntry, n );
         }
 
+        for( size_t n = 0; n < m_triggerDeltaD.size(); ++n )
+        {
+            m_triggerDeltaD[n] = m_triggerDelta.at( triggerDeltaRefEntry, n );
+        }
+
         std::cerr << "Act. Process:   " << mx::math::vectorMean( m_actProcD ) << " +/- "
                   << sqrt( mx::math::vectorVariance( m_actProcD ) ) << "\n";
         std::cerr << "Act. Command:   " << mx::math::vectorMean( m_actComD ) << " +/- "
@@ -1600,6 +1640,8 @@ int dm<derivedT, realT>::appLogic()
                   << sqrt( mx::math::vectorVariance( m_satUpD ) ) << "\n";
         std::cerr << "Delta Update:   " << mx::math::vectorMean( m_deltaUpD ) << " +/- "
                   << sqrt( mx::math::vectorVariance( m_deltaUpD ) ) << "\n";
+        std::cerr << "Trig. Delta:    " << mx::math::vectorMean( m_triggerDeltaD ) << " +/- "
+                  << sqrt( mx::math::vectorVariance( m_triggerDeltaD ) ) << "\n";
         std::cerr << "Tot. CommandDM: " << mx::math::vectorMean( m_piTimesD ) << " +/- "
                   << sqrt( mx::math::vectorVariance( m_piTimesD ) ) << "\n";
         std::cerr << "Sat. Semaphore: " << mx::math::vectorMean( m_satSemD ) << " +/- "
@@ -1836,6 +1878,7 @@ int dm<derivedT, realT>::allocate( const dev::shmimT &sp )
     m_actCom.maxEntries( 2000 );
     m_satUp.maxEntries( 2000 );
     m_deltaUp.maxEntries( 2000 );
+    m_triggerDelta.maxEntries( 2000 );
     #endif // clang-format on
 
     return 0;
@@ -1902,12 +1945,19 @@ int dm<derivedT, realT>::processImage( void *curr_src, const dev::shmimT &sp )
     // Update the latency circ. buffs
     if( m_piTimes.maxEntries() > 0 )
     {
+        if( m_t0Last > 0 )
+        {
+            m_triggerDelta.nextEntry( m_t0 - m_t0Last );
+        }
+
         m_piTimes.nextEntry( m_tf - m_t0 );
         m_satSem.nextEntry( m_tsatf - m_tsat0 );
         m_actProc.nextEntry( m_tact1 - m_tact0 );
         m_actCom.nextEntry( m_tact2 - m_tact1 );
         m_satUp.nextEntry( m_tact4 - m_tact3 );
         m_deltaUp.nextEntry( m_tdeltaf - m_tdelta0 );
+
+        m_t0Last = m_t0;
     }
 
         // clang-format off

--- a/tests/tests.list
+++ b/tests/tests.list
@@ -119,6 +119,7 @@
 
 ../utils/tests/cursesINDI_test
 ../utils/tests/logdump_test
+../utils/tests/shmimDelta_test
 ../utils/tests/shmimInfo_test
 ../utils/tests/shmimLat_test
 ../utils/tests/shmimPlot_test

--- a/utils/shmimDelta/Makefile
+++ b/utils/shmimDelta/Makefile
@@ -1,0 +1,7 @@
+
+allall: all
+
+OTHER_HEADERS=
+TARGET=shmimDelta
+include ../../Make/magAOXUtil.mk
+

--- a/utils/shmimDelta/doc/shmimDelta.md
+++ b/utils/shmimDelta/doc/shmimDelta.md
@@ -29,19 +29,27 @@ The reported delta is:
 shmimName2 time - shmimName1 time
 ```
 
-At startup, `shmimDelta` opens both streams, selects a wait semaphore for each
-stream, and flushes both semaphores before collecting samples.  During
-collection, each stream is watched by its own waiter thread so that waiting on
-one stream does not serialize waiting on the other.
+At startup, `shmimDelta` opens both streams and selects a wait semaphore for
+each stream.  It then performs a synchronization pass:
+
+1. flush both semaphores;
+2. wait for a frame from `shmimName1`;
+3. inspect `shmimName2` semaphore arrivals until it records the first
+   `shmimName2` frame whose sampled time is at or after the stream-1 reference.
+
+Those two frames establish the reference `cnt0` values for the measurement.
+During collection, each stream is watched by its own waiter thread so that
+waiting on one stream does not serialize waiting on the other.
 
 After each semaphore wake, `shmimDelta` drains any queued semaphore posts and
 records only the latest observed frame.  This avoids slowly accumulating stale
 semaphore posts when the reader falls behind.  Duplicate frame counters are
 ignored.
 
-When possible, samples are paired by matching ImageStreamIO frame counter
-(`cnt0`).  If no usable common `cnt0` values are found, samples are paired by
-arrival order and the output reports `pairing: order`.
+Samples are paired by matching counter advance from the synchronized references,
+not by requiring equal raw ImageStreamIO frame counter (`cnt0`) values.  This is
+important for derived streams whose counters are offset or independently
+initialized.
 
 # OPTIONS
 
@@ -67,7 +75,10 @@ It then prints the timing statistics:
 
 ```
 timed_pairs: 1000
-pairing: cnt0
+pairing: reference_cnt0
+reference1_cnt0: 215037
+reference2_cnt0: 810421
+reference_delta_usec: 123.000
 delta_mean_usec: 123.456
 delta_rms_usec: 7.890
 ```
@@ -75,11 +86,12 @@ delta_rms_usec: 7.890
 The timing values are in microseconds.  `delta_rms_usec` is the rms scatter of
 the paired deltas about `delta_mean_usec`.
 
-The `pairing` field reports how frames were paired:
+The `pairing` field should report `reference_cnt0`.  This means samples were
+paired by matching:
 
-- `cnt0`: samples were paired by matching ImageStreamIO frame counter values;
-- `order`: no usable common counters were found, so samples were paired by
-  collection order.
+```
+sample1.cnt0 - reference1_cnt0 == sample2.cnt0 - reference2_cnt0
+```
 
 # TIMING SOURCE
 
@@ -139,19 +151,27 @@ because the launcher process may not yet be allowed to run on the cpuset CPU.
 ## Negative Deltas
 
 A negative delta means the sampled time for `shmimName2` was earlier than the
-sampled time for `shmimName1`.  This can be real if the selected streams do not
-represent a causal source-to-output relationship, or if they are paired by
-arrival order and the physical delay crosses a frame boundary.
+sampled time for the paired `shmimName1` frame.  Since `shmimDelta` synchronizes
+on the first stream-2 frame after a stream-1 frame and then pairs by relative
+counter advance, persistent negative values usually indicate that the stream
+metadata timestamps are not measuring the event you intend, or that the selected
+streams are not in the expected causal order.
 
-Prefer runs with:
+Check the reference line first:
 
 ```
-pairing: cnt0
+reference_delta_usec: ...
 ```
 
-If the output reports `pairing: order`, the two streams did not expose matching
-frame counters during the run.  In that case, long runs are more sensitive to
-frame drops, startup phase, and scheduler effects.
+If the reference delta is already negative, inspect the stream metadata
+timestamps and the stream ordering.  If the run exits with:
+
+```
+Need at least 2 paired arrivals with matching synchronized counter advances
+```
+
+then one stream did not provide enough frames whose `cnt0` advanced by the same
+amount from the synchronized references.
 
 ## Timeouts
 

--- a/utils/shmimDelta/doc/shmimDelta.md
+++ b/utils/shmimDelta/doc/shmimDelta.md
@@ -81,10 +81,19 @@ reference2_cnt0: 810421
 reference_delta_usec: 123.000
 delta_mean_usec: 123.456
 delta_rms_usec: 7.890
+stream1_delta_mean_usec: 999.998
+stream1_delta_rms_usec: 3.210
+stream2_delta_mean_usec: 999.999
+stream2_delta_rms_usec: 3.456
 ```
 
 The timing values are in microseconds.  `delta_rms_usec` is the rms scatter of
 the paired deltas about `delta_mean_usec`.
+
+The `stream1_delta_*` and `stream2_delta_*` fields are frame-to-frame timing
+statistics for each stream independently.  They are calculated from consecutive
+recorded samples in that stream, beginning with the synchronized reference
+sample.
 
 The `pairing` field should report `reference_cnt0`.  This means samples were
 paired by matching:

--- a/utils/shmimDelta/doc/shmimDelta.md
+++ b/utils/shmimDelta/doc/shmimDelta.md
@@ -1,0 +1,187 @@
+shmimDelta
+==========
+
+[TOC]
+
+------------------------------------------------------------------------
+
+# NAME
+
+shmimDelta - measure semaphore timing deltas between two ImageStreamIO streams.
+
+# SYNOPSIS
+
+```
+shmimDelta [options]
+shmimDelta --shmimName1 camwfs --shmimName2 aol1_imWFS2 -N 1000 -t 1
+```
+
+# DESCRIPTION
+
+`shmimDelta` attaches to two ImageStreamIO shared memory image streams
+(`shmims`) and measures the timing delta between their semaphore updates.  It is
+intended for quick latency and jitter checks between a source stream and a
+downstream stream derived from it.
+
+The reported delta is:
+
+```
+shmimName2 time - shmimName1 time
+```
+
+At startup, `shmimDelta` opens both streams, selects a wait semaphore for each
+stream, and flushes both semaphores before collecting samples.  During
+collection, each stream is watched by its own waiter thread so that waiting on
+one stream does not serialize waiting on the other.
+
+After each semaphore wake, `shmimDelta` drains any queued semaphore posts and
+records only the latest observed frame.  This avoids slowly accumulating stale
+semaphore posts when the reader falls behind.  Duplicate frame counters are
+ignored.
+
+When possible, samples are paired by matching ImageStreamIO frame counter
+(`cnt0`).  If no usable common `cnt0` values are found, samples are paired by
+arrival order and the output reports `pairing: order`.
+
+# OPTIONS
+
+| Short | Long | Config-file key | Type | Description |
+| --- | --- | --- | --- | --- |
+| `-1` | `--shmimName1` | `shmimName1` | string | First stream name.  This is the reference stream in the delta calculation. |
+| `-2` | `--shmimName2` | `shmimName2` | string | Second stream name.  Reported delta is this stream's time minus stream 1's time. |
+| `-N` | `--nFrames` | `nFrames` | int | Number of paired frame arrivals to measure.  Default is `100`. |
+| `-t` | `--timeout` | `timeout` | float | Per-frame semaphore wait timeout in seconds.  Default is `1.0`. |
+
+# OUTPUT
+
+`shmimDelta` first prints the attached stream names and dimensions:
+
+```
+shmim1: camwfs
+size1: 50 50 1
+shmim2: aol2_imWFS2
+size2: 50 50 1
+```
+
+It then prints the timing statistics:
+
+```
+timed_pairs: 1000
+pairing: cnt0
+delta_mean_usec: 123.456
+delta_rms_usec: 7.890
+```
+
+The timing values are in microseconds.  `delta_rms_usec` is the rms scatter of
+the paired deltas about `delta_mean_usec`.
+
+The `pairing` field reports how frames were paired:
+
+- `cnt0`: samples were paired by matching ImageStreamIO frame counter values;
+- `order`: no usable common counters were found, so samples were paired by
+  collection order.
+
+# TIMING SOURCE
+
+For each semaphore wake, `shmimDelta` samples the latest stream metadata.  If
+the stream has a valid ImageStreamIO `writetime`, that metadata timestamp is
+used for the delta calculation.  If no valid metadata timestamp is available,
+the local `CLOCK_MONOTONIC` timestamp taken immediately after the semaphore wake
+is used as a fallback.
+
+The local fallback includes scheduler wake latency.  For lowest jitter, run
+`shmimDelta` on an isolated CPU or cpuset.
+
+# EXAMPLES
+
+Measure 1000 paired updates:
+
+```
+shmimDelta \
+  --shmimName1 camwfs \
+  --shmimName2 aol2_imWFS2 \
+  -N 1000 \
+  -t 1
+```
+
+Run on the `mlat` cpuset as user `xsup`, preserving the caller's environment:
+
+```
+sudo -E bash -lc '
+  echo $$ > /opt/MagAOX/cpuset/mlat/tasks
+  exec sudo -E -u xsup -- shmimDelta \
+    --shmimName1 camwfs \
+    --shmimName2 aol2_imWFS2 \
+    -N 1000 \
+    -t 1
+'
+```
+
+This pattern enters the cpuset before dropping privileges to `xsup`.  If the
+cpuset contains CPU 48, for example:
+
+```
+cat /opt/MagAOX/cpuset/mlat/cpuset.cpus
+48
+```
+
+then no additional `taskset -c 48` is needed.  Running `taskset` before entering
+the cpuset can fail with:
+
+```
+taskset: failed to set pid <pid>'s affinity: Invalid argument
+```
+
+because the launcher process may not yet be allowed to run on the cpuset CPU.
+
+# TROUBLESHOOTING
+
+## Negative Deltas
+
+A negative delta means the sampled time for `shmimName2` was earlier than the
+sampled time for `shmimName1`.  This can be real if the selected streams do not
+represent a causal source-to-output relationship, or if they are paired by
+arrival order and the physical delay crosses a frame boundary.
+
+Prefer runs with:
+
+```
+pairing: cnt0
+```
+
+If the output reports `pairing: order`, the two streams did not expose matching
+frame counters during the run.  In that case, long runs are more sensitive to
+frame drops, startup phase, and scheduler effects.
+
+## Timeouts
+
+Increase `-t` if either stream updates slower than the timeout:
+
+```
+shmimDelta --shmimName1 camwfs --shmimName2 aol2_imWFS2 -N 1000 -t 5
+```
+
+Timeouts can also indicate that the stream was replaced or deleted while the
+tool was waiting.
+
+## Environment
+
+When running through `sudo`, preserve the runtime environment if stream lookup
+depends on variables such as `MILK_SHM_DIR`:
+
+```
+sudo -E ...
+```
+
+# EXIT STATUS
+
+`shmimDelta` returns:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Measurement completed and statistics were printed. |
+| non-zero | Stream open, semaphore wait, timeout, or configuration error. |
+
+# SEE ALSO
+
+`shmimInfo`, `shmimLat`, `ImageStreamIO`

--- a/utils/shmimDelta/shmimDelta.cpp
+++ b/utils/shmimDelta/shmimDelta.cpp
@@ -191,9 +191,9 @@ int shmimDelta::execute()
     return rv;
 }
 
-double shmimDelta::elapsedSeconds( const timespec &t0, const timespec &t1 )
+double shmimDelta::elapsedUsec( const timespec &t0, const timespec &t1 )
 {
-    return static_cast<double>( t1.tv_sec - t0.tv_sec ) + 1e-9 * static_cast<double>( t1.tv_nsec - t0.tv_nsec );
+    return 1e6 * static_cast<double>( t1.tv_sec - t0.tv_sec ) + 1e-3 * static_cast<double>( t1.tv_nsec - t0.tv_nsec );
 }
 
 double shmimDelta::mean( const std::vector<double> &values )
@@ -379,28 +379,76 @@ int shmimDelta::measureDeltas()
         return -1;
     }
 
-    const size_t pairedFrames = std::min( m_stream1.m_arrivalTimes.size(), m_stream2.m_arrivalTimes.size() );
+    const char *pairingMethod = "cnt0";
+
+    size_t pairedFrames = pairByCounter();
+    if( pairedFrames < 2 )
+    {
+        pairedFrames  = pairByOrder();
+        pairingMethod = "order";
+        std::cerr << "No common cnt0 pairing found; paired samples by arrival order.\n";
+    }
+
     if( pairedFrames < 2 )
     {
         std::cerr << "Need at least 2 paired arrivals to calculate delta rms.\n";
         return -1;
     }
 
-    m_deltaSeconds.resize( pairedFrames );
-    for( size_t n = 0; n < pairedFrames; ++n )
-    {
-        m_deltaSeconds[n] = elapsedSeconds( m_stream1.m_arrivalTimes[n], m_stream2.m_arrivalTimes[n] );
-    }
+    const double deltaMean = mean( m_deltaUsec );
+    const double deltaRms  = rms( m_deltaUsec, deltaMean );
 
-    const double deltaMean = mean( m_deltaSeconds );
-    const double deltaRms  = rms( m_deltaSeconds, deltaMean );
-
-    std::cout << std::fixed << std::setprecision( 9 );
+    std::cout << std::fixed << std::setprecision( 3 );
     std::cout << "timed_pairs: " << pairedFrames << "\n";
-    std::cout << "delta_mean_sec: " << deltaMean << "\n";
-    std::cout << "delta_rms_sec: " << deltaRms << "\n";
+    std::cout << "pairing: " << pairingMethod << "\n";
+    std::cout << "delta_mean_usec: " << deltaMean << "\n";
+    std::cout << "delta_rms_usec: " << deltaRms << "\n";
 
     return 0;
+}
+
+size_t shmimDelta::pairByCounter()
+{
+    m_deltaUsec.clear();
+
+    size_t n1 = 0;
+    size_t n2 = 0;
+
+    while( n1 < m_stream1.m_samples.size() && n2 < m_stream2.m_samples.size() )
+    {
+        const auto &sample1 = m_stream1.m_samples[n1];
+        const auto &sample2 = m_stream2.m_samples[n2];
+
+        if( sample1.m_cnt0 == sample2.m_cnt0 )
+        {
+            m_deltaUsec.push_back( elapsedUsec( sample1.m_eventTime, sample2.m_eventTime ) );
+            ++n1;
+            ++n2;
+        }
+        else if( sample1.m_cnt0 < sample2.m_cnt0 )
+        {
+            ++n1;
+        }
+        else
+        {
+            ++n2;
+        }
+    }
+
+    return m_deltaUsec.size();
+}
+
+size_t shmimDelta::pairByOrder()
+{
+    const size_t pairedFrames = std::min( m_stream1.m_samples.size(), m_stream2.m_samples.size() );
+
+    m_deltaUsec.resize( pairedFrames );
+    for( size_t n = 0; n < pairedFrames; ++n )
+    {
+        m_deltaUsec[n] = elapsedUsec( m_stream1.m_samples[n].m_eventTime, m_stream2.m_samples[n].m_eventTime );
+    }
+
+    return m_deltaUsec.size();
 }
 
 void shmimDelta::waitThreadStart( shmimDelta *app, streamState *stream )
@@ -410,13 +458,13 @@ void shmimDelta::waitThreadStart( shmimDelta *app, streamState *stream )
 
 int shmimDelta::waitFrames( streamState &stream )
 {
-    stream.m_arrivalTimes.clear();
-    stream.m_arrivalTimes.reserve( m_nFrames );
+    stream.m_samples.clear();
+    stream.m_samples.reserve( m_nFrames );
     stream.m_errorMessage.clear();
 
-    for( size_t n = 0; n < m_nFrames && !g_timeToDie; ++n )
+    while( stream.m_samples.size() < m_nFrames && !g_timeToDie )
     {
-        if( waitForFrame( stream, n + 1 ) < 0 )
+        if( waitForFrame( stream, stream.m_samples.size() + 1 ) < 0 )
         {
             return -1;
         }
@@ -464,16 +512,82 @@ int shmimDelta::waitForFrame( streamState &stream, size_t frameNumber )
         return -1;
     }
 
-    timespec arrivalTime;
-    if( clock_gettime( CLOCK_MONOTONIC, &arrivalTime ) < 0 )
+    while( sem_trywait( stream.m_semaphore ) == 0 )
+    {
+    }
+
+    if( errno != EAGAIN && errno != EINTR )
+    {
+        stream.m_errorMessage = "error from sem_trywait for " + stream.m_name + ": " + strerror( errno );
+        return -1;
+    }
+
+    return recordLatestSample( stream );
+}
+
+int shmimDelta::recordLatestSample( streamState &stream )
+{
+    streamState::frameSample sample = latestSample( stream );
+
+    if( clock_gettime( CLOCK_MONOTONIC, &sample.m_arrivalTime ) < 0 )
     {
         stream.m_errorMessage = "error from clock_gettime after semaphore wake for " + stream.m_name;
         return -1;
     }
 
-    stream.m_arrivalTimes.push_back( arrivalTime );
+    if( !validTime( sample.m_eventTime ) )
+    {
+        sample.m_eventTime = sample.m_arrivalTime;
+    }
+
+    if( !stream.m_samples.empty() && sample.m_cnt0 == stream.m_samples.back().m_cnt0 )
+    {
+        return 0;
+    }
+
+    stream.m_samples.push_back( sample );
 
     return 0;
+}
+
+shmimDelta::streamState::frameSample shmimDelta::latestSample( const streamState &stream ) const
+{
+    streamState::frameSample sample;
+
+    const IMAGE &image = stream.m_imageStream;
+
+    uint64_t currImage = ImageStreamIO_readLastWroteIndex( &image );
+    if( currImage >= ImageStreamIO_nbSlices( &image ) )
+    {
+        currImage = 0;
+    }
+
+    if( image.cntarray != nullptr )
+    {
+        sample.m_cnt0 = image.cntarray[currImage];
+    }
+    else
+    {
+        sample.m_cnt0 = image.md[0].cnt0;
+    }
+
+    if( image.writetimearray != nullptr && validTime( image.writetimearray[currImage] ) )
+    {
+        sample.m_eventTime        = image.writetimearray[currImage];
+        sample.m_usedMetadataTime = true;
+    }
+    else if( validTime( image.md[0].writetime ) )
+    {
+        sample.m_eventTime        = image.md[0].writetime;
+        sample.m_usedMetadataTime = true;
+    }
+
+    return sample;
+}
+
+bool shmimDelta::validTime( const timespec &ts )
+{
+    return ts.tv_sec != 0 || ts.tv_nsec != 0;
 }
 
 bool shmimDelta::streamChanged( const streamState &stream ) const

--- a/utils/shmimDelta/shmimDelta.cpp
+++ b/utils/shmimDelta/shmimDelta.cpp
@@ -1,0 +1,518 @@
+/** \file shmimDelta.cpp
+ * \brief The shmimDelta main program and implementation.
+ *
+ * \ingroup shmimDelta_files
+ *
+ * \author Codex
+ */
+
+#include "shmimDelta.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <csignal>
+#include <cstring>
+#include <ctime>
+#include <fcntl.h>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+
+namespace
+{
+
+volatile sig_atomic_t g_timeToDie = 0;
+
+/// Handle termination signals by requesting a clean shutdown.
+void sigTermHandler( int        signum /**< [in] received signal number. */,
+                     siginfo_t *siginf /**< [in] unused signal metadata. */,
+                     void      *ucont /**< [in] unused signal context. */ )
+{
+    static_cast<void>( signum );
+    static_cast<void>( siginf );
+    static_cast<void>( ucont );
+
+    std::cerr << "\n";
+
+    g_timeToDie = 1;
+}
+
+/// Install the signal handlers used by this utility.
+int installSignalHandlers( const std::string &invokedName /**< [in] utility name for error reporting. */ )
+{
+    struct sigaction act;
+    sigset_t         set;
+
+    act.sa_sigaction = sigTermHandler;
+    act.sa_flags     = SA_SIGINFO;
+    sigemptyset( &set );
+    act.sa_mask = set;
+
+    errno = 0;
+    if( sigaction( SIGTERM, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGTERM handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    errno = 0;
+    if( sigaction( SIGQUIT, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGQUIT handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    errno = 0;
+    if( sigaction( SIGINT, &act, nullptr ) < 0 )
+    {
+        std::cerr << " (" << invokedName << "): error setting SIGINT handler: " << strerror( errno ) << "\n";
+        return -1;
+    }
+
+    return 0;
+}
+
+} // namespace
+
+shmimDelta::shmimDelta() = default;
+
+shmimDelta::~shmimDelta()
+{
+    closeStreams();
+}
+
+void shmimDelta::setupConfig()
+{
+    config.add( "shmimName1",
+                "1",
+                "shmimName1",
+                argType::Required,
+                "",
+                "shmimName1",
+                false,
+                "string",
+                "The name of the first shared memory image stream. Delta is shmimName2 minus shmimName1." );
+
+    config.add( "shmimName2",
+                "2",
+                "shmimName2",
+                argType::Required,
+                "",
+                "shmimName2",
+                false,
+                "string",
+                "The name of the second shared memory image stream. Delta is shmimName2 minus shmimName1." );
+
+    config.add( "nFrames",
+                "N",
+                "nFrames",
+                argType::Required,
+                "",
+                "nFrames",
+                false,
+                "int",
+                "The number of paired semaphore arrivals to measure. Default is 100." );
+
+    config.add( "timeout",
+                "t",
+                "timeout",
+                argType::Required,
+                "",
+                "timeout",
+                false,
+                "float",
+                "The per-frame wait timeout in seconds. Default is 1.0 second." );
+}
+
+void shmimDelta::loadConfig()
+{
+    config( m_shmimName1, "shmimName1" );
+    config( m_shmimName2, "shmimName2" );
+    config( m_nFrames, "nFrames" );
+    config( m_timeoutSec, "timeout" );
+
+    if( m_shmimName1.empty() )
+    {
+        std::cerr << "first shmim name not specified with --shmimName1\n";
+        doHelp = true;
+        return;
+    }
+
+    if( m_shmimName2.empty() )
+    {
+        std::cerr << "second shmim name not specified with --shmimName2\n";
+        doHelp = true;
+        return;
+    }
+
+    if( m_nFrames < 2 )
+    {
+        std::cerr << "nFrames must be at least 2 to measure delta rms\n";
+        doHelp = true;
+        return;
+    }
+
+    if( m_timeoutSec <= 0 )
+    {
+        std::cerr << "timeout must be greater than 0 seconds\n";
+        doHelp = true;
+        return;
+    }
+
+    m_stream1.m_name = m_shmimName1;
+    m_stream2.m_name = m_shmimName2;
+}
+
+int shmimDelta::execute()
+{
+    if( installSignalHandlers( invokedName ) < 0 )
+    {
+        return -1;
+    }
+
+    if( openStream( m_stream1 ) < 0 || openStream( m_stream2 ) < 0 )
+    {
+        closeStreams();
+        return -1;
+    }
+
+    std::cout << "shmim1: " << m_stream1.m_name << "\n";
+    std::cout << "size1: " << m_stream1.m_width << " " << m_stream1.m_height << " " << m_stream1.m_depth << "\n";
+    std::cout << "shmim2: " << m_stream2.m_name << "\n";
+    std::cout << "size2: " << m_stream2.m_width << " " << m_stream2.m_height << " " << m_stream2.m_depth << "\n";
+
+    int rv = measureDeltas();
+    closeStreams();
+
+    return rv;
+}
+
+double shmimDelta::elapsedSeconds( const timespec &t0, const timespec &t1 )
+{
+    return static_cast<double>( t1.tv_sec - t0.tv_sec ) + 1e-9 * static_cast<double>( t1.tv_nsec - t0.tv_nsec );
+}
+
+double shmimDelta::mean( const std::vector<double> &values )
+{
+    if( values.empty() )
+    {
+        return 0;
+    }
+
+    return std::accumulate( values.begin(), values.end(), 0.0 ) / static_cast<double>( values.size() );
+}
+
+double shmimDelta::rms( const std::vector<double> &values, double meanValue )
+{
+    if( values.empty() )
+    {
+        return 0;
+    }
+
+    double variance = 0;
+
+    for( const double value : values )
+    {
+        const double residual = value - meanValue;
+        variance += residual * residual;
+    }
+
+    return std::sqrt( variance / static_cast<double>( values.size() ) );
+}
+
+int shmimDelta::openStream( streamState &stream )
+{
+    int logged = 0;
+
+    while( !g_timeToDie )
+    {
+        int  SM_fd;
+        char SM_fname[200];
+        ImageStreamIO_filename( SM_fname, sizeof( SM_fname ), stream.m_name.c_str() );
+
+        SM_fd = open( SM_fname, O_RDWR );
+        if( SM_fd == -1 )
+        {
+            if( !logged )
+            {
+                std::cerr << "ImageStream " << stream.m_name << " not found (yet). Retrying . . .\n";
+            }
+
+            logged = 1;
+            sleep( 1 );
+            continue;
+        }
+
+        logged = 0;
+        close( SM_fd );
+
+        if( ImageStreamIO_openIm( &stream.m_imageStream, stream.m_name.c_str() ) != 0 )
+        {
+            mx::sys::sleep( 1 );
+            continue;
+        }
+
+        if( stream.m_imageStream.md[0].sem <= stream.m_semaphoreNumber )
+        {
+            ImageStreamIO_closeIm( &stream.m_imageStream );
+            mx::sys::sleep( 1 );
+            continue;
+        }
+
+        struct stat buffer;
+        if( stat( SM_fname, &buffer ) != 0 )
+        {
+            std::cerr << "Could not get inode for " << stream.m_name << ".\n";
+            ImageStreamIO_closeIm( &stream.m_imageStream );
+            return -1;
+        }
+
+        stream.m_inode  = buffer.st_ino;
+        stream.m_opened = true;
+
+        stream.m_width  = stream.m_imageStream.md[0].size[0];
+        stream.m_height = 1;
+        stream.m_depth  = 1;
+
+        if( stream.m_imageStream.md[0].naxis > 1 )
+        {
+            stream.m_height = stream.m_imageStream.md[0].size[1];
+        }
+
+        if( stream.m_imageStream.md[0].naxis > 2 )
+        {
+            stream.m_depth = stream.m_imageStream.md[0].size[2];
+        }
+
+        return 0;
+    }
+
+    return -1;
+}
+
+void shmimDelta::closeStream( streamState &stream )
+{
+    if( !stream.m_opened )
+    {
+        return;
+    }
+
+    if( stream.m_semaphoreNumber >= 0 )
+    {
+        stream.m_imageStream.semReadPID[stream.m_semaphoreNumber] = 0;
+    }
+
+    ImageStreamIO_closeIm( &stream.m_imageStream );
+    stream.m_opened    = false;
+    stream.m_semaphore = nullptr;
+}
+
+void shmimDelta::closeStreams()
+{
+    closeStream( m_stream1 );
+    closeStream( m_stream2 );
+}
+
+int shmimDelta::prepareSemaphore( streamState &stream )
+{
+    stream.m_semaphoreNumber = ImageStreamIO_getsemwaitindex( &stream.m_imageStream, stream.m_semaphoreNumber );
+    if( stream.m_semaphoreNumber < 0 )
+    {
+        std::cerr << "No valid semaphore found for " << stream.m_name << ".\n";
+        return -1;
+    }
+
+    ImageStreamIO_semflush( &stream.m_imageStream, stream.m_semaphoreNumber );
+    stream.m_semaphore = stream.m_imageStream.semptr[stream.m_semaphoreNumber];
+
+    return 0;
+}
+
+int shmimDelta::measureDeltas()
+{
+    if( prepareSemaphore( m_stream1 ) < 0 || prepareSemaphore( m_stream2 ) < 0 )
+    {
+        return -1;
+    }
+
+    std::thread thread1;
+    std::thread thread2;
+
+    try
+    {
+        thread1 = std::thread( waitThreadStart, this, &m_stream1 );
+        thread2 = std::thread( waitThreadStart, this, &m_stream2 );
+    }
+    catch( const std::exception &e )
+    {
+        std::cerr << "exception starting wait threads: " << e.what() << "\n";
+        g_timeToDie = 1;
+        if( thread1.joinable() )
+        {
+            thread1.join();
+        }
+
+        if( thread2.joinable() )
+        {
+            thread2.join();
+        }
+
+        return -1;
+    }
+
+    thread1.join();
+    thread2.join();
+
+    if( m_stream1.m_status < 0 )
+    {
+        std::cerr << m_stream1.m_errorMessage << "\n";
+        return -1;
+    }
+
+    if( m_stream2.m_status < 0 )
+    {
+        std::cerr << m_stream2.m_errorMessage << "\n";
+        return -1;
+    }
+
+    const size_t pairedFrames = std::min( m_stream1.m_arrivalTimes.size(), m_stream2.m_arrivalTimes.size() );
+    if( pairedFrames < 2 )
+    {
+        std::cerr << "Need at least 2 paired arrivals to calculate delta rms.\n";
+        return -1;
+    }
+
+    m_deltaSeconds.resize( pairedFrames );
+    for( size_t n = 0; n < pairedFrames; ++n )
+    {
+        m_deltaSeconds[n] = elapsedSeconds( m_stream1.m_arrivalTimes[n], m_stream2.m_arrivalTimes[n] );
+    }
+
+    const double deltaMean = mean( m_deltaSeconds );
+    const double deltaRms  = rms( m_deltaSeconds, deltaMean );
+
+    std::cout << std::fixed << std::setprecision( 9 );
+    std::cout << "timed_pairs: " << pairedFrames << "\n";
+    std::cout << "delta_mean_sec: " << deltaMean << "\n";
+    std::cout << "delta_rms_sec: " << deltaRms << "\n";
+
+    return 0;
+}
+
+void shmimDelta::waitThreadStart( shmimDelta *app, streamState *stream )
+{
+    stream->m_status = app->waitFrames( *stream );
+}
+
+int shmimDelta::waitFrames( streamState &stream )
+{
+    stream.m_arrivalTimes.clear();
+    stream.m_arrivalTimes.reserve( m_nFrames );
+    stream.m_errorMessage.clear();
+
+    for( size_t n = 0; n < m_nFrames && !g_timeToDie; ++n )
+    {
+        if( waitForFrame( stream, n + 1 ) < 0 )
+        {
+            return -1;
+        }
+    }
+
+    if( g_timeToDie )
+    {
+        stream.m_errorMessage = "Interrupted while waiting for frames from " + stream.m_name + ".";
+        return -1;
+    }
+
+    return 0;
+}
+
+int shmimDelta::waitForFrame( streamState &stream, size_t frameNumber )
+{
+    timespec deadline;
+    if( setWaitDeadline( deadline ) < 0 )
+    {
+        stream.m_errorMessage = "error from clock_gettime while waiting for " + stream.m_name;
+        return -1;
+    }
+
+    if( sem_timedwait( stream.m_semaphore, &deadline ) != 0 )
+    {
+        if( errno == ETIMEDOUT )
+        {
+            stream.m_errorMessage = "Timed out waiting for frame " + std::to_string( frameNumber ) + " of " +
+                                    std::to_string( m_nFrames ) + " from " + stream.m_name + ".";
+        }
+        else if( errno == EINTR && g_timeToDie )
+        {
+            stream.m_errorMessage = "Interrupted while waiting for frames from " + stream.m_name + ".";
+        }
+        else
+        {
+            stream.m_errorMessage = "error from sem_timedwait for " + stream.m_name + ": " + strerror( errno );
+        }
+
+        if( streamChanged( stream ) )
+        {
+            stream.m_errorMessage += " The shmim changed while waiting for frames.";
+        }
+
+        return -1;
+    }
+
+    timespec arrivalTime;
+    if( clock_gettime( CLOCK_MONOTONIC, &arrivalTime ) < 0 )
+    {
+        stream.m_errorMessage = "error from clock_gettime after semaphore wake for " + stream.m_name;
+        return -1;
+    }
+
+    stream.m_arrivalTimes.push_back( arrivalTime );
+
+    return 0;
+}
+
+bool shmimDelta::streamChanged( const streamState &stream ) const
+{
+    char SM_fname[200];
+    ImageStreamIO_filename( SM_fname, sizeof( SM_fname ), stream.m_name.c_str() );
+
+    struct stat buffer;
+    if( stat( SM_fname, &buffer ) != 0 )
+    {
+        return true;
+    }
+
+    return buffer.st_ino != stream.m_inode;
+}
+
+int shmimDelta::setWaitDeadline( timespec &deadline ) const
+{
+    if( clock_gettime( CLOCK_REALTIME, &deadline ) < 0 )
+    {
+        return -1;
+    }
+
+    const auto seconds = static_cast<time_t>( m_timeoutSec );
+    deadline.tv_sec += seconds;
+    deadline.tv_nsec += static_cast<long>( ( m_timeoutSec - static_cast<double>( seconds ) ) * 1e9 );
+
+    if( deadline.tv_nsec >= 1000000000L )
+    {
+        ++deadline.tv_sec;
+        deadline.tv_nsec -= 1000000000L;
+    }
+
+    return 0;
+}
+
+int main( int argc, char **argv )
+{
+    shmimDelta sd;
+
+    return sd.main( argc, argv );
+}

--- a/utils/shmimDelta/shmimDelta.cpp
+++ b/utils/shmimDelta/shmimDelta.cpp
@@ -396,6 +396,17 @@ int shmimDelta::measureDeltas()
     const double deltaMean = mean( m_deltaUsec );
     const double deltaRms  = rms( m_deltaUsec, deltaMean );
 
+    std::vector<double> stream1FrameDeltaUsec;
+    std::vector<double> stream2FrameDeltaUsec;
+
+    calculateFrameDeltas( m_stream1, stream1FrameDeltaUsec );
+    calculateFrameDeltas( m_stream2, stream2FrameDeltaUsec );
+
+    const double stream1DeltaMean = mean( stream1FrameDeltaUsec );
+    const double stream1DeltaRms  = rms( stream1FrameDeltaUsec, stream1DeltaMean );
+    const double stream2DeltaMean = mean( stream2FrameDeltaUsec );
+    const double stream2DeltaRms  = rms( stream2FrameDeltaUsec, stream2DeltaMean );
+
     std::cout << std::fixed << std::setprecision( 3 );
     std::cout << "timed_pairs: " << pairedFrames << "\n";
     std::cout << "pairing: reference_cnt0\n";
@@ -406,6 +417,10 @@ int shmimDelta::measureDeltas()
               << "\n";
     std::cout << "delta_mean_usec: " << deltaMean << "\n";
     std::cout << "delta_rms_usec: " << deltaRms << "\n";
+    std::cout << "stream1_delta_mean_usec: " << stream1DeltaMean << "\n";
+    std::cout << "stream1_delta_rms_usec: " << stream1DeltaRms << "\n";
+    std::cout << "stream2_delta_mean_usec: " << stream2DeltaMean << "\n";
+    std::cout << "stream2_delta_rms_usec: " << stream2DeltaRms << "\n";
 
     return 0;
 }
@@ -526,6 +541,25 @@ size_t shmimDelta::pairByReferenceCounter()
     }
 
     return m_deltaUsec.size();
+}
+
+size_t shmimDelta::calculateFrameDeltas( const streamState &stream, std::vector<double> &frameDeltas ) const
+{
+    frameDeltas.clear();
+
+    if( stream.m_samples.size() < 2 )
+    {
+        return 0;
+    }
+
+    frameDeltas.reserve( stream.m_samples.size() - 1 );
+
+    for( size_t n = 1; n < stream.m_samples.size(); ++n )
+    {
+        frameDeltas.push_back( elapsedUsec( stream.m_samples[n - 1].m_eventTime, stream.m_samples[n].m_eventTime ) );
+    }
+
+    return frameDeltas.size();
 }
 
 bool shmimDelta::counterAdvance( uint64_t                       &advance,

--- a/utils/shmimDelta/shmimDelta.cpp
+++ b/utils/shmimDelta/shmimDelta.cpp
@@ -339,6 +339,11 @@ int shmimDelta::measureDeltas()
         return -1;
     }
 
+    if( synchronizeStreams() < 0 )
+    {
+        return -1;
+    }
+
     std::thread thread1;
     std::thread thread2;
 
@@ -379,19 +384,12 @@ int shmimDelta::measureDeltas()
         return -1;
     }
 
-    const char *pairingMethod = "cnt0";
-
-    size_t pairedFrames = pairByCounter();
-    if( pairedFrames < 2 )
-    {
-        pairedFrames  = pairByOrder();
-        pairingMethod = "order";
-        std::cerr << "No common cnt0 pairing found; paired samples by arrival order.\n";
-    }
+    const size_t pairedFrames = pairByReferenceCounter();
 
     if( pairedFrames < 2 )
     {
-        std::cerr << "Need at least 2 paired arrivals to calculate delta rms.\n";
+        std::cerr << "Need at least 2 paired arrivals with matching synchronized counter advances to calculate delta "
+                     "rms.\n";
         return -1;
     }
 
@@ -400,16 +398,93 @@ int shmimDelta::measureDeltas()
 
     std::cout << std::fixed << std::setprecision( 3 );
     std::cout << "timed_pairs: " << pairedFrames << "\n";
-    std::cout << "pairing: " << pairingMethod << "\n";
+    std::cout << "pairing: reference_cnt0\n";
+    std::cout << "reference1_cnt0: " << m_stream1.m_referenceSample.m_cnt0 << "\n";
+    std::cout << "reference2_cnt0: " << m_stream2.m_referenceSample.m_cnt0 << "\n";
+    std::cout << "reference_delta_usec: "
+              << elapsedUsec( m_stream1.m_referenceSample.m_eventTime, m_stream2.m_referenceSample.m_eventTime )
+              << "\n";
     std::cout << "delta_mean_usec: " << deltaMean << "\n";
     std::cout << "delta_rms_usec: " << deltaRms << "\n";
 
     return 0;
 }
 
-size_t shmimDelta::pairByCounter()
+int shmimDelta::synchronizeStreams()
+{
+    m_stream1.m_haveReference = false;
+    m_stream2.m_haveReference = false;
+
+    m_stream1.m_samples.clear();
+    m_stream2.m_samples.clear();
+
+    ImageStreamIO_semflush( &m_stream1.m_imageStream, m_stream1.m_semaphoreNumber );
+    ImageStreamIO_semflush( &m_stream2.m_imageStream, m_stream2.m_semaphoreNumber );
+
+    if( waitForFrame( m_stream1, 1 ) < 0 )
+    {
+        std::cerr << "Error synchronizing reference from " << m_stream1.m_name << ": " << m_stream1.m_errorMessage
+                  << "\n";
+        return -1;
+    }
+
+    if( m_stream1.m_samples.empty() )
+    {
+        std::cerr << "No reference frame recorded from " << m_stream1.m_name << ".\n";
+        return -1;
+    }
+
+    m_stream1.m_referenceSample = m_stream1.m_samples.back();
+    m_stream1.m_haveReference   = true;
+
+    size_t stream2Attempts = 0;
+
+    // Do not flush stream 2 here; a low-latency post after the stream-1 reference may already be queued.
+    while( !g_timeToDie )
+    {
+        ++stream2Attempts;
+
+        if( waitForFrame( m_stream2, stream2Attempts ) < 0 )
+        {
+            std::cerr << "Error synchronizing reference from " << m_stream2.m_name << ": " << m_stream2.m_errorMessage
+                      << "\n";
+            return -1;
+        }
+
+        if( m_stream2.m_samples.empty() )
+        {
+            continue;
+        }
+
+        const auto &candidate = m_stream2.m_samples.back();
+        if( timeAtOrAfter( candidate.m_eventTime, m_stream1.m_referenceSample.m_eventTime ) )
+        {
+            m_stream2.m_referenceSample = candidate;
+            m_stream2.m_haveReference   = true;
+            break;
+        }
+    }
+
+    if( !m_stream2.m_haveReference )
+    {
+        std::cerr << "No reference frame recorded from " << m_stream2.m_name << " after " << m_stream1.m_name << ".\n";
+        return -1;
+    }
+
+    m_stream2.m_samples.clear();
+    m_stream2.m_samples.push_back( m_stream2.m_referenceSample );
+
+    return 0;
+}
+
+size_t shmimDelta::pairByReferenceCounter()
 {
     m_deltaUsec.clear();
+
+    if( !m_stream1.m_haveReference || !m_stream2.m_haveReference )
+    {
+        return 0;
+    }
 
     size_t n1 = 0;
     size_t n2 = 0;
@@ -419,13 +494,28 @@ size_t shmimDelta::pairByCounter()
         const auto &sample1 = m_stream1.m_samples[n1];
         const auto &sample2 = m_stream2.m_samples[n2];
 
-        if( sample1.m_cnt0 == sample2.m_cnt0 )
+        uint64_t advance1 = 0;
+        uint64_t advance2 = 0;
+
+        if( !counterAdvance( advance1, sample1, m_stream1.m_referenceSample ) )
+        {
+            ++n1;
+            continue;
+        }
+
+        if( !counterAdvance( advance2, sample2, m_stream2.m_referenceSample ) )
+        {
+            ++n2;
+            continue;
+        }
+
+        if( advance1 == advance2 )
         {
             m_deltaUsec.push_back( elapsedUsec( sample1.m_eventTime, sample2.m_eventTime ) );
             ++n1;
             ++n2;
         }
-        else if( sample1.m_cnt0 < sample2.m_cnt0 )
+        else if( advance1 < advance2 )
         {
             ++n1;
         }
@@ -438,17 +528,18 @@ size_t shmimDelta::pairByCounter()
     return m_deltaUsec.size();
 }
 
-size_t shmimDelta::pairByOrder()
+bool shmimDelta::counterAdvance( uint64_t                       &advance,
+                                 const streamState::frameSample &sample,
+                                 const streamState::frameSample &reference ) const
 {
-    const size_t pairedFrames = std::min( m_stream1.m_samples.size(), m_stream2.m_samples.size() );
-
-    m_deltaUsec.resize( pairedFrames );
-    for( size_t n = 0; n < pairedFrames; ++n )
+    if( sample.m_cnt0 < reference.m_cnt0 )
     {
-        m_deltaUsec[n] = elapsedUsec( m_stream1.m_samples[n].m_eventTime, m_stream2.m_samples[n].m_eventTime );
+        return false;
     }
 
-    return m_deltaUsec.size();
+    advance = sample.m_cnt0 - reference.m_cnt0;
+
+    return true;
 }
 
 void shmimDelta::waitThreadStart( shmimDelta *app, streamState *stream )
@@ -458,7 +549,6 @@ void shmimDelta::waitThreadStart( shmimDelta *app, streamState *stream )
 
 int shmimDelta::waitFrames( streamState &stream )
 {
-    stream.m_samples.clear();
     stream.m_samples.reserve( m_nFrames );
     stream.m_errorMessage.clear();
 
@@ -588,6 +678,16 @@ shmimDelta::streamState::frameSample shmimDelta::latestSample( const streamState
 bool shmimDelta::validTime( const timespec &ts )
 {
     return ts.tv_sec != 0 || ts.tv_nsec != 0;
+}
+
+bool shmimDelta::timeAtOrAfter( const timespec &ts, const timespec &reference )
+{
+    if( ts.tv_sec != reference.tv_sec )
+    {
+        return ts.tv_sec > reference.tv_sec;
+    }
+
+    return ts.tv_nsec >= reference.tv_nsec;
 }
 
 bool shmimDelta::streamChanged( const streamState &stream ) const

--- a/utils/shmimDelta/shmimDelta.hpp
+++ b/utils/shmimDelta/shmimDelta.hpp
@@ -1,0 +1,165 @@
+/** \file shmimDelta.hpp
+ * \brief The shmimDelta class declaration.
+ *
+ * \ingroup shmimDelta_files
+ *
+ * \author Codex
+ */
+
+#ifndef shmimDelta_hpp
+#define shmimDelta_hpp
+
+#include <ImageStreamIO/ImageStruct.h>
+#include <ImageStreamIO/ImageStreamIO.h>
+
+#include <semaphore.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <sys/types.h>
+#include <time.h>
+#include <vector>
+
+#include "../../libMagAOX/libMagAOX.hpp"
+
+/** \defgroup shmimDelta shmimDelta: measure semaphore-arrival deltas between two shmims
+ * \brief Attaches to two shmims and reports the mean and rms delta between their semaphore arrivals.
+ *
+ * \ingroup utils
+ *
+ */
+
+/** \defgroup shmimDelta_files shmimDelta Files
+ * \ingroup shmimDelta
+ */
+
+/// Utility for measuring the delta between two shmim semaphore arrival times.
+/**
+ * \ingroup shmimDelta
+ */
+class shmimDelta : public mx::app::application
+{
+  protected:
+    /// Runtime state for one monitored shmim.
+    struct streamState
+    {
+        std::string m_name; ///< Name of the shmim to monitor.
+
+        IMAGE m_imageStream{}; ///< Attached ImageStreamIO handle for this shmim.
+
+        bool m_opened{ false }; ///< Tracks whether `m_imageStream` owns an open attachment.
+
+        ino_t m_inode{ 0 }; ///< Inode of the backing shmim file used to detect stream replacement.
+
+        int m_semaphoreNumber{ 9 }; ///< Preferred semaphore index used to subscribe to frame arrivals.
+
+        sem_t *m_semaphore{ nullptr }; ///< Semaphore selected by ImageStreamIO for this reader.
+
+        uint32_t m_width{ 0 }; ///< Stream size along the first axis.
+
+        uint32_t m_height{ 1 }; ///< Stream size along the second axis, or 1 when absent.
+
+        uint32_t m_depth{ 1 }; ///< Stream size along the third axis, or 1 when absent.
+
+        std::vector<timespec> m_arrivalTimes; ///< Local timestamps recorded after semaphore wakes.
+
+        std::string m_errorMessage; ///< Error text recorded by the waiter thread on failure.
+
+        int m_status{ 0 }; ///< Waiter-thread completion status, 0 on success and -1 on error.
+    };
+
+    /** \name Configurable Parameters
+     * @{
+     */
+
+    std::string m_shmimName1; ///< Name of the first shmim, used as the reference arrival time.
+
+    std::string m_shmimName2; ///< Name of the second shmim. Reported delta is shmimName2 minus shmimName1.
+
+    size_t m_nFrames{ 100 }; ///< Number of paired semaphore arrivals to measure.
+
+    double m_timeoutSec{ 1.0 }; ///< Timeout, in seconds, used for each frame-arrival wait.
+
+    ///@}
+
+    /** \name Stream State - Data
+     * @{
+     */
+
+    streamState m_stream1; ///< State for `m_shmimName1`.
+
+    streamState m_stream2; ///< State for `m_shmimName2`.
+
+    ///@}
+
+    /** \name Measurement - Data
+     * @{
+     */
+
+    std::vector<double> m_deltaSeconds; ///< Paired semaphore-arrival deltas in seconds.
+
+    ///@}
+
+  public:
+    /// Default constructor.
+    shmimDelta();
+
+    /// Destructor.
+    ~shmimDelta() override;
+
+    /// Define command-line and config-file options.
+    void setupConfig() override;
+
+    /// Load configured values into member state.
+    void loadConfig() override;
+
+    /// Connect to both shmims, collect semaphore arrivals, and report delta statistics.
+    int execute() override;
+
+    /// Convert a pair of timespec timestamps to elapsed seconds.
+    static double elapsedSeconds( const timespec &t0 /**< [in] starting timestamp. */,
+                                  const timespec &t1 /**< [in] ending timestamp. */ );
+
+    /// Calculate the arithmetic mean of a vector.
+    static double mean( const std::vector<double> &values /**< [in] values to average. */ );
+
+    /// Calculate the rms scatter about a supplied mean.
+    static double rms( const std::vector<double> &values /**< [in] values to calculate rms for. */,
+                       double                     meanValue /**< [in] arithmetic mean of `values`. */ );
+
+  protected:
+    /// Open one shmim and cache its dimensions.
+    int openStream( streamState &stream /**< [in,out] stream state to open. */ );
+
+    /// Close one shmim attachment if it is open.
+    void closeStream( streamState &stream /**< [in,out] stream state to close. */ );
+
+    /// Close both shmim attachments if open.
+    void closeStreams();
+
+    /// Select and flush the semaphore used to monitor one stream.
+    int prepareSemaphore( streamState &stream /**< [in,out] stream state to prepare. */ );
+
+    /// Collect semaphore-arrival timestamps from both streams and report statistics.
+    int measureDeltas();
+
+    /// Thread entry point for collecting arrival timestamps from one stream.
+    static void waitThreadStart( shmimDelta  *app /**< [in] owning application instance. */,
+                                 streamState *stream /**< [in,out] stream state to monitor. */ );
+
+    /// Collect all configured frame-arrival timestamps for one stream.
+    int waitFrames( streamState &stream /**< [in,out] stream state to monitor. */ );
+
+    /// Wait for one frame arrival and record its timestamp.
+    int waitForFrame( streamState &stream /**< [in,out] stream state to monitor. */,
+                      size_t       frameNumber /**< [in] one-based frame number used for error reporting. */ );
+
+    /// Check whether a stream disappeared or was replaced after a wait error.
+    bool streamChanged( const streamState &stream /**< [in] stream state to check. */ ) const;
+
+    /// Fill a timespec with the absolute timeout deadline for sem_timedwait.
+    int setWaitDeadline( timespec &deadline /**< [out] absolute realtime wait deadline. */ ) const;
+};
+
+#endif // shmimDelta_hpp

--- a/utils/shmimDelta/shmimDelta.hpp
+++ b/utils/shmimDelta/shmimDelta.hpp
@@ -78,6 +78,10 @@ class shmimDelta : public mx::app::application
 
         std::vector<frameSample> m_samples; ///< Unique frame samples recorded after semaphore wakes.
 
+        frameSample m_referenceSample; ///< Synchronized frame sample used as the counter reference.
+
+        bool m_haveReference{ false }; ///< True once `m_referenceSample` is valid.
+
         std::string m_errorMessage; ///< Error text recorded by the waiter thread on failure.
 
         int m_status{ 0 }; ///< Waiter-thread completion status, 0 on success and -1 on error.
@@ -158,11 +162,17 @@ class shmimDelta : public mx::app::application
     /// Collect semaphore-arrival timestamps from both streams and report statistics.
     int measureDeltas();
 
-    /// Build delta samples by pairing matching frame counters.
-    size_t pairByCounter();
+    /// Synchronize the stream counter references before collecting the full measurement.
+    int synchronizeStreams();
 
-    /// Build delta samples by pairing samples in arrival order.
-    size_t pairByOrder();
+    /// Build delta samples by pairing matching counter advances from the synchronized references.
+    size_t pairByReferenceCounter();
+
+    /// Calculate a sample's frame-counter advance from its synchronized reference.
+    bool counterAdvance( uint64_t                       &advance,  /**< [out] frame-counter advance. */
+                         const streamState::frameSample &sample,   /**< [in] sample to compare. */
+                         const streamState::frameSample &reference /**< [in] synchronized reference sample. */
+    ) const;
 
     /// Thread entry point for collecting arrival timestamps from one stream.
     static void waitThreadStart( shmimDelta  *app /**< [in] owning application instance. */,
@@ -183,6 +193,10 @@ class shmimDelta : public mx::app::application
 
     /// Check whether a timespec is non-zero.
     static bool validTime( const timespec &ts /**< [in] timestamp to inspect. */ );
+
+    /// Check whether one timestamp is at or after another timestamp.
+    static bool timeAtOrAfter( const timespec &ts, /**< [in] timestamp to inspect. */
+                               const timespec &reference /**< [in] reference timestamp. */ );
 
     /// Check whether a stream disappeared or was replaced after a wait error.
     bool streamChanged( const streamState &stream /**< [in] stream state to check. */ ) const;

--- a/utils/shmimDelta/shmimDelta.hpp
+++ b/utils/shmimDelta/shmimDelta.hpp
@@ -168,6 +168,11 @@ class shmimDelta : public mx::app::application
     /// Build delta samples by pairing matching counter advances from the synchronized references.
     size_t pairByReferenceCounter();
 
+    /// Build frame-to-frame delta samples for one stream.
+    size_t calculateFrameDeltas( const streamState   &stream,     /**< [in] stream state to inspect. */
+                                 std::vector<double> &frameDeltas /**< [out] frame-to-frame deltas in microseconds. */
+    ) const;
+
     /// Calculate a sample's frame-counter advance from its synchronized reference.
     bool counterAdvance( uint64_t                       &advance,  /**< [out] frame-counter advance. */
                          const streamState::frameSample &sample,   /**< [in] sample to compare. */

--- a/utils/shmimDelta/shmimDelta.hpp
+++ b/utils/shmimDelta/shmimDelta.hpp
@@ -44,6 +44,18 @@ class shmimDelta : public mx::app::application
     /// Runtime state for one monitored shmim.
     struct streamState
     {
+        /// One measured frame arrival.
+        struct frameSample
+        {
+            uint64_t m_cnt0{ 0 }; ///< Frame counter sampled after the semaphore wake.
+
+            timespec m_eventTime{}; ///< Frame timestamp used for delta calculation.
+
+            timespec m_arrivalTime{}; ///< Local timestamp recorded after the semaphore wake.
+
+            bool m_usedMetadataTime{ false }; ///< True when `m_eventTime` came from stream metadata.
+        };
+
         std::string m_name; ///< Name of the shmim to monitor.
 
         IMAGE m_imageStream{}; ///< Attached ImageStreamIO handle for this shmim.
@@ -62,7 +74,7 @@ class shmimDelta : public mx::app::application
 
         uint32_t m_depth{ 1 }; ///< Stream size along the third axis, or 1 when absent.
 
-        std::vector<timespec> m_arrivalTimes; ///< Local timestamps recorded after semaphore wakes.
+        std::vector<frameSample> m_samples; ///< Unique frame samples recorded after semaphore wakes.
 
         std::string m_errorMessage; ///< Error text recorded by the waiter thread on failure.
 
@@ -97,7 +109,7 @@ class shmimDelta : public mx::app::application
      * @{
      */
 
-    std::vector<double> m_deltaSeconds; ///< Paired semaphore-arrival deltas in seconds.
+    std::vector<double> m_deltaUsec; ///< Paired frame-arrival deltas in microseconds.
 
     ///@}
 
@@ -117,9 +129,9 @@ class shmimDelta : public mx::app::application
     /// Connect to both shmims, collect semaphore arrivals, and report delta statistics.
     int execute() override;
 
-    /// Convert a pair of timespec timestamps to elapsed seconds.
-    static double elapsedSeconds( const timespec &t0 /**< [in] starting timestamp. */,
-                                  const timespec &t1 /**< [in] ending timestamp. */ );
+    /// Convert a pair of timespec timestamps to elapsed microseconds.
+    static double elapsedUsec( const timespec &t0 /**< [in] starting timestamp. */,
+                               const timespec &t1 /**< [in] ending timestamp. */ );
 
     /// Calculate the arithmetic mean of a vector.
     static double mean( const std::vector<double> &values /**< [in] values to average. */ );
@@ -144,6 +156,12 @@ class shmimDelta : public mx::app::application
     /// Collect semaphore-arrival timestamps from both streams and report statistics.
     int measureDeltas();
 
+    /// Build delta samples by pairing matching frame counters.
+    size_t pairByCounter();
+
+    /// Build delta samples by pairing samples in arrival order.
+    size_t pairByOrder();
+
     /// Thread entry point for collecting arrival timestamps from one stream.
     static void waitThreadStart( shmimDelta  *app /**< [in] owning application instance. */,
                                  streamState *stream /**< [in,out] stream state to monitor. */ );
@@ -154,6 +172,15 @@ class shmimDelta : public mx::app::application
     /// Wait for one frame arrival and record its timestamp.
     int waitForFrame( streamState &stream /**< [in,out] stream state to monitor. */,
                       size_t       frameNumber /**< [in] one-based frame number used for error reporting. */ );
+
+    /// Record the latest frame metadata after a semaphore wake.
+    int recordLatestSample( streamState &stream /**< [in,out] stream state to sample. */ );
+
+    /// Get the latest frame counter and timestamp from a stream.
+    streamState::frameSample latestSample( const streamState &stream /**< [in] stream state to sample. */ ) const;
+
+    /// Check whether a timespec is non-zero.
+    static bool validTime( const timespec &ts /**< [in] timestamp to inspect. */ );
 
     /// Check whether a stream disappeared or was replaced after a wait error.
     bool streamChanged( const streamState &stream /**< [in] stream state to check. */ ) const;

--- a/utils/shmimDelta/shmimDelta.hpp
+++ b/utils/shmimDelta/shmimDelta.hpp
@@ -26,6 +26,8 @@
 /** \defgroup shmimDelta shmimDelta: measure semaphore-arrival deltas between two shmims
  * \brief Attaches to two shmims and reports the mean and rms delta between their semaphore arrivals.
  *
+ * <a href="../handbook/utils/shmimDelta.html">Utility Documentation</a>
+ *
  * \ingroup utils
  *
  */

--- a/utils/tests/shmimDelta_test.cpp
+++ b/utils/tests/shmimDelta_test.cpp
@@ -1,0 +1,25 @@
+/** \file shmimDelta_test.cpp
+ * \brief Catch2 tests for the shmimDelta utility.
+ *
+ * \author Codex
+ */
+
+#include "../../tests/catch2/catch.hpp"
+
+#include <type_traits>
+
+#include "../shmimDelta/shmimDelta.hpp"
+
+namespace shmimDelta_test
+{
+
+/// Verify shmimDelta declares the expected application type.
+/**
+ * \ingroup shmimDelta
+ */
+SCENARIO( "shmimDelta declares the expected application type", "[shmimDelta]" )
+{
+    REQUIRE( std::is_base_of_v<mx::app::application, shmimDelta> );
+}
+
+} // namespace shmimDelta_test


### PR DESCRIPTION
# Add shmimDelta timing utility and DM trigger delta stats

This work was performed by Codex (GPT-5) in response to the prompt: "Add frame-to-frame trigger timing stats for app::dev::dm, add a shmimDelta utility to measure semaphore-arrival deltas between two shmims, fix synchronization/pairing for delayed streams, document the utility, and report per-stream frame timing stats."

## Summary

- Add frame-to-frame trigger semaphore timing statistics to `app::dev::dm`.
- Add the `shmimDelta` utility for measuring timing deltas between two ImageStreamIO shmims.
- Pair shmim samples by synchronized relative `cnt0` advance rather than raw counter equality or arrival order.
- Report cross-stream delta mean/rms in microseconds.
- Report per-stream frame-to-frame mean/rms timing stats in microseconds.
- Add build/test integration and user-facing documentation, including isolated-cpuset usage.

## Testing

- `make -C utils/shmimDelta`
- `make -B -C tests -f Makefile.one t=../utils/tests/shmimDelta_test`
- `./utils/tests/shmimDelta_test`
- `git diff --check`
- Hardware-tested with representative shmim streams.