### PR TITLE
Added time-based rotation for log and telemetry files

### DIFF
--- a/libMagAOX/app/MagAOXApp.hpp
+++ b/libMagAOX/app/MagAOXApp.hpp
@@ -1148,6 +1148,50 @@ class MagAOXApp : public application
     int newCallBack_clearFSMAlert( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
                                                                              the new property request.*/ );
 
+    /// Indi property to request rotation of the process log file.
+    pcf::IndiProperty m_indiP_rotateLogs;
+
+    /// The static callback function to be registered for requesting log file rotation
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    static int st_newCallBack_rotateLogs( void *app,                      /**< [in] a pointer to this, will be
+                                                                                    static_cast-ed to MagAOXApp. */
+                                          const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                                    the new property request. */
+    );
+
+    /// The callback called by the static version, to actually process the log rotation request.
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    int newCallBack_rotateLogs( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                          the new property request.*/ );
+
+    /// indi Property to report and update the process log file time interval, in minutes.
+    pcf::IndiProperty m_indiP_maxLogTime;
+
+    /// The static callback function to be registered for setting the log file time interval
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    static int st_newCallBack_maxLogTime( void *app,                      /**< [in] a pointer to this, will be
+                                                                                    static_cast-ed to MagAOXApp. */
+                                          const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                                    the new property request. */
+    );
+
+    /// The callback called by the static version, to actually process the log interval change.
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    int newCallBack_maxLogTime( const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                          the new property request.*/ );
+
     ///@} --INDI Interface
 
     /** \name Power Management
@@ -1481,7 +1525,20 @@ void MagAOXApp<_useINDI>::setDefaults( int argc,
     createStandardIndiRequestSw( m_indiP_clearFSMAlert, "fsm_clear_alert", "Clear FSM Alert", "FSM" );
     if( registerIndiPropertyNew( m_indiP_clearFSMAlert, st_newCallBack_clearFSMAlert ) < 0 )
     {
-        log<software_error>( { __FILE__, __LINE__, "failed to register new fsm_alert property" } );
+        log<software_error>( { __FILE__, __LINE__, "Failed to register new fsm_alert property" } );
+    }
+
+    createStandardIndiRequestSw( m_indiP_rotateLogs, "logs_rotate", "New Log File", "Logging" );
+    if( registerIndiPropertyNew( m_indiP_rotateLogs, st_newCallBack_rotateLogs ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__, "Failed to register new logs_rotate property" } );
+    }
+
+    createStandardIndiNumber<unsigned>(
+        m_indiP_maxLogTime, "logs_maxtime", 0, 525600, 1, "", "Max Log Interval [minutes]", "Logging" );
+    if( registerIndiPropertyNew( m_indiP_maxLogTime, st_newCallBack_maxLogTime ) < 0 )
+    {
+        log<software_error>( { __FILE__, __LINE__, "Failed to register new logs_maxtime property" } );
     }
 
     return;
@@ -1605,6 +1662,15 @@ void MagAOXApp<_useINDI>::loadBasicConfig() // virtual
     //---------- Setup the logger ----------//
     m_log.logName( m_configName );
     m_log.loadConfig( config );
+
+    // Set the INDI property to the configured interval.
+    // The elements are created by setDefaults, which is not called in all contexts (e.g. unit tests),
+    // so check before assigning.
+    if( m_indiP_maxLogTime.find( "current" ) && m_indiP_maxLogTime.find( "target" ) )
+    {
+        m_indiP_maxLogTime["current"] = m_log.maxLogTime();
+        m_indiP_maxLogTime["target"]  = m_log.maxLogTime();
+    }
 
     //--------- Loop Pause Time --------//
     config( m_loopPause, "loopPause" );
@@ -3865,6 +3931,58 @@ int MagAOXApp<_useINDI>::newCallBack_clearFSMAlert( const pcf::IndiProperty &ipR
         }
 
     }
+    return 0;
+}
+
+template <bool _useINDI>
+int MagAOXApp<_useINDI>::st_newCallBack_rotateLogs( void *app, const pcf::IndiProperty &ipRecv )
+{
+    return static_cast<MagAOXApp<_useINDI> *>( app )->newCallBack_rotateLogs( ipRecv );
+}
+
+template <bool _useINDI>
+int MagAOXApp<_useINDI>::newCallBack_rotateLogs( const pcf::IndiProperty &ipRecv )
+{
+    if( ipRecv.createUniqueKey() != m_indiP_rotateLogs.createUniqueKey() )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__, "wrong indi property received" } );
+    }
+
+    if( ipRecv.find( "request" ) )
+    {
+        if( ipRecv["request"].getSwitchState() == pcf::IndiElement::On )
+        {
+            // This only sets a flag. The new file is created by the log thread on the next entry.
+            m_log.requestRotation();
+            updateSwitchIfChanged( m_indiP_rotateLogs, "request", pcf::IndiElement::Off, INDI_IDLE );
+        }
+    }
+
+    return 0;
+}
+
+template <bool _useINDI>
+int MagAOXApp<_useINDI>::st_newCallBack_maxLogTime( void *app, const pcf::IndiProperty &ipRecv )
+{
+    return static_cast<MagAOXApp<_useINDI> *>( app )->newCallBack_maxLogTime( ipRecv );
+}
+
+template <bool _useINDI>
+int MagAOXApp<_useINDI>::newCallBack_maxLogTime( const pcf::IndiProperty &ipRecv )
+{
+    unsigned target = 0;
+
+    if( indiTargetUpdate( m_indiP_maxLogTime, target, ipRecv, false ) < 0 )
+    {
+        return log<software_error, -1>( { __FILE__, __LINE__ } );
+    }
+
+    m_log.maxLogTime( target );
+
+    log<text_log>( "set log file interval to " + std::to_string( target ) + " minutes" );
+
+    updateIfChanged( m_indiP_maxLogTime, "current", target, INDI_IDLE );
+
     return 0;
 }
 

--- a/libMagAOX/app/dev/telemeter.hpp
+++ b/libMagAOX/app/dev/telemeter.hpp
@@ -82,7 +82,61 @@ struct telemeter
 
     double m_maxInterval{10.0}; ///< The maximum interval, in seconds, between telemetry records. Default is 10.0 seconds.
 
+    pcf::IndiProperty m_indiP_rotateTelem; ///< indi Property to request rotation of the telemetry file.
+
+    pcf::IndiProperty m_indiP_maxLogTime; ///< indi Property to report and set the telemetry file time interval, in minutes.
+
     telemeter();
+
+    /// Destructor
+    /** Explicitly noexcept. The INDI property members above have destructors which are not noexcept,
+      * which would otherwise make the implicit destructor of any class deriving from both this and
+      * MagAOXApp looser than MagAOXApp's virtual noexcept destructor. MagAOXApp declares its own
+      * destructor noexcept for the same reason.
+      */
+    ~telemeter() noexcept;
+
+    /// The static callback function to be registered for requesting telemetry file rotation
+    /** The `void *` is a pointer to the app, which is converted to this telemeter.
+     *
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    static int st_newCallBack_rotateTelem(void *app,                     /**< [in] a pointer to the app, will be
+                                                                                   converted to telemeter. */
+                                          const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                                    the new property request. */
+    );
+
+    /// The callback called by the static version, to actually process the telemetry rotation request.
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    int newCallBack_rotateTelem(const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the new
+                                                                          property request. */
+    );
+
+    /// The static callback function to be registered for setting the telemetry file time interval
+    /** The `void *` is a pointer to the app, which is converted to this telemeter.
+     *
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    static int st_newCallBack_maxLogTime(void *app,                      /**< [in] a pointer to the app, will be
+                                                                                   converted to telemeter. */
+                                         const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with
+                                                                                   the new property request. */
+    );
+
+    /// The callback called by the static version, to actually process the telemetry interval change.
+    /**
+     * \returns 0 on success.
+     * \returns -1 on error.
+     */
+    int newCallBack_maxLogTime(const pcf::IndiProperty &ipRecv /**< [in] the INDI property sent with the new
+                                                                         property request. */
+    );
 
     /// Make a telemetry recording
     /** Wrapper for logManager::log, which updates telT::lastRecord.
@@ -190,6 +244,11 @@ telemeter<derivedT>::telemeter()
 }
 
 template <class derivedT>
+telemeter<derivedT>::~telemeter() noexcept
+{
+}
+
+template <class derivedT>
 template <typename telT>
 int telemeter<derivedT>::telem(const typename telT::messageT &msg)
 {
@@ -256,6 +315,29 @@ template <class derivedT>
 int telemeter<derivedT>::appStartup()
 {
     //----------------------------------------//
+    //        Set up the INDI properties
+    //----------------------------------------//
+
+    // These are registered through the app, which this class is a friend of, so that apps without
+    // telemetry do not get telemetry properties.
+    derived().createStandardIndiRequestSw(m_indiP_rotateTelem, "telem_rotate", "New Telemetry File", "Logging");
+    if (derived().registerIndiPropertyNew(m_indiP_rotateTelem, st_newCallBack_rotateTelem) < 0)
+    {
+        derivedT::template log<software_error>({__FILE__, __LINE__, "failed to register new telem_rotate property"});
+    }
+
+    derived().template createStandardIndiNumber<unsigned>(
+        m_indiP_maxLogTime, "telem_maxtime", 0, 525600, 1, "", "Max Telemetry Interval [minutes]", "Logging");
+    if (derived().registerIndiPropertyNew(m_indiP_maxLogTime, st_newCallBack_maxLogTime) < 0)
+    {
+        derivedT::template log<software_error>({__FILE__, __LINE__, "failed to register new telem_maxtime property"});
+    }
+
+    // Set the INDI property to the configured interval.
+    m_indiP_maxLogTime["current"] = m_tel.maxLogTime();
+    m_indiP_maxLogTime["target"] = m_tel.maxLogTime();
+
+    //----------------------------------------//
     //        Begin the telemetry system
     //----------------------------------------//
 
@@ -301,6 +383,64 @@ int telemeter<derivedT>::appLogic()
     }
 
     return derived().checkRecordTimes();
+}
+
+template <class derivedT>
+int telemeter<derivedT>::st_newCallBack_rotateTelem(void *app, const pcf::IndiProperty &ipRecv)
+{
+    // MagAOXApp::handleNewProperty always passes its own `this`, so the argument is the app, not
+    // this telemeter.
+    telemeter<derivedT> *tel = static_cast<derivedT *>(app);
+    return tel->newCallBack_rotateTelem(ipRecv);
+}
+
+template <class derivedT>
+int telemeter<derivedT>::newCallBack_rotateTelem(const pcf::IndiProperty &ipRecv)
+{
+    if (ipRecv.createUniqueKey() != m_indiP_rotateTelem.createUniqueKey())
+    {
+        return derivedT::template log<software_error, -1>({__FILE__, __LINE__, "wrong indi property received"});
+    }
+
+    if (ipRecv.find("request"))
+    {
+        if (ipRecv["request"].getSwitchState() == pcf::IndiElement::On)
+        {
+            // This only sets a flag. The new file is created by the telemetry thread on the next record.
+            m_tel.requestRotation();
+            derived().updateSwitchIfChanged(m_indiP_rotateTelem, "request", pcf::IndiElement::Off, INDI_IDLE);
+        }
+    }
+
+    return 0;
+}
+
+template <class derivedT>
+int telemeter<derivedT>::st_newCallBack_maxLogTime(void *app, const pcf::IndiProperty &ipRecv)
+{
+    // MagAOXApp::handleNewProperty always passes its own `this`, so the argument is the app, not
+    // this telemeter.
+    telemeter<derivedT> *tel = static_cast<derivedT *>(app);
+    return tel->newCallBack_maxLogTime(ipRecv);
+}
+
+template <class derivedT>
+int telemeter<derivedT>::newCallBack_maxLogTime(const pcf::IndiProperty &ipRecv)
+{
+    unsigned target = 0;
+
+    if (derived().indiTargetUpdate(m_indiP_maxLogTime, target, ipRecv, false) < 0)
+    {
+        return derivedT::template log<software_error, -1>({__FILE__, __LINE__});
+    }
+
+    m_tel.maxLogTime(target);
+
+    derivedT::template log<software_info>({__FILE__, __LINE__, "Set telemetry file interval to " + std::to_string(target) + " minutes"});
+
+    derived().updateIfChanged(m_indiP_maxLogTime, "current", target, INDI_IDLE);
+
+    return 0;
 }
 
 template <class derivedT>

--- a/libMagAOX/common/defaults.hpp
+++ b/libMagAOX/common/defaults.hpp
@@ -40,6 +40,18 @@
    #define MAGAOX_default_max_logSize (10485760)
 #endif
 
+#ifndef MAGAOX_default_maxLogTime
+   /// The default maximum log file time
+   /** Defines the default maximum time span covered by a single log file.  Default: 1440 minutes (24 hours).
+     *
+     * File boundaries are aligned to the wall clock, not the app's start time.
+     * A value of 0 disables time-based rotation, leaving \ref MAGAOX_default_max_logSize as the only limit.
+     *
+     * Units: minutes
+     */
+   #define MAGAOX_default_maxLogTime (1440)
+#endif
+
 #ifndef MAGAOX_default_loopPause
    /// The default application loopPause
    /** Defines default value of how long the event loop in execute() pauses. Default is 1 sec.

--- a/libMagAOX/logger/logFileRaw.hpp
+++ b/libMagAOX/logger/logFileRaw.hpp
@@ -6,6 +6,7 @@
 #ifndef logger_logFileRaw_hpp
 #define logger_logFileRaw_hpp
 
+#include <atomic>
 #include <iostream>
 
 #include <mx/ioutils/fileUtils.hpp>
@@ -23,8 +24,20 @@ namespace logger
 /// A class to manage raw binary log files
 /** Manages a binary file containing MagAO-X logs.
  *
- * The log entries are written as a binary stream of a configurable
- * maximum size.  If this size will be exceed by the next entry, then a new file is created.
+ * A new file is created when any of the following are true:
+ * - the next entry would cause the file to exceed a configurable maximum size, \ref m_maxLogSize
+ * - the next entry falls in a different wall-clock interval than the current file, \ref m_maxLogTime
+ * - a rotation has been requested with \ref requestRotation
+ *
+ * Time-based rotation is aligned to the wall clock: the timeline is divided into consecutive intervals of
+ * \ref m_maxLogTime minutes measured from the Unix epoch, and a new file begins when an entry falls in a
+ * different interval than the one the open file began in.
+ *
+ * Rotation is evaluated lazily when an entry is actually written, so an idle app never creates an
+ * empty file. A gap in the file timestamps therefore indicates a gap in the logged data.
+ *
+ * The size limit acts as a backstop and it can also trigger a new file for a verbose app, even if 
+ * the time limit has not been reached.
  *
  * Filenames have a standard form of: `[path]/[name]/[name]_YYYYMMDDHHMMSSNNNNNNNNN.[ext]` where fields in [] are
  * configurable.
@@ -45,6 +58,9 @@ class logFileRaw
     std::string m_logExt{ MAGAOX_default_logExt }; ///< The extension for the log files.
 
     size_t m_maxLogSize{ MAGAOX_default_max_logSize }; ///< The maximum file size in bytes. Default is 10 MB.
+
+    /// Atomic because it can be changed at runtime from an INDI callback, while the log thread is reading it.
+    std::atomic<unsigned> m_maxLogTime{ MAGAOX_default_maxLogTime }; ///< The maximum time span of a file in minutes. Default is 1440 (24 hours). 0 disables time-based rotation.
     ///@}
 
     /** \name Internal State
@@ -54,6 +70,11 @@ class logFileRaw
     FILE *m_fout{ 0 }; ///< The file pointer
 
     size_t m_currFileSize{ 0 }; ///< The current file size.
+
+    uint64_t m_currFileStartSec{ 0 }; ///< The timestamp in seconds of the first entry in the current file.
+
+    /// This is atomic because it is set from an INDI callback thread, while the log thread is reading it.
+    std::atomic<bool> m_rotateRequested{ false }; ///< Flag indicating that a new file has been requested at runtime.
 
     ///@}
 
@@ -71,8 +92,8 @@ class logFileRaw
     /// Set the path.
     /**
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t logPath( const std::string &newPath /**< [in] the new value of _path */ );
 
@@ -85,8 +106,8 @@ class logFileRaw
     /// Set the log name
     /**
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t logName( const std::string &newName /**< [in] the new value of m_logName */ );
 
@@ -99,8 +120,8 @@ class logFileRaw
     /// Set the log extension
     /**
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t logExt( const std::string &newExt /**< [in] the new value of m_logExt */ );
 
@@ -113,8 +134,8 @@ class logFileRaw
     /// Set the maximum file size
     /**
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t maxLogSize( size_t newMaxFileSize /**< [in] the new value of _maxLogSize */ );
 
@@ -124,28 +145,49 @@ class logFileRaw
      */
     size_t maxLogSize();
 
+    /// Set the maximum file time span
+    /** A value of 0 disables time-based rotation, leaving only the size limit.
+     *
+     * \returns mx::error_t::noerror
+     */
+    mx::error_t maxLogTime( unsigned newMaxLogTime /**< [in] the new value of m_maxLogTime, in minutes */ );
+
+    /// Get the maximum file time span
+    /**
+     * \returns the current value of m_maxLogTime, in minutes
+     */
+    unsigned maxLogTime();
+
+    /// Request that a new file be created on the next log entry
+    /** This only sets a flag, so is safe to call from any thread.
+      * The new file is created by the next call to \ref writeLog.  If no further entries are written,
+      * no new file is created.
+      */
+    void requestRotation();
+
     /// Write a log entry to the file
-    /** Checks if this write will exceed m_maxLogSize, and if so opens a new file.
+    /** Opens a new file if this write would exceed m_maxLogSize, if this entry falls in a different
+     * wall-clock interval than the current file, or if a rotation has been requested.
      * The new file will have the timestamp of this log entry.
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t writeLog( flatlogs::bufferPtrT &data /**< [in] the log entry to write to disk */ );
 
     /// Flush the stream
     /** Calls `fflush`. See issue #192
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t flush();
 
     /// Close the file pointer
     /** Sets \ref m_fout to nullptr after calling fclose regardless of error.
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t close();
 
@@ -155,8 +197,8 @@ class logFileRaw
      * [path]/[name]/YYYY_MM_DD/[name]_YYYYMMDDHHMMSSNNNNNNNNN.[ext]
      *
      *
-     * \returns 0 on success
-     * \returns -1 on error
+     * \returns mx::error_t::noerror on success
+     * \returns an error code on error
      */
     mx::error_t createFile( flatlogs::timespecX &ts /**< [in] A MagAOX timespec, used to set the timestamp */ );
 };
@@ -273,15 +315,44 @@ size_t logFileRaw<verboseT>::maxLogSize()
 }
 
 template <class verboseT>
+mx::error_t logFileRaw<verboseT>::maxLogTime( unsigned newMaxLogTime )
+{
+    m_maxLogTime = newMaxLogTime;
+
+    return mx::error_t::noerror;
+}
+
+template <class verboseT>
+unsigned logFileRaw<verboseT>::maxLogTime()
+{
+    return m_maxLogTime;
+}
+
+template <class verboseT>
+void logFileRaw<verboseT>::requestRotation()
+{
+    m_rotateRequested = true;
+}
+
+template <class verboseT>
 mx::error_t logFileRaw<verboseT>::writeLog( flatlogs::bufferPtrT &data )
 {
     size_t N = flatlogs::logHeader::totalSize( data );
 
-    // Check if we need a new file
-    if( m_currFileSize + N > m_maxLogSize || m_fout == 0 )
-    {
-        flatlogs::timespecX ts = flatlogs::logHeader::timespec( data );
+    flatlogs::timespecX ts = flatlogs::logHeader::timespec( data );
 
+    bool rotateNow = m_rotateRequested.exchange( false );
+
+    uint64_t period = m_maxLogTime;
+    period *= 60; // minutes to seconds
+
+    // Recompute wall-clock interval for both the new entry and the open file
+    bool newInterval =
+        ( period != 0 && static_cast<uint64_t>( ts.time_s ) / period != m_currFileStartSec / period );
+
+    // Check if we need a new file
+    if( m_fout == 0 || rotateNow || newInterval || m_currFileSize + N > m_maxLogSize )
+    {
         mx_error_check( createFile( ts ) );
     }
 
@@ -392,6 +463,7 @@ mx::error_t logFileRaw<verboseT>::createFile( flatlogs::timespecX &ts )
 
     // Reset counters.
     m_currFileSize = 0;
+    m_currFileStartSec = ts.time_s;
 
     return mx::error_t::noerror;
 }

--- a/libMagAOX/logger/logManager.hpp
+++ b/libMagAOX/logger/logManager.hpp
@@ -365,6 +365,7 @@ int logManager<parentT, logFileT>::setupConfig( mx::app::appConfigurator & confi
    config.add(m_configSection+".logDir","L", "logDir",mx::app::argType::Required, m_configSection, "logDir", false, "string", "The directory for log files");
    config.add(m_configSection+".logExt","", "logExt",mx::app::argType::Required, m_configSection, "logExt", false, "string", "The extension for log files");
    config.add(m_configSection+".maxLogSize","", "maxLogSize",mx::app::argType::Required, m_configSection, "maxLogSize", false, "string", "The maximum size of log files");
+   config.add(m_configSection+".maxLogTime","", "maxLogTime",mx::app::argType::Required, m_configSection, "maxLogTime", false, "unsigned", "The maximum time span of log files in minutes. 0 disables time-based rotation.");
    config.add(m_configSection+".writePause","", "writePause",mx::app::argType::Required, m_configSection, "writePause", false, "unsigned long", "The log thread pause time in ns");
    config.add(m_configSection+".logThreadPrio", "", "logThreadPrio", mx::app::argType::Required, m_configSection, "logThreadPrio", false, "int", "The log thread priority");
    config.add(m_configSection+".logLevel","l", "logLevel",mx::app::argType::Required, m_configSection, "logLevel", false, "string", "The log level");
@@ -404,6 +405,11 @@ int logManager<parentT, logFileT>::loadConfig( mx::app::appConfigurator & config
 
    //maxLogSize
    config(this->m_maxLogSize, m_configSection+".maxLogSize");
+
+   //maxLogTime - read into a plain type, as the configurator cannot populate a std::atomic
+   unsigned mlt = this->maxLogTime();
+   config(mlt, m_configSection+".maxLogTime");
+   this->maxLogTime(mlt);
 
    //writePause
    config(m_writePause, m_configSection+".writePause");

--- a/libMagAOX/logger/tests/logFileRaw_test.cpp
+++ b/libMagAOX/logger/tests/logFileRaw_test.cpp
@@ -55,6 +55,11 @@ class logFileRawTest : public MagAOX::logger::logFileRaw<XWC_DEFAULT_VERBOSITY>
     {
         return createFile( ts );
     }
+
+    uint64_t test_currFileStartSec()
+    {
+        return m_currFileStartSec;
+    }
 };
 
 /// Construction of logFileRaw
@@ -71,6 +76,7 @@ TEST_CASE( "Construction of logFileRaw", "[libMagAOX::logger::logFileRaw]" )
         REQUIRE( lfr.logName() == "xlog" );
         REQUIRE( lfr.logExt() == MAGAOX_default_logExt );
         REQUIRE( lfr.maxLogSize() == MAGAOX_default_max_logSize );
+        REQUIRE( lfr.maxLogTime() == MAGAOX_default_maxLogTime );
 
         lfr.logPath( "/newp/test/x" );
         REQUIRE( lfr.logPath() == "/newp/test/x" );
@@ -83,6 +89,12 @@ TEST_CASE( "Construction of logFileRaw", "[libMagAOX::logger::logFileRaw]" )
 
         lfr.maxLogSize( 10 );
         REQUIRE( lfr.maxLogSize() == 10 );
+
+        lfr.maxLogTime( 15 );
+        REQUIRE( lfr.maxLogTime() == 15 );
+
+        lfr.maxLogTime( 0 );
+        REQUIRE( lfr.maxLogTime() == 0 );
     }
 }
 
@@ -440,6 +452,276 @@ TEST_CASE( "Writing to a log file", "[libMagAOX::logger::logFileRaw]" )
         fsz = std::filesystem::file_size( fullPath2 );
 
         REQUIRE( fsz == 1 * ( 256 + 14 ) );
+    }
+}
+
+
+/// Time-based rotation of a log file
+/**
+ * \ingroup logFileRaw_unit_test
+ */
+TEST_CASE( "Time based rotation of a log file", "[libMagAOX::logger::logFileRaw]" )
+{
+    // All timestamps below are chosen relative to a 10 minute (600 second) interval:
+    //   1732170780 = 2024-11-21 06:33:00 UTC, bin 2886951
+    //   1732171199 = 2024-11-21 06:39:59 UTC, bin 2886951 (same)
+    //   1732171200 = 2024-11-21 06:40:00 UTC, bin 2886952 (next)
+    //   1732171260 = 2024-11-21 06:41:00 UTC, bin 2886952 (same)
+
+    std::string msg( 256, 't' );
+
+    /// Write a log with the given timestamp, requiring success
+    auto writeAt = []( logFileRawTest &lfr, flatlogs::timespecX ts, const std::string &m )
+    {
+        flatlogs::bufferPtrT logbuff;
+        flatlogs::logHeader::createLog<dummyLog>( logbuff, ts, m, flatlogs::logPrio::LOG_NOTICE );
+        REQUIRE( lfr.writeLog( logbuff ) == mx::error_t::noerror );
+    };
+
+    /// Path of the file that an entry at this timestamp would create
+    auto pathFor = []( logFileRawTest &lfr, const std::string &stamp )
+    { return lfr.testPath + "/2024_11_21/" + lfr.logName() + "_" + stamp + "." + lfr.logExt(); };
+
+    /// Guard against deleting all of /tmp, and clear any previous run
+    auto resetPath = []( logFileRawTest &lfr )
+    {
+        if( lfr.testPath == "/tmp" )
+        {
+            std::cerr << "\nTESTING-ERROR: testPath is just /tmp, so logName is null.  Can't go on\n";
+            std::cerr << __FILE__ << ' ' << __LINE__ << "\n\n";
+            REQUIRE( false );
+            return false;
+        }
+        std::filesystem::remove_all( lfr.testPath );
+        return true;
+    };
+
+    SECTION( "two entries in the same interval share a file" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 10 );
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+        writeAt( lfr, flatlogs::timespecX( 1732171199, 3 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+        REQUIRE( !std::filesystem::exists( pathFor( lfr, "20241121063959000000003" ) ) );
+
+        lfr.close();
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121063300000000002" ) ) == 2 * ( 256 + 14 ) );
+    }
+
+    SECTION( "an entry in the next interval starts a new file" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 10 );
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121063300000000002" ) ) == 1 * ( 256 + 14 ) );
+
+        // The new file, not the old one, is now the current file
+        REQUIRE( lfr.test_currFileStartSec() == 1732171200 );
+
+        lfr.close();
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121064000000000004" ) ) == 1 * ( 256 + 14 ) );
+    }
+
+    SECTION( "a size triggered split does not shift the interval boundary" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 10 );
+        lfr.maxLogSize( 256 ); // force every write after the first to split
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        // Two entries in the same interval, split by size rather than by time
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+        writeAt( lfr, flatlogs::timespecX( 1732171199, 3 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063959000000003" ) ) );
+
+        // The mid-interval file inherits the later start time, but is still in interval 2886951 ...
+        REQUIRE( lfr.test_currFileStartSec() == 1732171199 );
+
+        // ... so an entry in the next interval must still start a new file at the boundary.
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+        REQUIRE( lfr.test_currFileStartSec() == 1732171200 );
+
+        lfr.close();
+    }
+
+    SECTION( "maxLogTime of 0 disables time based rotation" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 0 );
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        // These are in different 10 minute intervals, and even different days, but time rotation is off
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+        REQUIRE( !std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+
+        lfr.close();
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121063300000000002" ) ) == 2 * ( 256 + 14 ) );
+    }
+
+    SECTION( "a change to maxLogTime takes effect on the next entry" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 60 ); // both timestamps below are in the same 60 minute interval
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+
+        // Shortening the interval puts the open file's start time in a different interval than the
+        // next entry, so the next entry must rotate.
+        lfr.maxLogTime( 10 );
+
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+
+        lfr.close();
+    }
+}
+
+/// Rotation of a log file on request
+/**
+ * \ingroup logFileRaw_unit_test
+ */
+TEST_CASE( "Requested rotation of a log file", "[libMagAOX::logger::logFileRaw]" )
+{
+    std::string msg( 256, 't' );
+
+    auto writeAt = []( logFileRawTest &lfr, flatlogs::timespecX ts, const std::string &m )
+    {
+        flatlogs::bufferPtrT logbuff;
+        flatlogs::logHeader::createLog<dummyLog>( logbuff, ts, m, flatlogs::logPrio::LOG_NOTICE );
+        REQUIRE( lfr.writeLog( logbuff ) == mx::error_t::noerror );
+    };
+
+    auto pathFor = []( logFileRawTest &lfr, const std::string &stamp )
+    { return lfr.testPath + "/2024_11_21/" + lfr.logName() + "_" + stamp + "." + lfr.logExt(); };
+
+    auto resetPath = []( logFileRawTest &lfr )
+    {
+        if( lfr.testPath == "/tmp" )
+        {
+            std::cerr << "\nTESTING-ERROR: testPath is just /tmp, so logName is null.  Can't go on\n";
+            std::cerr << __FILE__ << ' ' << __LINE__ << "\n\n";
+            REQUIRE( false );
+            return false;
+        }
+        std::filesystem::remove_all( lfr.testPath );
+        return true;
+    };
+
+    SECTION( "a request forces a new file on the next entry" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 0 ); // isolate the request from time based rotation
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+
+        lfr.requestRotation();
+
+        writeAt( lfr, flatlogs::timespecX( 1732171199, 3 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063959000000003" ) ) );
+
+        // The request must be consumed, so a further entry does not rotate again
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( !std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+
+        lfr.close();
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121063959000000003" ) ) == 2 * ( 256 + 14 ) );
+    }
+
+    SECTION( "a request with no subsequent entry creates no file" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 0 );
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+
+        lfr.requestRotation();
+
+        lfr.close();
+
+        // Only the one file from the single write exists
+        int nfiles = 0;
+        for( const auto &e : std::filesystem::directory_iterator( lfr.testPath + "/2024_11_21/" ) )
+        {
+            (void)e;
+            ++nfiles;
+        }
+
+        REQUIRE( nfiles == 1 );
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121063300000000002" ) ) );
+    }
+
+    SECTION( "a request is consumed even when another condition also triggers" )
+    {
+        logFileRawTest lfr;
+        lfr.maxLogTime( 10 );
+        if( !resetPath( lfr ) )
+        {
+            return;
+        }
+
+        writeAt( lfr, flatlogs::timespecX( 1732170780, 2 ), msg );
+
+        lfr.requestRotation();
+
+        // This entry is in the next interval, so time rotation also fires.  The request must still be
+        // cleared, otherwise it would cause a spurious rotation on the entry after this one.
+        writeAt( lfr, flatlogs::timespecX( 1732171200, 4 ), msg );
+
+        REQUIRE( std::filesystem::exists( pathFor( lfr, "20241121064000000000004" ) ) );
+
+        // Same interval as the previous entry, and no pending request, so no new file
+        writeAt( lfr, flatlogs::timespecX( 1732171260, 5 ), msg );
+
+        REQUIRE( !std::filesystem::exists( pathFor( lfr, "20241121064100000000005" ) ) );
+
+        lfr.close();
+        REQUIRE( std::filesystem::file_size( pathFor( lfr, "20241121064000000000004" ) ) == 2 * ( 256 + 14 ) );
     }
 }
 


### PR DESCRIPTION
Answers issue #238 

Files previously rotated on size only (10 MB). Added rotation based on wall-clock time, or when rotation has been requested. Intervals are measure from the Unix epoch.
Rotation is evaluated only when an entry is written, so idle apps create no empty files.
Size rotation remain as a backstop.
The interval is set in minutes by logger.maxLogTime and telemeter.maxLogTime, independently per app and thread. Default is 1440 minutes (24 h). 0 disables time-based rotation and reverts to size-only. Added INDI properties logs_rotate/logs_maxtime on MagAOXApp and telem_rotate/telem_maxtime on dev::telemeter, for rotating on demand and changing the interval at runtime.
Added unit tests for interval boundaries, size/time interaction, disabling, runtime interval changes, and runtime requested rotation.